### PR TITLE
Fix undefined method #empty? for nil:NilClass

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -15,7 +15,7 @@ class Dataset
                 :_index, :_type, :_id, :_score, :_source,
                 :_version
 
-  attr_reader :organisation,:docs, :datafiles
+  attr_reader :organisation
 
   index_name ENV['ES_INDEX'] || "datasets-#{Rails.env}"
 
@@ -62,8 +62,16 @@ class Dataset
     map_keys(buckets)
   end
 
+  def docs
+    Array(@docs)
+  end
+
   def docs=(docs)
     @docs = docs.map { |file| Doc.new(file) }
+  end
+
+  def datafiles
+    Array(@datafiles)
   end
 
   def datafiles=(datafiles)


### PR DESCRIPTION
Fixes https://sentry.io/government-digital-service/find/issues/437118602/

Coercing `@datafiles` and `@docs` into an array ensures the reader methods always returns an array, as can reasonably be expected.