### PR TITLE
Use Rails' custom configuration support to configure Elasticsearch

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -35,6 +35,8 @@ module FindDataBeta
     config.filter_parameters << :password
     config.filter_parameters << :password_confirmation
 
+    config.elasticsearch = config_for(:elasticsearch)
+
     Raven.configure do |config|
       if ENV['SENTRY_DSN']
         config.dsn = ENV['SENTRY_DSN']

--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -1,16 +1,5 @@
 require 'base64'
 
-CONFIG_PATH = Rails.root.join('config', 'elasticsearch.yml')
-TEMPLATE = ERB.new File.new(CONFIG_PATH).read
-
-begin
-  ELASTIC_CONFIG = YAML.load(TEMPLATE.result(binding))[ENV['RAILS_ENV']]
-rescue => e
-  Rails.logger.fatal 'Failed to parse elasticsearch yaml configuration. Exiting'
-  Rails.logger.fatal e
-  exit
-end
-
 def create_es_cert_file(cert)
   begin
     es_cert_file = File.new('elasticsearch_cert.pem', 'w')
@@ -26,12 +15,12 @@ end
 
 def es_config_from_vcap
   begin
-    vcap = JSON.parse(ELASTIC_CONFIG['vcap_services'])
+    vcap = JSON.parse(Rails.configuration.elasticsearch['vcap_services'])
     es_server = vcap['elasticsearch'][0]['credentials']['uri'].chomp('/')
     es_cert = Base64.decode64(vcap['elasticsearch'][0]['credentials']['ca_certificate_base64'])
   rescue => e
     Rails.logger.fatal 'Failed to extract ES creds from VCAP_SERVICES. Exiting'
-    Rails.logger.fatal ELASTIC_CONFIG['vcap_services']
+    Rails.logger.fatal Rails.configuration.elasticsearch['vcap_services']
     Rails.logger.fatal e
     exit
   end
@@ -41,7 +30,7 @@ def es_config_from_vcap
     host: es_server,
     transport_options: {
       request: {
-        timeout: ELASTIC_CONFIG['elastic_timeout']
+        timeout: Rails.configuration.elasticsearch['elastic_timeout']
       },
       ssl: {
         ca_file: es_cert_file.path
@@ -52,18 +41,18 @@ end
 
 def es_config_from_host
   {
-    host: ELASTIC_CONFIG['host'],
+    host: Rails.configuration.elasticsearch['host'],
     transport_options: {
       request: {
-        timeout: ELASTIC_CONFIG['elastic_timeout']
+        timeout: Rails.configuration.elasticsearch['elastic_timeout']
       }
     }
   }
 end
 
-if ELASTIC_CONFIG['host']
+if Rails.configuration.elasticsearch['host']
   config = es_config_from_host
-elsif ELASTIC_CONFIG['vcap_services']
+elsif Rails.configuration.elasticsearch['vcap_services']
   config = es_config_from_vcap
 else
   Rails.logger.fatal "No elasticsearch environment variables found"


### PR DESCRIPTION
Rails has built-in support for custom configuration. This takes care of parsing configuration files, and selecting the correct configuration values for the current environment.

This changes the way we configure Elasticsearch to use this strategy instead of rolling our own implementation.

I unearthed this because I couldn't run the application without a `RAILS_ENV` variable set which was required in line 7 of `config/initializers/elasticsearch.rb`.