### PR TITLE
Redirect visitor of a dataset to latest slugged URL

### DIFF
--- a/app/controllers/datasets_controller.rb
+++ b/app/controllers/datasets_controller.rb
@@ -7,6 +7,11 @@ class DatasetsController < LoggedAreaController
     @non_timeseries_datafiles = @dataset.non_timeseries_datafiles
     @referer_query = referer_query
     @related_datasets = Dataset.related(@dataset._id)
+
+    if request_to_outdated_url?
+      return redirect_to newest_dataset_path, status: :moved_permanently
+    end
+
   rescue => e
     handle_error(e)
   end
@@ -28,5 +33,13 @@ class DatasetsController < LoggedAreaController
 
   def current_host_matches_referer_host
     URI(request.host).to_s == URI(request.referer).host.to_s
+  end
+
+  def request_to_outdated_url?
+    request.path != newest_dataset_path
+  end
+
+  def newest_dataset_path
+    dataset_path(@dataset.uuid, @dataset.name)
   end
 end

--- a/spec/controllers/datasets_controller_spec.rb
+++ b/spec/controllers/datasets_controller_spec.rb
@@ -36,4 +36,12 @@ describe DatasetsController, type: :controller do
       end
     end
   end
+
+  describe 'visiting the dataset page' do
+    it "redirects to the latest slugged URL" do
+      index([dataset])
+      get :show, params: { uuid: dataset[:uuid], name: "outdated-slug" }
+      expect(response).to redirect_to(dataset_url(dataset[:uuid], dataset[:name]))
+    end
+  end
 end


### PR DESCRIPTION
### Problem

When a publisher changes the title of a dataset in PUBLISH, its URL slug changes. Problem: the user can visit a dataset page in FIND via an outdated URL (using an old slug).

### Solution

When a publisher changes the title of dataset from "Old Title" to "New Title" in PUBLISH, pointing the browser at `http://find-url.com/dataset/1234-5678-9876/old-title` in FIND will redirect the user to `http://find-url.com/dataset/1234-5678-9876/new-title`.