### PR TITLE
Redirect cookies url

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
     get 'dataset/:legacy_dataset_name/resource/:datafile_uuid', to: 'datafiles#redirect'
     get 'data/search',          to: 'search#redirect'
     get 'contact',              to: redirect('support')
+    get 'cookies-policy',       to: redirect('cookies')
   end
 
   scope module: 'pages' do

--- a/spec/requests/legacy/redirect_spec.rb
+++ b/spec/requests/legacy/redirect_spec.rb
@@ -81,4 +81,13 @@ describe 'legacy', :type => :request do
       expect(response).to have_http_status(:moved_permanently)
     end
   end
+
+  describe 'cookies page' do
+    it 'redirects to the cookies page' do
+      get '/cookies-policy'
+
+      expect(response).to redirect_to(cookies_url)
+      expect(response).to have_http_status(:moved_permanently)
+    end
+  end
 end


### PR DESCRIPTION
Current page is at /cookies-policy, new page is at /cookies
https://trello.com/c/d28qWGAM/122-simple-301-redirects