### PR TITLE
Display a datafile's creation date, instead of datafile's updated date. 

### DIFF
--- a/app/views/datasets/_datafile_table.html.erb
+++ b/app/views/datasets/_datafile_table.html.erb
@@ -2,7 +2,7 @@
   <tr>
     <th class="title small"><%= t('.link_to_data') %></th>
     <th><%= t('.format') %></th>
-    <th><%= t('.last_updated') %></th>
+    <th><%= t('.file_added') %></th>
     <th><%= t('.data_preview') %></th>
   </tr>
   <tbody>
@@ -24,9 +24,9 @@
           <% end %>
           </td>
         <% end %>
-        <% if datafile.updated_at.present? %>
+        <% if datafile.created_at.present? %>
           <td>
-            <%= format(datafile.updated_at) %>
+            <%= format(datafile.created_at) %>
           </td>
         <% else %>
           <td class="dgu-secondary-text">Not available</td>

--- a/config/locales/views/datasets/en.yml
+++ b/config/locales/views/datasets/en.yml
@@ -31,7 +31,7 @@ en:
     datafile_table:
       link_to_data: "Link to the data"
       format: "Format"
-      last_updated: "Last updated"
+      file_added: "File added"
       data_preview: "Data preview"
       data_link: "Data Link"
       n_a: "N/A"


### PR DESCRIPTION
This PR relates to https://trello.com/c/matLU6mH/48-make-last-updated-consistent-on-dataset-show-page

- Rename column in the datafiles table on show page, Last Updated --> File Added
- Display date that a datafile was created, instead of date the datafile was updated 
