### PR TITLE
Simplify indexing of test datasets

### DIFF
--- a/spec/features/dataset_show_page_spec.rb
+++ b/spec/features/dataset_show_page_spec.rb
@@ -79,7 +79,7 @@ feature 'Dataset page', elasticsearch: true do
           .with_datafiles(DATA_FILES_WITH_START_AND_ENDDATE)
           .build
 
-        index([@first_dataset, second_dataset])
+        index(@first_dataset, second_dataset)
         refresh_index
 
         visit dataset_path(@first_dataset[:short_id], @first_dataset[:name])
@@ -130,7 +130,7 @@ feature 'Dataset page', elasticsearch: true do
         .with_publisher('Unrelated publisher')
         .build
 
-      index([first_dataset, second_dataset, third_dataset])
+      index(first_dataset, second_dataset, third_dataset)
 
       refresh_index
 

--- a/spec/features/search_page_spec.rb
+++ b/spec/features/search_page_spec.rb
@@ -20,7 +20,7 @@ feature 'Search page', elasticsearch: true do
                 .with_title(dataset_title)
                 .build
 
-    index([dataset])
+    index(dataset)
     search_for(query)
 
     expect(page).to have_css('h1', text: 'Search results')
@@ -40,7 +40,7 @@ feature 'Search page', elasticsearch: true do
                     .last_updated_at('2017-07-24T14:47:25.975Z')
                     .build
 
-    index([old_dataset, new_dataset])
+    index(old_dataset, new_dataset)
 
     search_for('Old Interesting Dataset')
 
@@ -83,7 +83,7 @@ feature 'Search page', elasticsearch: true do
                       .with_publisher('Toby Corp')
                       .build
 
-    index([first_dataset, second_dataset])
+    index(first_dataset, second_dataset)
 
     visit('/search')
 
@@ -111,7 +111,7 @@ feature 'Search page', elasticsearch: true do
                       .with_licence('foo')
                       .build
 
-    index([first_dataset, second_dataset])
+    index(first_dataset, second_dataset)
 
     visit('/search')
 
@@ -139,7 +139,7 @@ feature 'Search page', elasticsearch: true do
                       .with_topic({id: 2, name: "business-and-economy", title: "Business and economy"})
                       .build
 
-    index([first_dataset, second_dataset])
+    index(first_dataset, second_dataset)
 
     visit('/search')
 
@@ -166,7 +166,7 @@ feature 'Search page', elasticsearch: true do
                       .with_datafiles([{'format' => 'bar'}])
                       .build
 
-    index([first_dataset, second_dataset])
+    index(first_dataset, second_dataset)
 
     visit('/search')
 

--- a/spec/helpers/search_helper_spec.rb
+++ b/spec/helpers/search_helper_spec.rb
@@ -19,7 +19,7 @@ describe SearchHelper do
       ])
       .build
 
-      index([first_dataset, second_dataset])
+      index(first_dataset, second_dataset)
 
       expect(datafile_formats_for_select).to eql ['', 'BAR', 'BAZ', 'FOO']
     end
@@ -39,7 +39,7 @@ describe SearchHelper do
       ])
       .build
 
-      index([first_dataset, second_dataset])
+      index(first_dataset, second_dataset)
 
       expect(datafile_formats_for_select).to eql ['', 'BAR', 'BAZ', 'FOO']
     end

--- a/spec/support/dataset_spec_helper.rb
+++ b/spec/support/dataset_spec_helper.rb
@@ -1,6 +1,6 @@
 INDEX = "datasets-test"
 
-def index(datasets)
+def index(*datasets)
   datasets.each do |dataset, i|
     ELASTIC.index index: INDEX, type: 'dataset', id: i, body: dataset
   end
@@ -12,7 +12,7 @@ def refresh_index
 end
 
 def index_and_visit(dataset)
-  index([dataset])
+  index(dataset)
   visit dataset_path(dataset[:short_id], dataset[:name])
 end
 


### PR DESCRIPTION
Simplify syntax of index helper by allowing it to take a collection of datasets to index.

See https://ruby-doc.org/core-2.5.0/doc/syntax/calling_methods_rdoc.html#label-Array+to+Arguments+Conversion