### PR TITLE
Filter search results by Open Government Licence (OGL)

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -8,6 +8,7 @@ class SearchController < LoggedAreaController
     @organisation = params.dig(:filters, :publisher)
     @location = params.dig(:filters, :location)
     @format = params.dig(:filters, :format)
+    @licence = params.dig(:filters, :licence)
     @datasets = @search.page(page_number)
   end
 

--- a/app/services/search/query.rb
+++ b/app/services/search/query.rb
@@ -108,11 +108,13 @@ module Search
       publisher_param = params.dig(:filters, :publisher)
       location_param =  params.dig(:filters, :location)
       format_param =    params.dig(:filters, :format)
+      licence_param =   params.dig(:filters, :licence)
 
       query[:query][:bool][:must] << multi_match(query_param)          if query_param.present?
       query[:query][:bool][:must] << publisher_filter(publisher_param) if publisher_param.present?
       query[:query][:bool][:must] << location_filter(location_param)   if location_param.present?
       query[:query][:bool][:must] << format_filter(format_param)       if format_param.present?
+      query[:query][:bool][:must] << licence_filter(licence_param)     if licence_param.present?
 
       query[:sort] = { "last_updated_at": { "order": "desc" } } if sort_param == "recent"
 
@@ -186,6 +188,14 @@ module Search
       }
     end
 
-    private_class_method :multi_match, :publisher_filter, :location_filter, :format_filter
+    def self.licence_filter(licence)
+      {
+        match: {
+          "licence": licence
+        }
+      }
+    end
+
+    private_class_method :multi_match, :publisher_filter, :location_filter, :format_filter, :licence_filter
   end
 end

--- a/app/views/search/_filters.html.erb
+++ b/app/views/search/_filters.html.erb
@@ -22,6 +22,13 @@
 </div>
 
 <div class="form-group">
+  <div class="multiple-choice">
+    <%= check_box_tag :licence, 'uk-ogl', @licence == 'uk-ogl' %>
+    <%= label_tag :licence, t('.filter_by_ogl') %>
+  </div>
+</div>
+
+<div class="form-group">
   <div class="dgu-filters__apply-button">
     <input class="button" type="submit" value="<%= t('.accessibility.submit_button') %>"/>
   </div>

--- a/app/views/search/_filters.html.erb
+++ b/app/views/search/_filters.html.erb
@@ -23,7 +23,7 @@
 
 <div class="form-group">
   <div class="multiple-choice">
-    <%= check_box_tag :licence, 'uk-ogl', @licence == 'uk-ogl' %>
+    <%= check_box_tag 'filters[licence]', 'uk-ogl', @licence == 'uk-ogl' %>
     <%= label_tag :licence, t('.filter_by_ogl') %>
   </div>
 </div>

--- a/app/views/search/search.html.erb
+++ b/app/views/search/search.html.erb
@@ -75,11 +75,11 @@
                   <dd><%= link_to d.organisation['title'], search_path(publisher: d.organisation['title']) %></dd>
                   <dt><%= t('.meta_data_box.last_updated') %>:</dt>
                   <% if d.last_updated_at.present? %>
-                    <dd> <%= format(d.last_updated_at) %></dd>
+                    <dd><%= format(d.last_updated_at) %></dd>
                   <% else %>
                     <dd class="dgu-secondary-text"> <%= t('.meta_data_box.not_applicable') %></dd>
                   <% end %>
-                  <dt> <%= t('.meta_data_box.geo_area') %>:</dt>
+                  <dt><%= t('.meta_data_box.geo_area') %>:</dt>
                   <% if d.location1.present? %>
                     <dd><%= d.location1 %></dd>
                   <% else %>

--- a/config/locales/views/search/en.yml
+++ b/config/locales/views/search/en.yml
@@ -26,6 +26,7 @@ en:
       filter_by_geo: "Geographical area"
       filter_by_pub: "Publisher"
       filter_by_format: "Format"
+      filter_by_ogl: "Open Government Licence (OGL) only"
       accessibility:
         submit_button: "Apply filters"
         publisher_label: "publisher"

--- a/spec/features/search_page_spec.rb
+++ b/spec/features/search_page_spec.rb
@@ -17,8 +17,8 @@ feature 'Search page', elasticsearch: true do
     query = 'interesting dataset'
 
     dataset = DatasetBuilder.new
-                .with_title(dataset_title)
-                .build
+    .with_title(dataset_title)
+    .build
 
     index([dataset])
     search_for(query)
