### PR TITLE
Unpublished datasets

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,3 +15,4 @@
 @import 'govuk';
 @import 'govuk-overrides';
 @import 'components';
+@import 'dgu';

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -368,9 +368,3 @@ span.showHide-open-all {
     }
   }
 }
-
-
-// ==== not a component ========================================================
-.dgu-unavailable {
-  color: $secondary-text-colour;
-}

--- a/app/assets/stylesheets/dgu.scss
+++ b/app/assets/stylesheets/dgu.scss
@@ -1,0 +1,8 @@
+.dgu-secondary-text {
+  color: $secondary-text-colour;
+}
+
+.highlight {
+  background: $grey-3;
+  padding: em(2) em(5) em(2) em(5);
+}

--- a/app/assets/stylesheets/dgu.scss
+++ b/app/assets/stylesheets/dgu.scss
@@ -2,7 +2,7 @@
   color: $secondary-text-colour;
 }
 
-.highlight {
+.dgu-highlight {
   background: $grey-3;
   padding: em(2) em(5) em(2) em(5);
 }

--- a/app/helpers/datasets_helper.rb
+++ b/app/helpers/datasets_helper.rb
@@ -39,7 +39,7 @@ module DatasetsHelper
   end
 
   def expected_update_class_for(freq)
-    "dgu-unavailable" if NO_MORE.include?(freq)
+    "dgu-secondary-text" if NO_MORE.include?(freq)
   end
 
   def dataset_location(dataset)
@@ -47,7 +47,7 @@ module DatasetsHelper
   end
 
   def expected_location_class_for(dataset)
-    "dgu-unavailable" if locations(dataset).empty?
+    "dgu-secondary-text" if locations(dataset).empty?
   end
 
   def name_of(dataset)

--- a/app/helpers/datasets_helper.rb
+++ b/app/helpers/datasets_helper.rb
@@ -97,12 +97,4 @@ module DatasetsHelper
   def foi_email_exists?(dataset)
     dataset.foi_email.present? || dataset.organisation.foi_email.present?
   end
-
-  def contact_instruction(dataset)
-    if contact_details_exist?(dataset)
-      "Contact the publisher for a data request."
-    else
-      "Contact the data.gov.uk team if you have any questions."
-    end
-  end
 end

--- a/app/helpers/datasets_helper.rb
+++ b/app/helpers/datasets_helper.rb
@@ -97,4 +97,12 @@ module DatasetsHelper
   def foi_email_exists?(dataset)
     dataset.foi_email.present? || dataset.organisation.foi_email.present?
   end
+
+  def contact_instruction(dataset)
+    if contact_details_exist?(dataset)
+      "Contact the publisher for a data request."
+    else
+      "Contact the data.gov.uk team if you have any questions."
+    end
+  end
 end

--- a/app/views/datasets/_datafile_table.html.erb
+++ b/app/views/datasets/_datafile_table.html.erb
@@ -15,7 +15,7 @@
           %>
         </td>
         <% if datafile.format.blank? %>
-          <td class="dgu-unavailable">N/A</td>
+          <td class="dgu-secondary-text">N/A</td>
         <% else %>
           <td><%= datafile.format.upcase %>
           <% if datafile.size %>
@@ -28,7 +28,7 @@
             <%= format(datafile.updated_at) %>
           </td>
         <% else %>
-          <td class="dgu-unavailable">Not available</td>
+          <td class="dgu-secondary-text">Not available</td>
         <% end %>
         <td class="datafiles__preview">
           <% if datafile.html? %>
@@ -36,7 +36,7 @@
           <% elsif datafile.csv? %>
             <%= link_to t('.preview'), datafile_preview_path(@dataset.uuid, @dataset.name, datafile.uuid) %>
           <% else %>
-            <span class="dgu-unavailable"><%= t('.not_available') %></span>
+            <span class="dgu-secondary-text"><%= t('.not_available') %></span>
           <% end %>
         </td>
       </tr>

--- a/app/views/datasets/_meta_data.html.erb
+++ b/app/views/datasets/_meta_data.html.erb
@@ -11,6 +11,12 @@
     <div class="column-two-thirds">
       <div class="dgu-metadata__box dgu-metadata__box--in-dataset">
         <dl class="metadata">
+          <% if @dataset.datafiles.none? %>
+            <dt><%= t('.availability') %>:</dt>
+            <dd>
+              <span class="dgu-highlight">Not released</span>
+            </dd>
+          <% end %>
           <dt><%= t('.published_by') %>:</dt>
           <dd><%= link_to @dataset.organisation.title, search_path(publisher: @dataset.organisation.title) %></dd>
           <dt><%= t('.last_updated') %>:</dt>

--- a/app/views/datasets/_meta_data.html.erb
+++ b/app/views/datasets/_meta_data.html.erb
@@ -21,7 +21,7 @@
               <%= expected_update(@dataset) %>
             </dd>
           <% else %>
-            <dd class="dgu-unavailable">
+            <dd class="dgu-secondary-text">
               <%= t('.no_data') %>
             </dd>
           <% end %>

--- a/app/views/datasets/show.html.erb
+++ b/app/views/datasets/show.html.erb
@@ -27,7 +27,11 @@
         <% if @dataset.datafiles.empty? %>
           <div class="panel panel-border-narrow">
             <p>This data hasn't been released to the public by the publisher yet.<br />
-            <%= contact_instruction(@dataset) %></p>
+            <% if contact_details_exist?(@dataset) %>
+              Contact the publisher for a data request.
+            <% else %>
+              Contact the team on <%= link_to 'data.gov.uk/support', support_path %> if you have any questions.
+            <% end %>
           </div>
         <% end %>
       </section>

--- a/app/views/datasets/show.html.erb
+++ b/app/views/datasets/show.html.erb
@@ -6,33 +6,39 @@
   <%= render "breadcrumb" %>
   <%= render "meta_data" %>
 
-  <% unless @dataset.datafiles.empty? %>
-    <div class="grid-row">
-      <div class="column-full">
-        <section class="dgu-datalinks">
-          <h2 class="heading-medium"><%= t('.data_links')%>
-            <% if @timeseries_datafiles.present? %>
-              <!-- accordions for time series datasets -->
-              <span class="showHide-open-all"><%= t('.open_all')%></span>
-            <% end %>
-          </h2>
-          <% unless @timeseries_datafiles.empty? %>
-            <%= render partial: "timeseries_data", locals: { datafiles: @timeseries_datafiles } %>
-          <% end %>
-          <% unless @non_timeseries_datafiles.empty? %>
-            <%= render partial: "non_timeseries_data", locals: { datafiles: @non_timeseries_datafiles } %>
-          <% end %>
-        </section>
-      </div>
+  <div class="grid-row">
+    <div class="column-full">
+      <section class="dgu-datalinks">
+        <h2 class="heading-medium"><%= t('.data_links')%>
+        <% unless @timeseries_datafiles.empty? %>
+          <!-- accordions for time series datasets -->
+          <span class="showHide-open-all"><%= t('.open_all')%></span>
+        <% end %>
+        </h2>
+
+        <% unless @timeseries_datafiles.empty? %>
+          <%= render partial: "timeseries_data", locals: { datafiles: @timeseries_datafiles } %>
+        <% end %>
+
+        <% unless @non_timeseries_datafiles.empty? %>
+          <%= render partial: "non_timeseries_data", locals: { datafiles: @non_timeseries_datafiles } %>
+        <% end %>
+
+        <% if @dataset.datafiles.empty? %>
+          <div class="panel panel-border-narrow">
+            <p>This data hasn't been released to the public by the publisher yet.<br />
+            <%= contact_instruction(@dataset) %></p>
+          </div>
+        <% end %>
+      </section>
     </div>
-  <% end %>
+  </div>
 
   <%= render "additional_info" %>
 
   <% unless no_documents?(@dataset.datafiles) %>
     <%= render "supporting_docs" %>
   <% end %>
-
 
   <% if contact_details_exist?(@dataset) %>
     <section class="contact">

--- a/app/views/search/search.html.erb
+++ b/app/views/search/search.html.erb
@@ -62,7 +62,7 @@
                   <% if d.datafiles.none? %>
                     <dt><%= t('.meta_data_box.availability') %>:</dt>
                     <dd>
-                      <span class="highlight">Not released</span>
+                      <span class="dgu-highlight">Not released</span>
                     </dd>
                   <% end %>
                   <dt> <%= t('.meta_data_box.published_by') %>:</dt>

--- a/app/views/search/search.html.erb
+++ b/app/views/search/search.html.erb
@@ -59,19 +59,25 @@
                   <%= link_to d.title, dataset_path(d.uuid, d.name) %>
                 </h2>
                 <dl class="dgu-metadata__box">
+                  <% if d.datafiles.none? %>
+                    <dt><%= t('.meta_data_box.availability') %>:</dt>
+                    <dd>
+                      <span class="highlight">Not released</span>
+                    </dd>
+                  <% end %>
                   <dt> <%= t('.meta_data_box.published_by') %>:</dt>
                   <dd> <%= link_to d.organisation['title'], search_path(publisher: d.organisation['title']) %></dd>
                   <dt> <%= t('.meta_data_box.last_updated') %>:</dt>
                   <% if d.last_updated_at.present? %>
                     <dd> <%= format(d.last_updated_at) %></dd>
                   <% else %>
-                    <dd class="dgu-unavailable"> <%= t('.meta_data_box.not_applicable') %></dd>
+                    <dd class="dgu-secondary-text"> <%= t('.meta_data_box.not_applicable') %></dd>
                   <% end %>
                   <dt> <%= t('.meta_data_box.geo_area') %>:</dt>
                   <% if d.location1.present? %>
                     <dd><%= d.location1 %></dd>
                   <% else %>
-                    <dd class="dgu-unavailable"> <%= t('.meta_data_box.not_applicable') %></dd>
+                    <dd class="dgu-secondary-text"> <%= t('.meta_data_box.not_applicable') %></dd>
                   <% end %>
                 </dl>
                 <p><%= truncate(strip_tags(d.summary), length: 200, separator: ' ') %></p>

--- a/config/locales/views/datasets/en.yml
+++ b/config/locales/views/datasets/en.yml
@@ -40,6 +40,7 @@ en:
       go_to_site: "Go to site"
       preview: "Preview"
     meta_data:
+      availability: "Availability"
       published_by: "Published by"
       expected_update: "Expected update"
       last_updated: "Last updated"

--- a/config/locales/views/search/en.yml
+++ b/config/locales/views/search/en.yml
@@ -7,6 +7,7 @@ en:
         search_box_label: "Search"
         search_button_label: "Find data"
       results_summary: "results found for"
+      availability: "availability"
       published_by: "published by"
       filtered_by: "filtered by"
       datasets: 'Datasets'

--- a/config/locales/views/search/en.yml
+++ b/config/locales/views/search/en.yml
@@ -16,6 +16,7 @@ en:
         different_words: "searching again using different words"
         clear_filters: "clearing your filters"
       meta_data_box:
+        availability: "Availability"
         published_by: "Published by"
         last_updated: "Last updated"
         geo_area: "Geographical area"

--- a/spec/features/dataset_show_page_spec.rb
+++ b/spec/features/dataset_show_page_spec.rb
@@ -316,7 +316,7 @@ feature 'Dataset page', elasticsearch: true do
     scenario 'publisher contact details do not exist' do
       dataset = DatasetBuilder.new.build
       index_and_visit(dataset)
-      expect(page).to have_content("Contact the data.gov.uk team if you have any questions.")
+      expect(page).to have_content("Contact the team on data.gov.uk/support if you have any questions.")
     end
   end
 end

--- a/spec/features/dataset_show_page_spec.rb
+++ b/spec/features/dataset_show_page_spec.rb
@@ -29,13 +29,13 @@ feature 'Dataset page', elasticsearch: true do
       expect(page).to have_css('h2', text: 'Data links')
     end
 
-    scenario 'do not display if datafiles are not present' do
+    scenario 'datafiles are not present' do
       dataset = DatasetBuilder.new
                   .build
 
       index_and_visit(dataset)
 
-      expect(page).to_not have_css('h2', text: 'Data links')
+      expect(page).to have_content("This data hasn't been released to the public by the publisher yet")
     end
 
     scenario 'display if some information is missing' do
@@ -302,6 +302,21 @@ feature 'Dataset page', elasticsearch: true do
       index_and_visit(dataset)
 
       expect(page).to have_css(".dgu-datalinks__year", count: 0)
+    end
+  end
+
+  feature 'contact instructions' do
+    scenario 'publisher contact details exist' do
+      dataset = DatasetBuilder.new.build
+      dataset[:contact_email] = "foo@bar.com"
+      index_and_visit(dataset)
+      expect(page).to have_content("Contact the publisher for a data request.")
+    end
+
+    scenario 'publisher contact details do not exist' do
+      dataset = DatasetBuilder.new.build
+      index_and_visit(dataset)
+      expect(page).to have_content("Contact the data.gov.uk team if you have any questions.")
     end
   end
 end


### PR DESCRIPTION
The Legacy concept of "unpublished" is where datasets have published metadata but no data files, and deliberately so.

This PR makes sure we:

* label unpublished datasets as `Not released` on both the search results page and the dataset page
* shows different instructions to contact the publisher, or DGU, based on the presence of contact details

Part of card https://trello.com/c/Ykb4YEZO/166-display-unpublished-datasets
Design: https://projects.invisionapp.com/d/main#/console/11687113/268789175/preview