### PR TITLE
Phrase based searches

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'sentry-raven'
 gem 'lograge', '~> 0.7'
 gem 'logstash-event', '~> 1.2'
 gem 'zendesk_api'
+gem 'parslet'
 
 group :development, :test do
   gem 'byebug', '~> 9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -243,6 +243,7 @@ GEM
     notiffany (0.1.1)
       nenv (~> 0.1)
       shellany (~> 0.0)
+    parslet (1.8.2)
     pg (0.21.0)
     polyamorous (1.3.1)
       activerecord (>= 3.0)
@@ -432,6 +433,7 @@ DEPENDENCIES
   lograge (~> 0.7)
   logstash-event (~> 1.2)
   mime-types (~> 3.1)
+  parslet
   pg (~> 0.18)
   pry (~> 0.10)
   pry-byebug (~> 3.4)
@@ -454,4 +456,4 @@ DEPENDENCIES
   zendesk_api
 
 BUNDLED WITH
-   1.16.0
+   1.16.1

--- a/app/services/search.rb
+++ b/app/services/search.rb
@@ -1,0 +1,6 @@
+module Search
+  Error = Class.new(StandardError)
+
+  PhraseClause = Struct.new(:phrase)
+  TermsClause = Struct.new(:terms)
+end

--- a/app/services/search/query.rb
+++ b/app/services/search/query.rb
@@ -2,6 +2,8 @@ module Search
   class Query
     TERMS_SIZE = 10_000
 