@@ -29,16 +29,16 @@ feature 'Search page', elasticsearch: true do
 
   scenario 'Search results are correctly sorted' do
     old_dataset = DatasetBuilder.new
-                    .with_title('Old Interesting Dataset')
-                    .with_name('old-dataset')
-                    .last_updated_at('2014-07-24T14:47:25.975Z')
-                    .build
+    .with_title('Old Interesting Dataset')
+    .with_name('old-dataset')
+    .last_updated_at('2014-07-24T14:47:25.975Z')
+    .build
 
     new_dataset = DatasetBuilder.new
-                    .with_title('Recent Interesting Dataset')
-                    .with_name('new-dataset')
-                    .last_updated_at('2017-07-24T14:47:25.975Z')
-                    .build
+    .with_title('Recent Interesting Dataset')
+    .with_name('new-dataset')
+    .last_updated_at('2017-07-24T14:47:25.975Z')
+    .build
 
     index([old_dataset, new_dataset])
 
@@ -66,14 +66,14 @@ feature 'Search page', elasticsearch: true do
   scenario 'Match location query against available locations', :js => true do
 
     first_dataset = DatasetBuilder.new
-                      .with_title('Wellington Dataset')
-                      .with_location('Wellington')
-                      .build
+    .with_title('Wellington Dataset')
+    .with_location('Wellington')
+    .build
 
     second_dataset = DatasetBuilder.new
-                       .with_title('Welding Dataset')
-                       .with_location('Welding')
-                       .build
+    .with_title('Welding Dataset')
+    .with_location('Welding')
+    .build
 
     index([first_dataset, second_dataset])
 
@@ -102,14 +102,14 @@ feature 'Search page', elasticsearch: true do
   scenario 'Match publisher query against available publishers', :js => true do
 
     first_dataset = DatasetBuilder.new
-                      .with_title('Data About Tonka Trucks')
-                      .with_publisher('Tonka Trucks')
-                      .build
+    .with_title('Data About Tonka Trucks')
+    .with_publisher('Tonka Trucks')
+    .build
 
     second_dataset = DatasetBuilder.new
-                       .with_title('Data About Toby')
-                       .with_publisher('Toby Corp')
-                       .build
+    .with_title('Data About Toby')
+    .with_publisher('Toby Corp')
+    .build
 
     index([first_dataset, second_dataset])
 
@@ -135,16 +135,44 @@ feature 'Search page', elasticsearch: true do
     expect(elements[0]).to have_content 'Data About Tonka Trucks'
   end
 
-  scenario 'filter by datafile format' do
+  scenario 'filter by OGL licence' do
     first_dataset = DatasetBuilder.new
-      .with_title('First Dataset Title')
-      .with_datafiles([{'format' => 'foo'}])
-      .build
+    .with_title('First Dataset Title')
+    .with_licence('uk-ogl')
+    .build
 
     second_dataset = DatasetBuilder.new
-      .with_title('Second Dataset Title')
-      .with_datafiles([{'format' => 'bar'}])
-      .build
+    .with_title('Second Dataset Title')
+    .with_licence('foo')
+    .build
+
+    index([first_dataset, second_dataset])
+
+    visit('/search')
+
+    assert_data_set_length_is(2)
+
+    check('Open Government Licence (OGL) only')
+
+    within('.dgu-filters__apply-button') do
+      find('.button').click
+    end
+
+    results = all('h2 a')
+    expect(results.length).to be(1)
+    expect(results[0]).to have_content 'First Dataset Title'
+  end
+
+  scenario 'filter by datafile format' do
+    first_dataset = DatasetBuilder.new
+    .with_title('First Dataset Title')
+    .with_datafiles([{'format' => 'foo'}])
+    .build
+
+    second_dataset = DatasetBuilder.new
+    .with_title('Second Dataset Title')
+    .with_datafiles([{'format' => 'bar'}])
+    .build
 
     index([first_dataset, second_dataset])
 

--- a/spec/features/search_page_spec.rb
+++ b/spec/features/search_page_spec.rb
@@ -17,8 +17,8 @@ feature 'Search page', elasticsearch: true do
     query = 'interesting dataset'
 
     dataset = DatasetBuilder.new
-    .with_title(dataset_title)
-    .build
+                .with_title(dataset_title)
+                .build
 
     index([dataset])
     search_for(query)
