### PR TITLE
Remove now obsolete rubyracer gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ gem "elasticsearch", "~> 5.0.4"
 gem "elasticsearch-model", "~> 5.0.1"
 gem "elasticsearch-rails", "~> 5.0.1"
 gem "elasticsearch-persistence", "~> 5", require: "elasticsearch/persistence/model"
-gem 'therubyracer'
 gem 'elasticsearch-dsl', "~> 0.1.5"
 gem 'htmlentities', "~> 4.3"
 gem 'gon'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -224,7 +224,6 @@ GEM
     kaminari-core (1.0.1)
     launchy (2.4.3)
       addressable (~> 2.3)
-    libv8 (3.16.14.19)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -309,7 +308,6 @@ GEM
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
-    ref (2.0.0)
     request_store (1.3.2)
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
@@ -377,9 +375,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    therubyracer (0.12.3)
-      libv8 (~> 3.16.14.15)
-      ref
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
@@ -469,7 +464,6 @@ DEPENDENCIES
   simplecov (~> 0.13)
   spring (~> 2.0)
   spring-watcher-listen (~> 2.0.0)
-  therubyracer
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)


### PR DESCRIPTION
It seems to have been installed to fix some Heroku deploy issue back in July 2017 in https://github.com/alphagov/datagovuk_find/pull/51.

This PR relates to https://trello.com/c/0sKohCiC/103-find-investigate-therubyracer-dependency