### PR TITLE
Deployment Tagging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ language: ruby
 cache: bundler
 rvm:
 - 2.4
+branches:
+  only:
+  - master
+  - /deploy-production*/
 services:
 - postgresql
 - elasticsearch
@@ -33,11 +37,14 @@ after_success:
   - sudo apt-get update
   - sudo apt-get install cf-cli
 deploy:
+  # To staging
   - provider: script
     script: scripts/deploy.sh find-data-beta-staging staging
     on:
-      branch: master
+      repo: alphagov/datagovuk_find
+  # To production
   - provider: script
     script: scripts/deploy.sh find-data-beta production
     on:
-      branch: production
+      repo: alphagov/datagovuk_find
+      tags: true


### PR DESCRIPTION
- Deploy to production if a github tag is pushed to master.
- Make the repo name a condition for deployment to Cloud Foundry