### PR TITLE
Bug: organisation contact details not displayed even though dataset details are blank

### DIFF
--- a/app/views/datasets/show.html.erb
+++ b/app/views/datasets/show.html.erb
@@ -60,7 +60,7 @@
 
             <p>
               <%= @dataset.contact_name.presence || @dataset.organisation.contact_name %></br>
-              <%= mail_to(@dataset.contact_email || @dataset.organisation.contact_email) %>
+              <%= mail_to(@dataset.contact_email.presence || @dataset.organisation.contact_email) %>
             </p>
           </div>
         <% end %>
@@ -73,7 +73,7 @@
 
             <p>
               <%= @dataset.foi_name.presence || @dataset.organisation.foi_name %></br>
-              <%= mail_to(@dataset.foi_email || @dataset.organisation.foi_email) %>
+              <%= mail_to(@dataset.foi_email.presence || @dataset.organisation.foi_email) %>
             </p>
           </div>
         <% end %>


### PR DESCRIPTION
When any dataset contact details value is blank , the organisation details never get displayed, because:

```
"" || "foo"
=> ""
```
### Fix:

```
"".presence || "foo"
=> "foo"
```

https://trello.com/c/Ou5kn5MN/168-email-addresses-not-being-shown-in-publisher-contact-details