### PR TITLE
Remove publisher filter link from search results and dataset page

### DIFF
--- a/app/views/datasets/_meta_data.html.erb
+++ b/app/views/datasets/_meta_data.html.erb
@@ -19,9 +19,7 @@
           <% end %>
           <dt><%= t('.published_by') %>:</dt>
           <dd itemprop="creator" itemscope itemtype="http://schema.org/Organization">
-            <%= link_to search_path(filters: { publisher: @dataset.organisation.title }), :itemprop => 'url' do %>
-              <span itemprop="name"><%= @dataset.organisation.title %></span>
-            <% end %>
+            <%= @dataset.organisation.title %>
           </dd>
 
           <dt><%= t('.last_updated') %>:</dt>

--- a/app/views/search/search.html.erb
+++ b/app/views/search/search.html.erb
@@ -72,7 +72,7 @@
                     </dd>
                   <% end %>
                   <dt><%= t('.meta_data_box.published_by') %>:</dt>
-                  <dd><%= link_to d.organisation['title'], search_path(filters: { publisher: d.organisation['title'] }) %></dd>
+                  <dd><%= d.organisation['title'] %></dd>
                   <dt><%= t('.meta_data_box.last_updated') %>:</dt>
                   <% if d.last_updated_at.present? %>
                     <dd><%= format(d.last_updated_at) %></dd>


### PR DESCRIPTION
The link to filtered search results from the "Published by" metadata item confuses users, because they expect to be taken to the publisher's page, rather than to search results filtered by publisher.

This PR removes the link anchors from the publisher organisation name, in the search results and on the dataset page.

https://trello.com/c/6ejtdzpl/165-remove-link-from-published-by-s