### PR TITLE
Redirect legacy /contact URL to /support

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   scope module: 'legacy' do
     get 'dataset/:legacy_name', to: 'datasets#redirect'
     get 'data/search',          to: 'search#redirect'
+    get 'contact',              to: redirect('support')
   end
 
   scope module: 'pages' do

--- a/spec/requests/legacy/redirect_spec.rb
+++ b/spec/requests/legacy/redirect_spec.rb
@@ -25,8 +25,8 @@ describe 'legacy', :type => :request do
     end
   end
 
-  describe 'visiting a dataset page with a legacy URL' do
-    it "redirects to the latest slugged URL" do
+  describe 'dataset page' do
+    it 'redirects to the latest slugged URL' do
       legacy_name = 'a-legacy-name'
       dataset = DatasetBuilder.new.with_legacy_name(legacy_name).build
       index([dataset])
@@ -34,6 +34,15 @@ describe 'legacy', :type => :request do
       get "/dataset/#{legacy_name}"
 
       expect(response).to redirect_to(dataset_url(dataset[:uuid], dataset[:name]))
+      expect(response.status).to eql 301
+    end
+  end
+
+  describe 'contact page' do
+    it 'redirects to the support page' do
+      get '/contact'
+
+      expect(response).to redirect_to(support_url)
       expect(response.status).to eql 301
     end
   end


### PR DESCRIPTION
As a user of legacy DGU, when I go to `/contact`, I am redirected to the new Find's `/support` page.

https://trello.com/c/rd0Esf10/226-find-redirect-legacy-contact-page-to-betas-support-page