### PR TITLE
Refactor models on Find

### DIFF
--- a/app/helpers/datasets_helper.rb
+++ b/app/helpers/datasets_helper.rb
@@ -17,10 +17,6 @@ module DatasetsHelper
     Time.parse(timestamp).strftime("%d %B %Y")
   end
 
-  def no_documents?(datafiles)
-    documents(datafiles).count == 0
-  end
-
   def documentation?(key)
     key != nil && key != ""
   end
@@ -50,12 +46,6 @@ module DatasetsHelper
   end
 
   private
-
-  def documents(datafiles)
-    datafiles.select do |file|
-      documentation?(file.documentation)
-    end
-  end
 
   def locations(dataset)
     ['location1', 'location2', 'location3']

--- a/app/helpers/datasets_helper.rb
+++ b/app/helpers/datasets_helper.rb
@@ -17,10 +17,6 @@ module DatasetsHelper
     Time.parse(timestamp).strftime("%d %B %Y")
   end
 
-  def documentation?(key)
-    key != nil && key != ""
-  end
-
   def last_updated_datafile(dataset)
     (dataset.datafiles.sort_by &:updated_at).last
   end

--- a/app/models/datafile.rb
+++ b/app/models/datafile.rb
@@ -1,6 +1,6 @@
 class Datafile
   attr_reader :name, :url, :start_date, :end_date,
-              :updated_at, :format, :size, :documentation,
+              :created_at, :updated_at, :format, :size,
               :uuid
 
   def initialize(attrs)
@@ -8,10 +8,10 @@ class Datafile
     @url = attrs["url"]
     @start_date = attrs["start_date"]
     @end_date = attrs["end_date"]
+    @created_at = attrs["created_at"]
     @updated_at = attrs["updated_at"]
     @format =  attrs["format"]
     @size =  attrs["size"]
-    @documentation = attrs["documentation"]
     @uuid = attrs["uuid"]
   end
 

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -8,14 +8,14 @@ class Dataset
                 :contact_name, :contact_email, :contact_phone,
                 :licence, :licence_other, :frequency,
                 :published_date, :last_updated_at, :created_at,
-                :harvested, :uuid, :datafiles,
+                :harvested, :uuid,
                 :inspire_dataset, :json, :notes,
                 :contact_name, :contact_email, :contact_phone,
                 :foi_name, :foi_email, :foi_phone, :foi_web,
                 :_index, :_type, :_id, :_score, :_source,
                 :_version
 
-  attr_reader :organisation
+  attr_reader :organisation,:docs, :datafiles
 
   index_name ENV['ES_INDEX'] || "datasets-#{Rails.env}"
 
@@ -62,8 +62,16 @@ class Dataset
     map_keys(buckets)
   end
 
-  def datafiles
-    @datafiles.map { |file| Datafile.new(file) }
+  def docs=(docs)
+    @docs = docs.map { |file| Doc.new(file) }
+  end
+
+  def datafiles=(datafiles)
+    @datafiles = datafiles.map { |file| Datafile.new(file)}
+  end
+
+  def links
+    @docs + @datafiles
   end
 
   def timeseries_datafiles

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -71,7 +71,7 @@ class Dataset
   end
 
   def links
-    @docs + @datafiles
+    docs + datafiles
   end
 
   def timeseries_datafiles

--- a/app/models/doc.rb
+++ b/app/models/doc.rb
@@ -1,0 +1,16 @@
+class Doc
+  attr_reader :name, :url, :created_at,
+              :updated_at, :format, :size,
+              :uuid
+
+  def initialize(attrs)
+    @name = attrs["name"]
+    @url = attrs["url"]
+    @created_at = attrs["created_at"]
+    @updated_at = attrs["updated_at"]
+    @format =  attrs["format"]
+    @size =  attrs["size"]
+    @uuid = attrs["uuid"]
+  end
+
+end

--- a/app/views/datasets/_supporting_docs.html.erb
+++ b/app/views/datasets/_supporting_docs.html.erb
@@ -15,10 +15,10 @@
     <% @dataset.docs.each do |doc| %>
       <tr>
         <td class="title">
-          <a href="<%= doc['url'] %>"><%= doc['name'] %></a>
+          <a href="<%= doc.url%>"><%= doc.name %></a>
         </td>
-        <td><%= doc["format"] or "N/A" %></td>
-        <td><%= doc["created_at"] or "N/A" %></td>
+        <td><%= doc.format or "N/A" %></td>
+        <td><%= format(doc.created_at) or "N/A" %></td>
       </tr>
     <% end %>
     </tbody>

--- a/app/views/datasets/_supporting_docs.html.erb
+++ b/app/views/datasets/_supporting_docs.html.erb
@@ -12,13 +12,13 @@
     </tr>
     </thead>
     <tbody>
