### PR TITLE
Remove expected update field from dataset show page

### DIFF
--- a/app/helpers/datasets_helper.rb
+++ b/app/helpers/datasets_helper.rb
@@ -1,12 +1,5 @@
 module DatasetsHelper
 
-  FREQUENCIES = {
-      'annually' => {years: 1},
-      'quarterly' => {months: 4},
-      'monthly' => {months: 1},
-      'daily' => {days: 1}
-  }
-
   NO_MORE = {
       'discontinued' => 'Dataset no longer updated',
       'never' => 'No future updates',
@@ -32,18 +25,8 @@ module DatasetsHelper
     key != nil && key != ""
   end
 
-  def expected_update(dataset)
-    dataset.frequency.nil? ?
-        NO_MORE['default'] :
-        datafile_next_updated(dataset)
-  end
-
   def last_updated_datafile(dataset)
     (dataset.datafiles.sort_by &:updated_at).last
-  end
-
-  def expected_update_class_for(freq)
-    "dgu-secondary-text" if NO_MORE.include?(freq)
   end
 
   def dataset_location(dataset)
@@ -67,19 +50,6 @@ module DatasetsHelper
   end
 
   private
-
-  def datafile_next_updated(dataset)
-    freq = dataset.frequency
-    last = Time.parse(most_recent_date(dataset.datafiles))
-
-    return last.advance(FREQUENCIES[freq]).strftime("%d %B %Y") if FREQUENCIES.has_key?(freq)
-    return NO_MORE[freq] if NO_MORE.has_key?(freq)
-    NO_MORE['default']
-  end
-
-  def most_recent_date(datafiles)
-    datafiles.map(&:most_recent_date).max
-  end
 
   def documents(datafiles)
     datafiles.select do |file|

--- a/app/views/datasets/_meta_data.html.erb
+++ b/app/views/datasets/_meta_data.html.erb
@@ -31,13 +31,6 @@
             <dd><%= format(last_updated_datafile(@dataset).updated_at) %></dd>
           <% end %>
 
-          <% if @dataset.datafiles.any? %>
-            <dt><%= t('.expected_update') %>:</dt>
-            <dd class="<%= expected_update_class_for(@dataset.frequency) %>">
-              <%= expected_update(@dataset) %>
-            </dd>
-          <% end %>
-          
           <dt><%= t('.geographical_area') %>:</dt>
           <dd class="<%= expected_location_class_for(@dataset) %>" itemprop="spatialCoverage" itemscope itemtype="http://schema.org/Place">
             <span itemprop="name"><%= dataset_location(@dataset) %></span>

--- a/config/locales/views/datasets/en.yml
+++ b/config/locales/views/datasets/en.yml
@@ -42,7 +42,6 @@ en:
     meta_data:
       availability: "Availability"
       published_by: "Published by"
-      expected_update: "Expected update"
       last_updated: "Last updated"
       geographical_area: "Geographical area"
       summary: "Summary"


### PR DESCRIPTION
This PR relates to https://trello.com/c/9iPeHrKL/109-remove-expected-update-field-from-dataset-template

As per description in the trello card, we do not currently have enough user research to know exactly what information a user requires to assess if a dataset is current and can answer their question, Jonathan has requested we remove the expected update field for the time being as it is inaccurate and causing confusion. 

- Removes expected update field from metadata box on show page
- Removes calculation of expected updated from datasets helper