### PR TITLE
Sort search filter datafile formats alphabetically

### DIFF
--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -9,7 +9,7 @@ module SearchHelper
   end
 
   def datafile_formats_for_select
-    Dataset.datafile_formats.map(&:upcase).unshift('')
+    Dataset.datafile_formats.sort.map(&:upcase).unshift('')
   end
 
   def selected_format

--- a/spec/helpers/search_helper_spec.rb
+++ b/spec/helpers/search_helper_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe SearchHelper do
   describe '#datafile_formats_for_select' do
-    it 'returns a list of upcased unique datafile formats ordered by datafile count (elasticsearch default)' do
+    it 'returns a list of upcased unique datafile formats ordered alphabetically' do
       # More info: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-nested-aggregation.html
 
       first_dataset = DatasetBuilder.new
@@ -21,7 +21,7 @@ describe SearchHelper do
 
       index([first_dataset, second_dataset])
 
-      expect(datafile_formats_for_select).to eql ['', 'BAZ', 'BAR', 'FOO']
+      expect(datafile_formats_for_select).to eql ['', 'BAR', 'BAZ', 'FOO']
     end
 
     it 'returns a list of datafile formats normalized for case' do
@@ -41,7 +41,7 @@ describe SearchHelper do
 
       index([first_dataset, second_dataset])
 
-      expect(datafile_formats_for_select).to eql ['', 'FOO', 'BAR', 'BAZ']
+      expect(datafile_formats_for_select).to eql ['', 'BAR', 'BAZ', 'FOO']
     end
   end
 end


### PR DESCRIPTION
![screen shot 2018-01-22 at 12 30 16](https://user-images.githubusercontent.com/3141541/35220884-023be650-ff70-11e7-82a4-5210efd5a506.png)

By default, ElasticSearch orders aggregations by the number of results associated with each filter, but this means the order is inconsistent across searches.

This makes sure they are always sorted alphabetically.

https://trello.com/c/8kQsYZeZ/130-order-file-formats-in-datafile-format-filter-list-alphabetically-s