### PR TITLE
Fix autocomplete on datafile format filter

### DIFF
--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -3,6 +3,8 @@
 $(document).ready(function() {
   accessibleAutocomplete.enhanceSelectElement({
     selectElement: document.querySelector('#js_format-filter'),
-    showAllValues: true
+    showAllValues: true,
+    confirmOnBlur: false,
+    autoselect: false
   })
 });

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -9,7 +9,7 @@ module SearchHelper
   end
 
   def datafile_formats_for_select
-    Dataset.datafile_formats
+    Dataset.datafile_formats.unshift("").uniq
   end
 
   def selected_format

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -1,15 +1,15 @@
 module SearchHelper
 
   def display_sort(sort)
-    sort == 'best' ? "Best Match" : "Most Recent"
+    sort == 'best' ? 'Best Match' : 'Most Recent'
   end
 
   def format(timestamp)
-    Time.parse(timestamp).strftime("%d %B %Y")
+    Time.parse(timestamp).strftime('%d %B %Y')
   end
 
   def datafile_formats_for_select
-    Dataset.datafile_formats.unshift("").uniq
+    Dataset.datafile_formats.unshift('').uniq
   end
 
   def selected_format

--- a/spec/helpers/search_helper_spec.rb
+++ b/spec/helpers/search_helper_spec.rb
@@ -21,7 +21,7 @@ describe SearchHelper do
 
       index([first_dataset, second_dataset])
 
-      expect(datafile_formats_for_select).to eql ['baz', 'bar', 'foo']
+      expect(datafile_formats_for_select).to eql ['', 'baz', 'bar', 'foo']
     end
   end
 end


### PR DESCRIPTION
### Bug

On arriving on the search page, with no filters selected, the datafile format filter already has one selected (the first one in the list).

### Fix

The accessible autocomplete automatically selects the first value in the list of possible values that is given to it. In this case, the list of available format filters is given to us by an elastic search aggregation query. For the filter to work with the expected behaviour, the first item in the list MUST be an empty string.

However, because the results of the aggregation are based on the datafile formats present in the ES index, this list will sometimes be in the correct format (i.e. `["", "foo", "bar"]`), sometimes not, depending on whether a datafile in the index happens to have a format value set as `""`.

To avoid this, this PR makes sure we always prepend an empty string to our list of formats.