### PR TITLE
Replace uuid's with short_id's

### DIFF
--- a/app/controllers/datasets_controller.rb
+++ b/app/controllers/datasets_controller.rb
@@ -2,7 +2,7 @@ class DatasetsController < LoggedAreaController
   include DatasetsHelper
 
   def show
-    @dataset = Dataset.get_by_uuid(uuid: params[:uuid])
+    @dataset = Dataset.get_by_short_id(short_id: params[:short_id])
     @timeseries_datafiles = @dataset.timeseries_datafiles
     @non_timeseries_datafiles = @dataset.non_timeseries_datafiles
     @referer_query = referer_query
@@ -40,6 +40,6 @@ class DatasetsController < LoggedAreaController
   end
 
   def newest_dataset_path
-    dataset_path(@dataset.uuid, @dataset.name)
+    dataset_path(@dataset.short_id, @dataset.name)
   end
 end

--- a/app/controllers/legacy/datasets_controller.rb
+++ b/app/controllers/legacy/datasets_controller.rb
@@ -1,6 +1,6 @@
 class Legacy::DatasetsController < ApplicationController
   def redirect
     dataset = Dataset.get_by_legacy_name(legacy_name: params[:legacy_name])
-    redirect_to dataset_path(dataset.uuid, dataset.name), status: :moved_permanently
+    redirect_to dataset_path(dataset.short_id, dataset.name), status: :moved_permanently
   end
 end

--- a/app/controllers/previews_controller.rb
+++ b/app/controllers/previews_controller.rb
@@ -1,6 +1,6 @@
 class PreviewsController < LoggedAreaController
   def show
-    @dataset = Dataset.get_by_uuid(uuid: params[:dataset_uuid])
-    @datafile = @dataset.datafiles.find { |f| f.uuid == params[:datafile_uuid] }
+    @dataset = Dataset.get_by_short_id(short_id: params[:dataset_short_id])
+    @datafile = @dataset.datafiles.find { |f| f.short_id == params[:datafile_short_id] }
   end
 end

--- a/app/models/datafile.rb
+++ b/app/models/datafile.rb
@@ -1,7 +1,7 @@
 class Datafile
   attr_reader :name, :url, :start_date, :end_date,
               :created_at, :updated_at, :format, :size,
-              :uuid
+              :short_id
 
   def initialize(attrs)
     @name = attrs["name"]
@@ -12,7 +12,7 @@ class Datafile
     @updated_at = attrs["updated_at"]
     @format =  attrs["format"]
     @size =  attrs["size"]
-    @uuid = attrs["uuid"]
+    @short_id = attrs["short_id"]
   end
 
   def start_year

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -8,7 +8,7 @@ class Dataset
                 :contact_name, :contact_email, :contact_phone,
                 :licence, :licence_other, :frequency,
                 :published_date, :last_updated_at, :created_at,
-                :harvested, :uuid,
+                :harvested, :uuid, :short_id,
                 :inspire_dataset, :json, :notes,
                 :_index, :_type, :_id, :_score, :_source,
                 :_version
@@ -17,8 +17,8 @@ class Dataset
 
   index_name ENV['ES_INDEX'] || "datasets-#{Rails.env}"
 
-  def self.get_by_uuid(uuid:)
-    query = Search::Query.by_uuid(uuid)
+  def self.get_by_short_id(short_id:)
+    query = Search::Query.by_short_id(short_id)
     result = Dataset.search(query).results.first
     attrs = result._source.to_hash.merge(_id: result._id)
     raise 'Metadata missing' if attrs["title"].blank?

--- a/app/services/search/query.rb
+++ b/app/services/search/query.rb
@@ -133,12 +133,12 @@ module Search
       }
     end
 
