### PR TITLE
Changes to metadata displayed on show page

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -104,9 +104,11 @@
   dt {
     width: 30%;
     font-weight: bold;
+    white-space: nowrap;
+    margin-right: 5px;
   }
   dd {
-    width: 69%;
+    width: 60%;
   }
 
 }

--- a/app/helpers/datasets_helper.rb
+++ b/app/helpers/datasets_helper.rb
@@ -38,6 +38,10 @@ module DatasetsHelper
         datafile_next_updated(dataset)
   end
 
+  def last_updated_datafile(dataset)
+    (dataset.datafiles.sort_by &:updated_at).last
+  end
+
   def expected_update_class_for(freq)
     "dgu-secondary-text" if NO_MORE.include?(freq)
   end

--- a/app/views/datasets/_meta_data.html.erb
+++ b/app/views/datasets/_meta_data.html.erb
@@ -24,7 +24,7 @@
             <% end %>
           </dd>
           <dt><%= t('.last_updated') %>:</dt>
-          <dd><%= format(@dataset.last_updated_at) %></dd>
+          <dd><%= format(last_updated_datafile(@dataset).updated_at) %></dd>
           <dt><%= t('.expected_update') %>:</dt>
           <% if @dataset.datafiles.any? %>
             <dd class="<%= expected_update_class_for(@dataset.frequency) %>">

--- a/app/views/datasets/_meta_data.html.erb
+++ b/app/views/datasets/_meta_data.html.erb
@@ -23,18 +23,21 @@
               <span itemprop="name"><%= @dataset.organisation.title =%></span>
             <% end %>
           </dd>
+
           <dt><%= t('.last_updated') %>:</dt>
-          <dd><%= format(last_updated_datafile(@dataset).updated_at) %></dd>
-          <dt><%= t('.expected_update') %>:</dt>
+          <% if @dataset.datafiles.none? %>
+            <dd><%= format(@dataset.last_updated_at) %></dd>
+          <% else %>
+            <dd><%= format(last_updated_datafile(@dataset).updated_at) %></dd>
+          <% end %>
+
           <% if @dataset.datafiles.any? %>
+            <dt><%= t('.expected_update') %>:</dt>
             <dd class="<%= expected_update_class_for(@dataset.frequency) %>">
               <%= expected_update(@dataset) %>
             </dd>
-          <% else %>
-            <dd class="dgu-secondary-text">
-              <%= t('.no_data') %>
-            </dd>
           <% end %>
+          
           <dt><%= t('.geographical_area') %>:</dt>
           <dd class="<%= expected_location_class_for(@dataset) %>" itemprop="spatialCoverage" itemscope itemtype="http://schema.org/Place">
             <span itemprop="name"><%= dataset_location(@dataset) %></span>

--- a/config/locales/views/datasets/en.yml
+++ b/config/locales/views/datasets/en.yml
@@ -44,7 +44,6 @@ en:
       published_by: "Published by"
       expected_update: "Expected update"
       last_updated: "Last updated"
-      no_data: "This dataset has no data yet"
       geographical_area: "Geographical area"
       summary: "Summary"
       related_datasets: "Related datasets"


### PR DESCRIPTION
This PR relates to [trello ticket 216](https://trello.com/c/matLU6mH/216-make-last-updated-consistent-on-dataset-show-page)

In metadata box we now display:
- date of update of most recently updated datafile, if datafiles.any?
- if no datafiles we display date of last update to the dataset.
- if no datafiles we hide the expected update field as per [this design](https://projects.invisionapp.com/d/main#/console/11687113/269790200/preview)
