### PR TITLE
Normalize datafile format case

### DIFF
--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -9,7 +9,7 @@ module SearchHelper
   end
 
   def datafile_formats_for_select
-    Dataset.datafile_formats.unshift('').uniq
+    Dataset.datafile_formats.map(&:upcase).unshift('')
   end
 
   def selected_format

--- a/spec/features/search_page_spec.rb
+++ b/spec/features/search_page_spec.rb
@@ -180,7 +180,7 @@ feature 'Search page', elasticsearch: true do
 
     assert_data_set_length_is(2)
 
-    select('foo', from: 'filters[format]')
+    select('FOO', from: 'filters[format]')
 
     within('.dgu-filters__apply-button') do
       find('.button').click
@@ -189,7 +189,7 @@ feature 'Search page', elasticsearch: true do
     results = all('h2 a')
     expect(results.length).to be(1)
     expect(results[0]).to have_content 'First Dataset Title'
-    expect(page).to have_content 'Datasets filtered by foo'
+    expect(page).to have_content 'Datasets filtered by FOO'
   end
 
   def assert_data_set_length_is(count)

--- a/spec/helpers/search_helper_spec.rb
+++ b/spec/helpers/search_helper_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe SearchHelper do
   describe '#datafile_formats_for_select' do
-    it 'returns a list of unique datafile formats ordered by datafile count (elasticsearch default)' do
+    it 'returns a list of upcased unique datafile formats ordered by datafile count (elasticsearch default)' do
       # More info: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-nested-aggregation.html
 
       first_dataset = DatasetBuilder.new
@@ -21,7 +21,27 @@ describe SearchHelper do
 
       index([first_dataset, second_dataset])
 
-      expect(datafile_formats_for_select).to eql ['', 'baz', 'bar', 'foo']
+      expect(datafile_formats_for_select).to eql ['', 'BAZ', 'BAR', 'FOO']
+    end
+
+    it 'returns a list of datafile formats normalized for case' do
+      first_dataset = DatasetBuilder.new
+      .with_title('First Dataset Title')
+      .with_datafiles([{'format' => 'FOO'}])
+      .build
+
+      second_dataset = DatasetBuilder.new
+      .with_title('Second Dataset Title')
+      .with_datafiles([
+                      {'format' => 'foo'},
+                      {'format' => 'BAR'},
+                      {'format' => 'BAZ'}
+      ])
+      .build
+
+      index([first_dataset, second_dataset])
+
+      expect(datafile_formats_for_select).to eql ['', 'FOO', 'BAR', 'BAZ']
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,7 +37,48 @@ RSpec.configure do |config|
   Kernel.srand config.seed
 end
 
-def mappings
+def delete_index
+  if Rails.env == "test"
+    begin
+      ELASTIC.indices.delete index: "datasets-test"
+    rescue
+      Rails.logger.debug("No test search index to delete")
+    end
+  end
+end
+
+def create_index
+  if Rails.env == "test"
+    begin
+      Rails.logger.info("Creating datasets-test index")
+
+      ELASTIC.indices.create(
+        index: "datasets-test",
+        body: {
+            settings: index_settings,
+            mappings: index_mappings
+        }
+      )
+    rescue
+      Rails.logger.debug("Could not create datasets-test index")
+    end
+  end
+end
+
+def index_settings
+  {
+    analysis: {
+      normalizer: {
+        lowercase_normalizer: {
+          type: "custom",
+          filter: "lowercase"
+        }
+      }
+    }
+  }
+end
+
+def index_mappings
   {
     dataset: {
       properties: {
@@ -79,37 +120,13 @@ def mappings
         datafiles: {
           type: "nested",
           properties: {
-            format: { type: "keyword" }
+            format: {
+              type: "keyword",
+              normalizer: "lowercase_normalizer"
+            }
           }
         }
       }
     }
   }
-end
-
-def delete_index
-  if Rails.env == "test"
-    begin
-      ELASTIC.indices.delete index: "datasets-test"
-    rescue
-      Rails.logger.debug("No test search index to delete")
-    end
-  end
-end
-
-def create_index
-  if Rails.env == "test"
-    begin
-      Rails.logger.info("Creating datasets-test index")
-
-      ELASTIC.indices.create(
-        index: "datasets-test",
-        body: {
-            mappings: mappings
-        }
-      )
-    rescue
-      Rails.logger.debug("Could not create datasets-test index")
-    end
-  end
 end


### PR DESCRIPTION
### Issue

![screen shot 2018-01-17 at 15 35 00](https://user-images.githubusercontent.com/3141541/35097701-1fa02b36-fc49-11e7-85e5-24da094a0f0d.png)

If a datafile has lowercase format (e.g. 'csv') and another has an uppercased one ('CSV'), then the list of available formats to pick from in the format filter shows both.

### Fix

This PR makes sure the user only sees a list of unique formats by making sure Elastic Search tokenizes file formats regardless of case, i.e. "csv" and "CSV" are both tokenized to "csv".

https://trello.com/c/r5koAzWE/128-find-bug-datafile-format-filter-list-shows-both-upcased-and-downcased-file-formats

More about ES normalisers: https://www.elastic.co/guide/en/elasticsearch/reference/master/normalizer.html.

Normalizer implemented in the Publish codebase: https://github.com/alphagov/datagovuk_publish/pull/496.