### PR TITLE
Upgrade deprecated Elasticsearch string types

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -83,27 +83,27 @@ def index_mappings
     dataset: {
       properties: {
         name: {
-          type: "string",
-          index: "not_analyzed"
+          type: "keyword",
+          index: true,
         },
         legacy_name: {
-          type: 'string',
-          index: 'not_analyzed'
+          type: "keyword",
+          index: true,
         },
         uuid: {
-          type: "string",
-          index: "not_analyzed"
+          type: "keyword",
+          index: true,
         },
         short_id: {
-          type: 'string',
-          index: 'not_analyzed'
+          type: "keyword",
+          index: true,
         },
         location1: {
-          type: 'string',
+          type: 'text',
           fields: {
             raw: {
-              type: 'string',
-              index: 'not_analyzed'
+              type: "keyword",
+              index: true,
             }
           }
         },
@@ -111,11 +111,11 @@ def index_mappings
           type: 'nested',
           properties: {
             title: {
-              type: 'string',
+              type: 'text',
               fields: {
                 raw: {
-                  type: 'string',
-                  index: 'not_analyzed'
+                  type: "keyword",
+                  index: true,
                 }
               }
             }
@@ -125,11 +125,11 @@ def index_mappings
           type: "nested",
           properties: {
             title: {
-              type: "string",
+              type: "text",
               fields: {
                 raw: {
-                  type: "string",
-                  index: "not_analyzed"
+                  type: "keyword",
+                  index: true,
                 }
               }
             }


### PR DESCRIPTION
String types are no longer supported in Elasticsearch 6.0. The string field has split into two new types: text, which should be used for full-text search, and keyword, which should be used for keyword search.

The previous mappings are currently working because Elasticsearch 5.0 has backward compatibility that is removed with Elasticsearch 6.0.

See https://www.elastic.co/blog/strings-are-dead-long-live-strings