### PR TITLE
Use require instead of sass @import directive

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,10 +10,10 @@
  * files in this directory. Styles in this file should be added after the last require_* statement.
  * It is generally better to create a new file per style scope.
  *
+ * = require accessible-autocomplete.min.css
  */
 
 @import 'govuk';
 @import 'govuk-overrides';
 @import 'components';
 @import 'dgu';
-@import 'accessible-autocomplete.min.css';


### PR DESCRIPTION
Not entirely sure why but `@import 'accessible-autocomplete.min.css'` literally gets processed into `@import url(accessible-autocomplete.min.css)`, which points to a non-existent file (the Rails asset pipeline processes all the CSS into a single file).

The good old `*/ = require` should fix this.