### PR TITLE
Time series datafiles are grouped and displayed in correct order

### DIFF
--- a/app/helpers/datasets_helper.rb
+++ b/app/helpers/datasets_helper.rb
@@ -41,6 +41,10 @@ module DatasetsHelper
     end
   end
 
+  def group_and_order(datafiles)
+    datafiles.group_by(&:start_year).sort.reverse
+  end
+
   private
 
   def locations(dataset)

--- a/app/views/datasets/_timeseries_data.html.erb
+++ b/app/views/datasets/_timeseries_data.html.erb
@@ -1,5 +1,5 @@
 <ul>
-  <% datafiles.group_by(&:start_year).each do |year, datafiles| %>
+  <% group_and_order(datafiles).each do |year, datafiles| %>
     <li class="showHide">
       <div class="year-expand showHide-control">
         <h3 class="heading-small">

--- a/spec/features/dataset_show_page_spec.rb
+++ b/spec/features/dataset_show_page_spec.rb
@@ -264,6 +264,14 @@ feature 'Dataset page', elasticsearch: true do
 
       index_and_visit(dataset)
       expect(page).to have_css(".dgu-datafiles__year", count: 2)
+
+      correct_order = [
+        "#{Time.parse(timeseries_and_non_timeseries[1][:start_date]).year}",
+        "#{Time.parse(timeseries_and_non_timeseries[0][:start_date]).year}"
+        ]
+      actual_order = all('button.dgu-datafiles__year').map(&:text)
+
+      expect(actual_order).to eq correct_order
     end
 
     scenario 'are not grouped when they contain non timeseries datafiles' do


### PR DESCRIPTION
This PR relates to: https://trello.com/c/vl7hH8cp/146-datafiles-grouped-by-year-are-not-displayed-chronologically

Currently we group time series datafiles by year, but we do not display them in order from newest to oldest. This PR corrects that. 