-    def self.by_uuid(uuid)
+    def self.by_short_id(short_id)
       {
         query: {
           constant_score: {
             filter: {
-              term: { uuid: uuid }
+              term: { short_id: short_id }
             }
           }
         }

--- a/app/views/datasets/_datafile_table.html.erb
+++ b/app/views/datasets/_datafile_table.html.erb
@@ -35,7 +35,7 @@
           <% if datafile.html? %>
             <%= link_to t('.go_to_site'), datafile.url %>
           <% elsif datafile.csv? %>
-            <%= link_to t('.preview'), datafile_preview_path(@dataset.uuid, @dataset.name, datafile.uuid) %>
+            <%= link_to t('.preview'), datafile_preview_path(@dataset.short_id, @dataset.name, datafile.short_id) %>
           <% else %>
             <span class="dgu-secondary-text"><%= t('.not_available') %></span>
           <% end %>

--- a/app/views/datasets/_meta_data.html.erb
+++ b/app/views/datasets/_meta_data.html.erb
@@ -76,7 +76,7 @@
           <ul>
             <% @related_datasets.each do |dataset| %>
               <li>
-                <%= link_to unescape(dataset.title), dataset_path(dataset.uuid, dataset.name) %>
+                <%= link_to unescape(dataset.title), dataset_path(dataset.short_id, dataset.name) %>
               </li>
             <% end %>
           </ul>

--- a/app/views/previews/show.html.erb
+++ b/app/views/previews/show.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 <div class="grid-row">
   <div class="column-two-thirds">
-    <%= link_to t('.back_link'), dataset_path(@dataset.uuid, @dataset.name), class: 'link-back' %>
+    <%= link_to t('.back_link'), dataset_path(@dataset.short_id, @dataset.name), class: 'link-back' %>
     <h1 class="heading-large">
       <%= @dataset.title %>
       <span class="heading-secondary dgu-home-spacer__bottom"><%= @datafile.name %></span>

--- a/app/views/search/search.html.erb
+++ b/app/views/search/search.html.erb
@@ -62,7 +62,7 @@
             <% @datasets.each do |d| %>
               <div class="dgu-results__result">
                 <h2 class="heading-medium">
-                  <%= link_to d.title, dataset_path(d.uuid, d.name) %>
+                  <%= link_to d.title, dataset_path(d.short_id, d.name) %>
                 </h2>
                 <dl class="dgu-metadata__box">
                   <% if d.datafiles.none? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,8 +20,8 @@ Rails.application.routes.draw do
   match "500", to: "errors#internal_server_error", via: :all
 
   get 'search/', to: 'search#search'
-  
-  get 'dataset/:uuid/:name', to: 'datasets#show', as: 'dataset'
+
+  get 'search/tips', to: 'search#tips'
 
   get 'use-of-data', to: 'consents#new', as: 'new_consent'
   get 'use-of-data/confirm', to: 'consents#confirm'
@@ -31,5 +31,6 @@ Rails.application.routes.draw do
   resources :tickets, only: [:new, :create]
   get 'tickets/confirmation', to: 'tickets#confirmation'
 
-  get 'dataset/:dataset_uuid/:name/datafile/:datafile_uuid/preview', to: 'previews#show', as: 'datafile_preview'
+  get 'dataset/:short_id/:name', to: 'datasets#show', as: 'dataset'
+  get 'dataset/:dataset_short_id/:name/datafile/:datafile_short_id/preview', to: 'previews#show', as: 'datafile_preview'
 end

--- a/spec/controllers/datasets_controller_spec.rb
+++ b/spec/controllers/datasets_controller_spec.rb
@@ -15,7 +15,7 @@ describe DatasetsController, type: :controller do
         request.env['HTTP_REFERER'] = 'http://test.host/search?q=fancypants'
 
         index([dataset])
-        get :show, params: { uuid: dataset[:uuid], name: dataset[:name] }
+        get :show, params: { short_id: dataset[:short_id], name: dataset[:name] }
 
         expect(response.body).to have_css('div.datagov_breadcrumb')
         expect(response.body).to_not have_css('li', text: 'Ministry of Defence')
@@ -28,7 +28,7 @@ describe DatasetsController, type: :controller do
         request.env['HTTP_REFERER'] = 'http://unknown.host/search?q=fancypants'
 
         index([dataset])
-        get :show, params: { uuid: dataset[:uuid], name: dataset[:name] }
+        get :show, params: { short_id: dataset[:short_id], name: dataset[:name] }
 
         expect(response.body).to have_css('div.datagov_breadcrumb')
         expect(response.body).to have_css('li', text: 'Ministry of Defence')
@@ -40,8 +40,8 @@ describe DatasetsController, type: :controller do
   describe 'visiting the dataset page with an outdated slug' do
     it "redirects to the latest slugged URL" do
       index([dataset])
-      get :show, params: { uuid: dataset[:uuid], name: "outdated-slug" }
-      expect(response).to redirect_to(dataset_url(dataset[:uuid], dataset[:name]))
+      get :show, params: { short_id: dataset[:short_id], name: "outdated-slug" }
+      expect(response).to redirect_to(dataset_url(dataset[:short_id], dataset[:name]))
     end
   end
 end

--- a/spec/controllers/previews_controller_spec.rb
+++ b/spec/controllers/previews_controller_spec.rb
@@ -18,7 +18,7 @@ describe PreviewsController, type: :controller do
         to_return(body: "a,Paris,c,d\ne,f,Berlin,h\ni,j,k,l")
 
       index([dataset])
-      get :show, params: { dataset_uuid: dataset[:uuid], name: dataset[:name], datafile_uuid: datafile.uuid }
+      get :show, params: { dataset_short_id: dataset[:short_id], name: dataset[:name], datafile_short_id: datafile.short_id }
       expect(response.body).to have_content('Berlin')
     end
 
@@ -27,7 +27,7 @@ describe PreviewsController, type: :controller do
         to_timeout
 
       index([dataset])
-      get :show, params: { dataset_uuid: dataset[:uuid], name: dataset[:name], datafile_uuid: datafile.uuid }
+      get :show, params: { dataset_short_id: dataset[:short_id], name: dataset[:name], datafile_short_id: datafile.short_id }
 
       expect(response.body).to have_content('No preview is available')
     end
@@ -37,7 +37,7 @@ describe PreviewsController, type: :controller do
         to_return(status: [500, "Internal Server Error"])
 
       index([dataset])
-      get :show, params: { dataset_uuid: dataset[:uuid], name: dataset[:name], datafile_uuid: datafile.uuid }
+      get :show, params: { dataset_short_id: dataset[:short_id], name: dataset[:name], datafile_short_id: datafile.short_id }
 
       expect(response.body).to have_content('No preview is available')
     end
@@ -47,7 +47,7 @@ describe PreviewsController, type: :controller do
         to_return(body: "<!DOCTYPE html><html lang=\"en\"><h")
 
       index([dataset])
-      get :show, params: { dataset_uuid: dataset[:uuid], name: dataset[:name], datafile_uuid: datafile.uuid }
+      get :show, params: { dataset_short_id: dataset[:short_id], name: dataset[:name], datafile_short_id: datafile.short_id }
 
       expect(response.body).to have_content('No preview is available')
     end
@@ -57,7 +57,7 @@ describe PreviewsController, type: :controller do
         to_return(body: "a,b,\",c,d\n000000\n")
 
       index([dataset])
-      get :show, params: { dataset_uuid: dataset[:uuid], name: dataset[:name], datafile_uuid: datafile.uuid }
+      get :show, params: { dataset_short_id: dataset[:short_id], name: dataset[:name], datafile_short_id: datafile.short_id }
 
       expect(response.body).to have_content('No preview is available')
     end

--- a/spec/features/dataset_show_page_spec.rb
+++ b/spec/features/dataset_show_page_spec.rb
@@ -72,7 +72,7 @@ feature 'Dataset page', elasticsearch: true do
         index([@first_dataset, second_dataset])
         refresh_index
 
-        visit dataset_path(@first_dataset[:uuid], @first_dataset[:name])
+        visit dataset_path(@first_dataset[:short_id], @first_dataset[:name])
       end
 
       scenario 'displays related datasets if there is a match' do

--- a/spec/features/dataset_show_page_spec.rb
+++ b/spec/features/dataset_show_page_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 feature 'Dataset page', elasticsearch: true do
   scenario 'Displays 404 page if a dataset does not exist' do
-    visit '/dataset/invalid-uuid/invalid-slug'
+    visit '/dataset/invalid-short_id/invalid-slug'
 
     expect(page.status_code).to eq(404)
     expect(page).to have_content('Page not found')
@@ -124,7 +124,7 @@ feature 'Dataset page', elasticsearch: true do
 
       refresh_index
 
-      visit dataset_path(first_dataset[:uuid], first_dataset[:name])
+      visit dataset_path(first_dataset[:short_id], first_dataset[:name])
 
       expect(page).to have_content('Related datasets')
       expect(page).to have_content(title_2)

--- a/spec/requests/legacy/redirect_spec.rb
+++ b/spec/requests/legacy/redirect_spec.rb
@@ -33,7 +33,7 @@ describe 'legacy', :type => :request do
 
       get "/dataset/#{legacy_name}"
 
-      expect(response).to redirect_to(dataset_url(dataset[:uuid], dataset[:name]))
+      expect(response).to redirect_to(dataset_url(dataset[:short_id], dataset[:name]))
       expect(response.status).to eql 301
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -94,6 +94,10 @@ def index_mappings
           type: "string",
           index: "not_analyzed"
         },