-    <% documents.each do |doc| %>
+    <% @dataset.docs.each do |doc| %>
       <tr>
         <td class="title">
           <a href="<%= doc['url'] %>"><%= doc['name'] %></a>
         </td>
         <td><%= doc["format"] or "N/A" %></td>
-        <td><%= doc["start_date"] or "N/A" %></td>
+        <td><%= doc["created_at"] or "N/A" %></td>
       </tr>
     <% end %>
     </tbody>

--- a/app/views/datasets/show.html.erb
+++ b/app/views/datasets/show.html.erb
@@ -41,7 +41,7 @@
 
   <%= render "additional_info" %>
 
-  <% unless no_documents?(@dataset.datafiles) %>
+  <% unless @dataset.docs.empty? %>
     <%= render "supporting_docs" %>
   <% end %>
 

--- a/spec/controllers/previews_controller_spec.rb
+++ b/spec/controllers/previews_controller_spec.rb
@@ -19,7 +19,6 @@ describe PreviewsController, type: :controller do
 
       index([dataset])
       get :show, params: { dataset_uuid: dataset[:uuid], name: dataset[:name], datafile_uuid: datafile.uuid }
-
       expect(response.body).to have_content('Berlin')
     end
 

--- a/spec/features/dataset_show_page_spec.rb
+++ b/spec/features/dataset_show_page_spec.rb
@@ -251,9 +251,9 @@ feature 'Dataset page', elasticsearch: true do
         {
           id: 4,
           url: "http://www.foobar.com",
-          name: "Datafile 3",
+          name: "Datafile 4",
           start_date: nil,
-          end_date: "2001/12/12",
+          end_date: nil,
           updated_at: "2001/01/01"
         }
       ]
@@ -263,7 +263,6 @@ feature 'Dataset page', elasticsearch: true do
         .build
 
       index_and_visit(dataset)
-
       expect(page).to have_css(".dgu-datafiles__year", count: 2)
     end
 
@@ -274,7 +273,7 @@ feature 'Dataset page', elasticsearch: true do
           url: "http://www.foobar.com",
           name: "Datafile 1",
           start_date: nil,
-          end_date: "2000/12/12",
+          end_date: nil,
           updated_at: "2000/01/01"
         },
         {
@@ -282,7 +281,7 @@ feature 'Dataset page', elasticsearch: true do
           url: "http://www.foobar.com",
           name: "Datafile 2",
           start_date: nil,
-          end_date: "2001/12/12",
+          end_date: nil,
           updated_at: "2001/01/01"
         },
         {
@@ -290,7 +289,7 @@ feature 'Dataset page', elasticsearch: true do
           url: "http://www.foobar.com",
           name: "Datafile 3",
           start_date: nil,
-          end_date: "2001/12/12",
+          end_date: nil,
           updated_at: "2001/01/01"
         }
       ]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -81,6 +81,12 @@ def mappings
           properties: {
             format: { type: "keyword" }
           }
+        },
+        docs: {
+          type: "nested",
+          properties: {
+            format: { type: "keyword" }
+          }
         }
       }
     }

--- a/spec/support/dataset_spec_builder.rb
+++ b/spec/support/dataset_spec_builder.rb
@@ -40,6 +40,7 @@ class DatasetBuilder
             ancestry: ''
         },
         datafiles: [],
+        docs: [],
         notes: ''
     }
   end
@@ -117,6 +118,7 @@ DATA_FILES_WITH_START_AND_ENDDATE = [
      'format' => 'HTML',
      'start_date' => '1/1/15',
      'end_date' => nil,
+     'created_at' => '2016-07-31T14:40:57.528Z',
      'updated_at' => '2016-08-31T14:40:57.528Z'
     },
     {'id' => 2,
@@ -125,6 +127,7 @@ DATA_FILES_WITH_START_AND_ENDDATE = [
      'format' => 'CSV',
      'start_date' => '1/1/15',
      'end_date' => '24/03/2018',
+     'created_at' => '2016-07-31T14:40:57.528Z',
      'updated_at' => '2016-08-31T14:40:57.528Z',
      'uuid' => '5e359634-f15b-4639-97e6-a4e28ba15276'
     },
@@ -134,6 +137,7 @@ DATA_FILES_WITH_START_AND_ENDDATE = [
      'format' => '',
      'start_date' => '1/1/15',
      'end_date' => '01/12/2018',
+     'created_at' => '2016-07-31T14:40:57.528Z',
      'updated_at' => '2016-08-31T14:40:57.528Z'
     }
 ]


### PR DESCRIPTION
This PR relates to https://trello.com/c/S2dYl1vy/97-bug-documents-are-shown-in-datafiles-sections

- Changes have been made to our data models on Publish. We now have Dataset.links with type datafile or type doc. See [Publish PR #493](https://github.com/alphagov/datagovuk_publish/pull/493)
- In addition we are now storing Datafiles and Docs as separate arrays on elastic search
- As a result changes were required on Find. Namely the creation of a new model: Doc, and a refactoring of the existing model Datafile. 