### PR TITLE
Handle broken previews better

### DIFF
--- a/app/models/preview.rb
+++ b/app/models/preview.rb
@@ -28,7 +28,11 @@ class Preview
   private
 
   def render
-    csv? ? CSV.parse(fetch_raw).reject{ |l| l.empty? } : []
+    begin
+      csv? ? CSV.parse(fetch_raw).reject{ |l| l.empty? } : []
+    rescue
+      []
+    end
   end
 
   def fetch_raw
@@ -41,11 +45,8 @@ class Preview
         request.url(url)
         request.options.timeout = 5
       end
-      # some datafiles have a format type of CSV but are HTML links.
-      unless html?(response)
-        raw_body = response.body.tr("\r", "\n").force_encoding('iso-8859-1').encode('utf-8')
-        raw_body.rpartition("\n")[0]
-      end
+      raw_body = response.body.tr("\r", "\n").force_encoding('iso-8859-1').encode('utf-8')
+      raw_body.rpartition("\n")[0]
     rescue
       ""
     end
@@ -56,10 +57,6 @@ class Preview
       faraday.use FaradayMiddleware::FollowRedirects, limit: 3
       faraday.adapter :net_http
     end
-  end
-
-  def html?(response)
-    response.body[1..100].include? "DOCTYPE"
   end
 
   def csv?

--- a/spec/controllers/previews_controller_spec.rb
+++ b/spec/controllers/previews_controller_spec.rb
@@ -42,5 +42,26 @@ describe PreviewsController, type: :controller do
 
       expect(response.body).to have_content('No preview is available')
     end
+
+    it 'will recover if the datafile is not CSV' do
+      stub_request(:get, datafile.url).
+        to_return(body: "<!DOCTYPE html><html lang=\"en\"><h")
+
+      index([dataset])
+      get :show, params: { dataset_uuid: dataset[:uuid], name: dataset[:name], datafile_uuid: datafile.uuid }
+
+      expect(response.body).to have_content('No preview is available')
+    end
+
+    it 'will recover if the datafile is malformed CSV' do
+      stub_request(:get, datafile.url).
+        to_return(body: "a,b,\",c,d\n000000\n")
+
+      index([dataset])
+      get :show, params: { dataset_uuid: dataset[:uuid], name: dataset[:name], datafile_uuid: datafile.uuid }
+
+      expect(response.body).to have_content('No preview is available')
+    end
+
   end
 end


### PR DESCRIPTION
Previously we checked for HTML files only, but preview would crash if it was
HTML. Now we're leaving it to the CSV gem to decide if it's valid CSV or
not.