### PR TITLE
Redirect legacy search URLs to beta search results page

### DIFF
--- a/app/controllers/legacy_search_controller.rb
+++ b/app/controllers/legacy_search_controller.rb
@@ -1,0 +1,17 @@
+class LegacySearchController < ApplicationController
+  def redirect
+    filters = {
+      format: params["res_format"],
+      publisher: params["publisher"],
+      licence: licence_param
+    }.compact
+
+    redirect_to search_path(q: params["q"], filters: filters)
+  end
+
+  private
+
+  def licence_param
+    return "uk-ogl" if params["license_id-is-ogl"] == "true"
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
 
   get 'search/', to: 'search#search'
   get 'search/tips', to: 'search#tips'
+  get 'data/search', to: 'legacy_search#redirect'
 
   get 'dataset/:legacy_name', to: 'legacy_datasets#redirect'
   get 'dataset/:uuid/:name', to: 'datasets#show', as: 'dataset'

--- a/spec/requests/legacy_redirect_spec.rb
+++ b/spec/requests/legacy_redirect_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+describe 'legacy', :type => :request do
+  describe 'search query' do
+    it 'is redirected to search results page with original query and filters' do
+      legacy_params = {
+        "q" => 'foo',
+        "res_format" => 'bar',
+        "publisher" => 'baz',
+        "license_id-is-ogl" => "true"
+      }
+
+      get "/data/search?#{legacy_params.to_query}"
+
+      expected_params = {
+        "q" => 'foo',
+        "filters" => {
+          "format" => 'bar',
+          "publisher" => 'baz',
+          "licence" => 'uk-ogl'
+        }
+      }
+
+      expect(response).to redirect_to(search_path(expected_params))
+    end
+  end
+end


### PR DESCRIPTION
This PR makes sure we redirect any legacy search URL to the search results page on Find Beta, in a way that includes the original search query and filters.

https://trello.com/c/NQa9b2KZ/225-find-redirect-searches-on-legacy-dgu-to-search-results-page-on-beta