### PR TITLE
Bug fix: only display topic if available

### DIFF
--- a/app/views/datasets/_meta_data.html.erb
+++ b/app/views/datasets/_meta_data.html.erb
@@ -36,8 +36,10 @@
             <span itemprop="name"><%= dataset_location(@dataset) %></span>
           </dd>
 
-          <dt><%= t('.topic') %>:</dt>
-          <dd><%= @dataset.topic['title'] %>
+          <% if @dataset.topic %>
+            <dt><%= t('.topic') %>:</dt>
+            <dd><%= @dataset.topic['title'] %>
+          <% end %>
 
           <dt><%= t('.licence') %>:</dt>
           <% if @dataset.licence == 'uk-ogl' %>


### PR DESCRIPTION
Find is blowing up if dataset.topic is nil. Seems a bit heavy handed to not show an intact dataset page just because it's missing one field for the purposes of debugging. 



