### PR TITLE
Change git release tagging convention to vX.X.X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ rvm:
 branches:
   only:
   - master
-  - /find-beta-v*/
+  - /^v\d+\.\d+\.\d+$/
 services:
 - postgresql
 - elasticsearch


### PR DESCRIPTION
https://trello.com/c/GiixWO8N/31-implement-github-tagging-for-production-deployments