+    def initialize(_clauses) ; end
+
     def self.publishers_aggregation
       {
         size: 0,

--- a/app/services/search/query_parser.rb
+++ b/app/services/search/query_parser.rb
@@ -1,0 +1,21 @@
+module Search
+  class QueryParser < Parslet::Parser
+    rule(:whitespace) { match['\s'].repeat(1) }
+    rule(:whitespace?) { whitespace.maybe }
+
+    rule(:quote) { str('"') >> whitespace? }
+    rule(:quote?) { quote.maybe }
+
+    rule(:term) { match['[^\s"]'].repeat(1).as(:term) >> whitespace? }
+    rule(:term?) { term.maybe }
+    rule(:terms) { term.repeat(1) }
+
+    rule(:phrase) { quote >> terms.as(:phrase) >> quote }
+
+    rule(:clause) { (phrase | terms.as(:terms) >> whitespace?).as(:clause) >> whitespace? }
+
+    rule(:query) { clause.repeat.as(:query) }
+
+    root :query
+  end
+end

--- a/app/services/search/query_transformer.rb
+++ b/app/services/search/query_transformer.rb
@@ -1,0 +1,15 @@
+require 'parslet/transform'
+
+class Search::QueryTransformer < Parslet::Transform
+  rule(clause: subtree(:clause)) do
+    if clause[:terms]
+      Search::TermsClause.new(clause[:terms].map { |p| p[:term].to_s }.join(' '))
+    elsif clause[:phrase]
+      Search::PhraseClause.new(clause[:phrase].map { |p| p[:term].to_s }.join(' '))
+    else
+      raise Search::Error, "Unexpected clause type: '#{clause}'"
+    end
+  end
+
+  rule(query: sequence(:clauses)) { Search::Query.new(clauses) }
+end

--- a/spec/features/search_page_spec.rb
+++ b/spec/features/search_page_spec.rb
@@ -182,8 +182,33 @@ feature 'Search page', elasticsearch: true do
     expect(page).to have_content 'Datasets filtered by FOO'
   end
 
+  scenario 'Searching for a phrase' do
+    index(DatasetBuilder.new.with_title('A very interesting dataset').build,
+          DatasetBuilder.new.with_title('A fairly interesting dataset').build)
+
+    search_for('"Very interesting"')
+
+    assert_search_results_headings('A very interesting dataset')
+  end
+
+  scenario 'Searching for a malformed phrase' do
+    index(DatasetBuilder.new.with_title('A very interesting dataset').build,
+          DatasetBuilder.new.with_title('A fairly interesting dataset').build)
+
+    search_for('"Very interesting')
+
+    assert_search_results_headings(
+      'A very interesting dataset',
+      'A fairly interesting dataset'
+    )
+  end
+
   def assert_data_set_length_is(count)
     datasets = all('h2 a')
     expect(datasets.length).to be(count)
+  end
+
+  def assert_search_results_headings(*headings)
+    expect(all('h2 a').map(&:text)).to contain_exactly(*headings)
   end
 end

--- a/spec/services/search/phrase_clause_spec.rb
+++ b/spec/services/search/phrase_clause_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe Search::PhraseClause do
+  subject { described_class.new(phrase) }
+
+  let(:phrase) { double }
+
+  it { is_expected.to have_attributes(phrase: phrase) }
+end

--- a/spec/services/search/query_parser_spec.rb
+++ b/spec/services/search/query_parser_spec.rb
@@ -1,0 +1,87 @@
+require 'rails_helper'
+
+RSpec.describe Search::QueryParser do
+  subject(:query_parser) { described_class.new }
+
+  describe '.parse' do
+    subject { query_parser.parse(query) }
+
+    context 'with a simple query' do
+      let(:query) { 'quick brown fox' }
+
+      it 'returns a clause for the terms of the query' do
+        expected_query = a_collection_containing_exactly(
+          a_hash_including(
+            clause: a_hash_including(
+              terms: a_collection_containing_exactly(
+                a_hash_including(term: 'quick'),
+                a_hash_including(term: 'brown'),
+                a_hash_including(term: 'fox')
+              )
+            )
+          )
+        )
+
+        is_expected.to match(query: expected_query)
+      end
+    end
+
+    context 'with a quoted query' do
+      let(:query) { '"quick brown fox"' }
+
+      it 'returns a clause with a phrase made up of each term in the query' do
+        expected_query = a_collection_containing_exactly(
+          a_hash_including(
+            clause: a_hash_including(
+              phrase: a_collection_containing_exactly(
+                a_hash_including(term: 'quick'),
+                a_hash_including(term: 'brown'),
+                a_hash_including(term: 'fox')
+              )
+            )
+          )
+        )
+
+        is_expected.to match(query: expected_query)
+      end
+    end
+
+    context 'with a partially quoted query' do
+      let(:query) { 'quick "brown fox"' }
+
+      it 'returns a terms clause and a phrase clause' do
+        expected_query = a_collection_containing_exactly(
+          a_hash_including(
+            clause: a_hash_including(
+              terms: a_collection_containing_exactly(
+                a_hash_including(term: 'quick')
+              )
+            )
+          ),
+          a_hash_including(
+            clause: a_hash_including(
+              phrase: a_collection_containing_exactly(
+                a_hash_including(term: 'brown'),
+                a_hash_including(term: 'fox')
+              )
+            )
+          )
+        )
+
+        is_expected.to match(query: expected_query)
+      end
+    end
+
+    context 'with a missing closing quote' do
+      let(:query) { 'quick "brown fox' }
+
+      specify { expect { subject }.to raise_error(Parslet::ParseFailed) }
+    end
+
+    context 'with a missing opening quote' do
+      let(:query) { 'quick brown fox"' }
+
+      specify { expect { subject }.to raise_error(Parslet::ParseFailed) }
+    end
+  end
+end

--- a/spec/services/search/query_transformer_spec.rb
+++ b/spec/services/search/query_transformer_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe Search::QueryTransformer do
+  subject(:query_transformer) { described_class.new }
+
+  describe '.apply' do
+    subject { query_transformer.apply(parse_tree) }
+
+    let(:parse_tree) { Search::QueryParser.new.parse(query) }
+    let(:query) { 'quick brown fox' }
+
+    it 'builds a search query' do
+      is_expected.to be_a(Search::Query)
+    end
+
+    context 'with a simple query' do
+      let(:query) { 'quick brown fox' }
+
+      it 'transforms the query into a collection of term clauses' do
+        is_expected
+          .to have_attributes(
+                clauses: a_collection_containing_exactly(
+                  an_instance_of(Search::TermsClause)
+                    .and(have_attributes(terms: 'quick brown fox'))
+                )
+              )
+      end
+    end
+
+    context 'with a quoted query' do
+      let(:query) { '"quick brown fox"' }
+
+      it 'transforms the query into a phrase clauses' do
+        is_expected
+          .to have_attributes(
+                clauses: a_collection_containing_exactly(
+                  an_instance_of(Search::PhraseClause)
+                    .and(have_attributes(phrase: 'quick brown fox'))
+                )
+              )
+      end
+    end
+
+    context 'with a partially quoted query' do
+      let(:query) { 'quick "brown fox"' }
+
+      it 'transforms the query into term and phrase clauses' do
+        is_expected
+          .to have_attributes(
+                clauses: a_collection_containing_exactly(
+                  an_instance_of(Search::TermsClause)
+                    .and(have_attributes(terms: 'quick')),
+                  an_instance_of(Search::PhraseClause)
+                    .and(have_attributes(phrase: 'brown fox'))
+                )
+              )
+      end
+    end
+  end
+end

--- a/spec/services/search/terms_clause_spec.rb
+++ b/spec/services/search/terms_clause_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe Search::TermsClause do
+  subject { described_class.new(terms) }
+
+  let(:terms) { double }
+
+  it { is_expected.to have_attributes(terms: terms) }
+end


### PR DESCRIPTION
This adds support for phrase based searches. A phrase being any part of the search query that is wrapped in quotes.

To achieve this I have introduced the [Parslet] Ruby library. This allows us to use a formal grammar to define the makeup of search queries. The implemented parser defines rules for term and phrase based queries.

For example, a query of 'flood map for planning' would be parsed as a term based query. A query of '"flood map" for planning' would be parsed as a phrase of "flood map" and the terms "for planning".

An alternative approach would be use Elasticsearch's support for [simple query string] however doing so would add support for a wider search syntax that we don't currently have an identified user need for.

[parslet]: http://kschiess.github.io/parslet/
[simple query string]: https://www.elastic.co/guide/en/elasticsearch/reference/6.2/query-dsl-simple-query-string-query.html

See https://trello.com/c/AyV10xt7