### PR TITLE
Redirect legacy dataset resource pages

### DIFF
--- a/app/controllers/legacy/datafiles_controller.rb
+++ b/app/controllers/legacy/datafiles_controller.rb
@@ -1,0 +1,20 @@
+class Legacy::DatafilesController < ApplicationController
+  def redirect
+    dataset = Dataset.get_by_legacy_name(legacy_name: params[:legacy_dataset_name])
+    datafile = dataset.datafiles.find { |f| f.uuid == params[:datafile_uuid] }
+
+    redirect_path = datafile_preview_path(dataset.short_id, dataset.name, datafile.short_id)
+
+    redirect_to redirect_path, status: :moved_permanently
+  rescue => e
+    handle_error(e)
+  end
+
+  private
+
+  def handle_error(e)
+    Rails.logger.debug 'ERROR! => ' + e.message
+    e.backtrace.each { |line| logger.error line }
+    render template: 'errors/not_found', status: 404
+  end
+end

--- a/app/models/datafile.rb
+++ b/app/models/datafile.rb
@@ -1,7 +1,7 @@
 class Datafile
   attr_reader :name, :url, :start_date, :end_date,
               :created_at, :updated_at, :format, :size,
-              :short_id
+              :short_id, :uuid
 
   def initialize(attrs)
     @name = attrs["name"]
@@ -13,6 +13,7 @@ class Datafile
     @format =  attrs["format"]
     @size =  attrs["size"]
     @short_id = attrs["short_id"]
+    @uuid = attrs["uuid"]
   end
 
   def start_year

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
 
   scope module: 'legacy' do
     get 'dataset/:legacy_name', to: 'datasets#redirect'
+    get 'dataset/:legacy_dataset_name/resource/:datafile_uuid', to: 'datafiles#redirect'
     get 'data/search',          to: 'search#redirect'
     get 'contact',              to: redirect('support')
   end

--- a/spec/requests/legacy/redirect_spec.rb
+++ b/spec/requests/legacy/redirect_spec.rb
@@ -38,6 +38,41 @@ describe 'legacy', :type => :request do
     end
   end
 
+  describe 'datafile resources' do
+    let(:legacy_dataset_name) { 'a-legacy-name' }
+    let(:datafile) { CSV_DATAFILE.with_indifferent_access }
+    let(:dataset) do
+      DatasetBuilder
+        .new
+        .with_legacy_name(legacy_dataset_name)
+        .with_datafiles([datafile])
+        .build
+    end
+
+    context 'when the datafile can not be found' do
+      it 'returns a not found error page' do
+        get "/dataset/#{legacy_dataset_name}/resource/#{datafile[:uuid]}"
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context 'when the datafile exists' do
+      before { index([dataset]) }
+
+      it 'redirects to the datefile preview page' do
+        get "/dataset/#{legacy_dataset_name}/resource/#{datafile[:uuid]}"
+
+        location = datafile_preview_path(
+          dataset[:short_id], dataset[:name], datafile[:short_id]
+        )
+
+        expect(response).to redirect_to(location)
+        expect(response).to have_http_status(:moved_permanently)
+      end
+    end
+  end
+
   describe 'contact page' do
     it 'redirects to the support page' do
       get '/contact'

--- a/spec/support/dataset_spec_builder.rb
+++ b/spec/support/dataset_spec_builder.rb
@@ -129,7 +129,8 @@ DATA_FILES_WITH_START_AND_ENDDATE = [
      'start_date' => '1/1/15',
      'end_date' => nil,
      'created_at' => '2016-07-31T14:40:57.528Z',
-     'updated_at' => '2016-08-31T14:40:57.528Z'
+     'updated_at' => '2016-08-31T14:40:57.528Z',
+     'uuid' => SecureRandom.uuid
     },
     {'id' => 2,
      'name' => 'I have an end date',
@@ -139,7 +140,8 @@ DATA_FILES_WITH_START_AND_ENDDATE = [
      'end_date' => '24/03/2018',
      'created_at' => '2016-07-31T14:40:57.528Z',
      'updated_at' => '2016-08-31T14:40:57.528Z',
-     'short_id' => SecureRandom.urlsafe_base64(6, true)
+     'short_id' => SecureRandom.urlsafe_base64(6, true),
+     'uuid' => SecureRandom.uuid
     },
     {'id' => 3,
      'name' => 'I have an end date',
@@ -148,7 +150,8 @@ DATA_FILES_WITH_START_AND_ENDDATE = [
      'start_date' => '1/1/15',
      'end_date' => '01/12/2018',
      'created_at' => '2016-07-31T14:40:57.528Z',
-     'updated_at' => '2016-08-31T14:40:57.528Z'
+     'updated_at' => '2016-08-31T14:40:57.528Z',
+     'uuid' => SecureRandom.uuid
     }
 ]
 
@@ -158,14 +161,16 @@ DATAFILES_WITHOUT_START_AND_ENDDATE = [
      'url' => 'http://example.com',
      'start_date' => nil,
      'end_date' => nil,
-     'updated_at' => '2016-08-31T14:40:57.528Z'
+     'updated_at' => '2016-08-31T14:40:57.528Z',
+     'uuid' => SecureRandom.uuid
     },
     {'id' => 2,
      'name' => 'I have an end date',
      'url' => 'http://example.com',
      'start_date' => nil,
      'end_date' => nil,
-     'updated_at' => '2016-08-31T14:40:57.528Z'
+     'updated_at' => '2016-08-31T14:40:57.528Z',
+     'uuid' => SecureRandom.uuid
     }]
 
 UNFORMATTED_DATASETS_MULTIYEAR = [


### PR DESCRIPTION
Adds a permanent redirect for dataset resource pages to the preview page. For example https://data.gov.uk/dataset/historic-flood-map1/resource/4f661185-1788-4d61-85e3-d843c6fc914a