### PR TITLE
Change cookies link to data.gov.uk one

### DIFF
--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -13,7 +13,7 @@
 <ul class="list list-bullet">
   <li>questions, queries or feedback you leave, including your email address if you contact data.gov.uk</li>
   <li>your IP address, and details of which version of <%= link_to 'web browser', 'https://www.gov.uk/help/browsers' %> you used</li>
-  <li>information on how you use the site, using <%= link_to 'cookies', 'https://www.gov.uk/help/cookies' %> and page tagging techniques</li>
+  <li>information on how you use the site, using <%= link_to 'cookies', '/cookies' %> and page tagging techniques</li>
 </ul>
 
 <p>This data can be viewed by authorised people in the <%= link_to 'Government Digital Service', 'https://www.gov.uk/government/organisations/government-digital-service' %> (GDS) and our suppliers, to:</p>

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -13,7 +13,7 @@
 <ul class="list list-bullet">
   <li>questions, queries or feedback you leave, including your email address if you contact data.gov.uk</li>
   <li>your IP address, and details of which version of <%= link_to 'web browser', 'https://www.gov.uk/help/browsers' %> you used</li>
-  <li>information on how you use the site, using <%= link_to 'cookies', '/cookies' %> and page tagging techniques</li>
+  <li>information on how you use the site, using <%= link_to 'cookies', cookies_path %> and page tagging techniques</li>
 </ul>
 
 <p>This data can be viewed by authorised people in the <%= link_to 'Government Digital Service', 'https://www.gov.uk/government/organisations/government-digital-service' %> (GDS) and our suppliers, to:</p>


### PR DESCRIPTION
We have a cookies page - we should link to it.

https://trello.com/c/IEmwriZb/163-privacy-page