@@ -29,16 +29,16 @@ feature 'Search page', elasticsearch: true do
 
   scenario 'Search results are correctly sorted' do
     old_dataset = DatasetBuilder.new
-    .with_title('Old Interesting Dataset')
-    .with_name('old-dataset')
-    .last_updated_at('2014-07-24T14:47:25.975Z')
-    .build
+                    .with_title('Old Interesting Dataset')
+                    .with_name('old-dataset')
+                    .last_updated_at('2014-07-24T14:47:25.975Z')
+                    .build
 
     new_dataset = DatasetBuilder.new
-    .with_title('Recent Interesting Dataset')
-    .with_name('new-dataset')
-    .last_updated_at('2017-07-24T14:47:25.975Z')
-    .build
+                    .with_title('Recent Interesting Dataset')
+                    .with_name('new-dataset')
+                    .last_updated_at('2017-07-24T14:47:25.975Z')
+                    .build
 
     index([old_dataset, new_dataset])
 
@@ -66,14 +66,14 @@ feature 'Search page', elasticsearch: true do
   scenario 'Match location query against available locations', :js => true do
 
     first_dataset = DatasetBuilder.new
-    .with_title('Wellington Dataset')
-    .with_location('Wellington')
-    .build
+                      .with_title('Wellington Dataset')
+                      .with_location('Wellington')
+                      .build
 
     second_dataset = DatasetBuilder.new
-    .with_title('Welding Dataset')
-    .with_location('Welding')
-    .build
+                      .with_title('Welding Dataset')
+                      .with_location('Welding')
+                      .build
 
     index([first_dataset, second_dataset])
 
@@ -102,14 +102,14 @@ feature 'Search page', elasticsearch: true do
   scenario 'Match publisher query against available publishers', :js => true do
 
     first_dataset = DatasetBuilder.new
-    .with_title('Data About Tonka Trucks')
-    .with_publisher('Tonka Trucks')
-    .build
+                      .with_title('Data About Tonka Trucks')
+                      .with_publisher('Tonka Trucks')
+                      .build
 
     second_dataset = DatasetBuilder.new
-    .with_title('Data About Toby')
-    .with_publisher('Toby Corp')
-    .build
+                      .with_title('Data About Toby')
+                      .with_publisher('Toby Corp')
+                      .build
 
     index([first_dataset, second_dataset])
 
@@ -137,14 +137,14 @@ feature 'Search page', elasticsearch: true do
 
   scenario 'filter by OGL licence' do
     first_dataset = DatasetBuilder.new
-    .with_title('First Dataset Title')
-    .with_licence('uk-ogl')
-    .build
+                      .with_title('First Dataset Title')
+                      .with_licence('uk-ogl')
+                      .build
 
     second_dataset = DatasetBuilder.new
-    .with_title('Second Dataset Title')
-    .with_licence('foo')
-    .build
+                      .with_title('Second Dataset Title')
+                      .with_licence('foo')
+                      .build
 
     index([first_dataset, second_dataset])
 
@@ -165,14 +165,14 @@ feature 'Search page', elasticsearch: true do
 
   scenario 'filter by datafile format' do
     first_dataset = DatasetBuilder.new
-    .with_title('First Dataset Title')
-    .with_datafiles([{'format' => 'foo'}])
-    .build
+                      .with_title('First Dataset Title')
+                      .with_datafiles([{'format' => 'foo'}])
+                      .build
 
     second_dataset = DatasetBuilder.new
-    .with_title('Second Dataset Title')
-    .with_datafiles([{'format' => 'bar'}])
-    .build
+                      .with_title('Second Dataset Title')
+                      .with_datafiles([{'format' => 'bar'}])
+                      .build
 
     index([first_dataset, second_dataset])
 

--- a/spec/support/dataset_spec_builder.rb
+++ b/spec/support/dataset_spec_builder.rb
@@ -95,6 +95,11 @@ class DatasetBuilder
     self
   end
 
+  def with_licence(licence)
+    @dataset[:licence] = licence
+    self
+  end
+
   def build
     @dataset
   end


### PR DESCRIPTION
As a user, I want to be able to see only datasets which have an Open Government License, so I know which datasets I can reuse easily. 

This will be done via a search filter - where user can choose to show only OGL datasets 

Link to the design on InVision: https://projects.invisionapp.com/d/main#/console/11687113/246684236/preview

Trello: https://trello.com/c/WbTdQtNC/206-license-filter