+        short_id: {
+          type: 'string',
+          index: 'not_analyzed'
+        },
         location1: {
           type: 'string',
           fields: {

--- a/spec/support/dataset_spec_builder.rb
+++ b/spec/support/dataset_spec_builder.rb
@@ -15,7 +15,7 @@ class DatasetBuilder
         harvested: false,
         created_at: '2013-08-31T00:56:15.435Z',
         last_updated_at: '2017-07-24T14:47:25.975Z',
-        uuid: SecureRandom.uuid,
+        short_id: SecureRandom.urlsafe_base64(6, true),
         organisation: {
             id: 582,
             name: 'ministry-of-defence',
@@ -129,7 +129,7 @@ DATA_FILES_WITH_START_AND_ENDDATE = [
      'end_date' => '24/03/2018',
      'created_at' => '2016-07-31T14:40:57.528Z',
      'updated_at' => '2016-08-31T14:40:57.528Z',
-     'uuid' => '5e359634-f15b-4639-97e6-a4e28ba15276'
+     'short_id' => SecureRandom.urlsafe_base64(6, true)
     },
     {'id' => 3,
      'name' => 'I have an end date',

--- a/spec/support/dataset_spec_helper.rb
+++ b/spec/support/dataset_spec_helper.rb
@@ -13,7 +13,7 @@ end
 
 def index_and_visit(dataset)
   index([dataset])
-  visit dataset_path(dataset[:uuid], dataset[:name])
+  visit dataset_path(dataset[:short_id], dataset[:name])
 end
 
 def search_for(query)


### PR DESCRIPTION
Path to datasets and previews now uses a short_id rather than a uuid.

Corresponding PR for Publish Beta -https://github.com/alphagov/datagovuk_publish/pull/508

https://trello.com/c/kt5eSCvX/46-shorten-dataset-urls