### PR TITLE
Datasets with no topics will display 'not added'

### DIFF
--- a/app/views/datasets/_meta_data.html.erb
+++ b/app/views/datasets/_meta_data.html.erb
@@ -36,9 +36,11 @@
             <span itemprop="name"><%= dataset_location(@dataset) %></span>
           </dd>
 
+          <dt><%= t('.topic') %>:</dt>
           <% if @dataset.topic %>
-            <dt><%= t('.topic') %>:</dt>
-            <dd><%= @dataset.topic['title'] %>
+            <dd><%= @dataset.topic['title'] %></dd>
+          <% else %>
+            <dd><%= t('.topic_not_added') %></dd>
           <% end %>
 
           <dt><%= t('.licence') %>:</dt>

--- a/config/locales/views/datasets/en.yml
+++ b/config/locales/views/datasets/en.yml
@@ -45,6 +45,8 @@ en:
       published_by: "Published by"
       last_updated: "Last updated"
       geographical_area: "Geographical area"
+      topic: "Topic"
+      topic_not_added: "Not added"
       summary: "Summary"
       related_datasets: "Related datasets"
       search_gov_data: "Search government data"

--- a/spec/features/dataset_show_page_spec.rb
+++ b/spec/features/dataset_show_page_spec.rb
@@ -19,8 +19,17 @@ feature 'Dataset page', elasticsearch: true do
       expect(page).to have_content('Geographical area: London Southwark')
     end
 
-    scenario 'Display the topic' do
+    scenario 'Display the topic if there is one' do
       expect(page).to have_content('Topic: Government')
+    end
+
+    scenario 'Do not display the topic if information missing' do
+      dataset = DatasetBuilder.new.build
+      dataset['topic'] = nil
+      
+      index_and_visit(dataset)
+
+      expect(page).to have_content('Topic: Not added')
     end
   end
 


### PR DESCRIPTION
Some datasets do not have a topic assigned. If so then show 'Topic: Not added' in the dataset meta data panel

Trello - https://trello.com/c/Ot65Qefh/80-implement-topics-themes-l