### PR TITLE
Redirect legacy URLs

### DIFF
--- a/app/controllers/datasets_controller.rb
+++ b/app/controllers/datasets_controller.rb
@@ -2,7 +2,7 @@ class DatasetsController < LoggedAreaController
   include DatasetsHelper
 
   def show
-    @dataset = Dataset.get_by(uuid: params[:uuid])
+    @dataset = Dataset.get_by_uuid(uuid: params[:uuid])
     @timeseries_datafiles = @dataset.timeseries_datafiles
     @non_timeseries_datafiles = @dataset.non_timeseries_datafiles
     @referer_query = referer_query

--- a/app/controllers/legacy_datasets_controller.rb
+++ b/app/controllers/legacy_datasets_controller.rb
@@ -1,0 +1,6 @@
+class LegacyDatasetsController < ApplicationController
+  def redirect
+    dataset = Dataset.get_by_legacy_name(legacy_name: params[:legacy_name])
+    redirect_to dataset_path(dataset.uuid, dataset.name), status: :moved_permanently
+  end
+end

--- a/app/controllers/previews_controller.rb
+++ b/app/controllers/previews_controller.rb
@@ -1,6 +1,6 @@
 class PreviewsController < LoggedAreaController
   def show
-    @dataset = Dataset.get_by(uuid: params[:dataset_uuid])
+    @dataset = Dataset.get_by_uuid(uuid: params[:dataset_uuid])
     @datafile = @dataset.datafiles.find { |f| f.uuid == params[:datafile_uuid] }
   end
 end

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -19,8 +19,16 @@ class Dataset
 
   index_name ENV['ES_INDEX'] || "datasets-#{Rails.env}"
 
-  def self.get_by(uuid:)
+  def self.get_by_uuid(uuid:)
     query = Search::Query.by_uuid(uuid)
+    result = Dataset.search(query).results.first
+    attrs = result._source.to_hash.merge(_id: result._id)
+    raise 'Metadata missing' if attrs["title"].blank?
+    Dataset.new(attrs)
+  end
+
+  def self.get_by_legacy_name(legacy_name:)
+    query = Search::Query.by_legacy_name(legacy_name)
     result = Dataset.search(query).results.first
     attrs = result._source.to_hash.merge(_id: result._id)
     raise 'Metadata missing' if attrs["title"].blank?

--- a/app/services/search/query.rb
+++ b/app/services/search/query.rb
@@ -121,6 +121,18 @@ module Search
       query
     end
 
+    def self.by_legacy_name(legacy_name)
+      {
+        query: {
+          constant_score: {
+            filter: {
+              term: { legacy_name: legacy_name }
+            }
+          }
+        }
+      }
+    end
+
     def self.by_uuid(uuid)
       {
         query: {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
   get 'search/', to: 'search#search'
   get 'search/tips', to: 'search#tips'
 
+  get 'dataset/:legacy_name', to: 'legacy_datasets#redirect'
   get 'dataset/:uuid/:name', to: 'datasets#show', as: 'dataset'
 
   get 'use-of-data', to: 'consents#new', as: 'new_consent'

--- a/spec/controllers/datasets_controller_spec.rb
+++ b/spec/controllers/datasets_controller_spec.rb
@@ -37,7 +37,7 @@ describe DatasetsController, type: :controller do
     end
   end
 
-  describe 'visiting the dataset page' do
+  describe 'visiting the dataset page with an outdated slug' do
     it "redirects to the latest slugged URL" do
       index([dataset])
       get :show, params: { uuid: dataset[:uuid], name: "outdated-slug" }

--- a/spec/controllers/legacy_datasets_controller_spec.rb
+++ b/spec/controllers/legacy_datasets_controller_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe LegacyDatasetsController, type: :controller do
+  describe 'visiting a dataset page with a legacy URL' do
+    it "redirects to the latest slugged URL" do
+      dataset = DatasetBuilder.new.with_legacy_name('a-legacy-name').build
+      index([dataset])
+
+      get :redirect, params: { legacy_name: 'a-legacy_name' }
+
+      expect(response).to redirect_to(dataset_url(dataset[:uuid], dataset[:name]))
+      expect(response.status).to eql 301
+    end
+  end
+end

--- a/spec/controllers/legacy_datasets_controller_spec.rb
+++ b/spec/controllers/legacy_datasets_controller_spec.rb
@@ -3,10 +3,11 @@ require 'rails_helper'
 describe LegacyDatasetsController, type: :controller do
   describe 'visiting a dataset page with a legacy URL' do
     it "redirects to the latest slugged URL" do
-      dataset = DatasetBuilder.new.with_legacy_name('a-legacy-name').build
+      legacy_name = 'a-legacy-name'
+      dataset = DatasetBuilder.new.with_legacy_name(legacy_name).build
       index([dataset])
 
-      get :redirect, params: { legacy_name: 'a-legacy_name' }
+      get :redirect, params: { legacy_name: legacy_name }
 
       expect(response).to redirect_to(dataset_url(dataset[:uuid], dataset[:name]))
       expect(response.status).to eql 301

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,6 +45,10 @@ def mappings
           type: "string",
           index: "not_analyzed"
         },
+        legacy_name: {
+          type: 'string',
+          index: 'not_analyzed'
+        },
         uuid: {
           type: "string",
           index: "not_analyzed"

--- a/spec/support/dataset_spec_builder.rb
+++ b/spec/support/dataset_spec_builder.rb
@@ -49,6 +49,11 @@ class DatasetBuilder
     self
   end
 
+  def with_legacy_name(slug)
+    @dataset[:legacy_name] = slug
+    self
+  end
+
   def with_name(slug)
     @dataset[:name] = slug
     self


### PR DESCRIPTION
Trello: https://trello.com/c/HbtA8f6l/165-make-legacy-dataset-urls-work-in-find-l

This PR makes sure we redirect dataset legacy URLs to the new ones, i.e. when a user visits `https://data.gov.uk/old-title` he will be redirected to `https://data.gov.uk/:uuid/new-title`.