### PR TITLE
Add Spring config for RSpec

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+PATH_add bin

--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ group :development do
   gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.2'
   gem 'spring', '~> 2.0'
+  gem 'spring-commands-rspec'
   gem 'spring-watcher-listen', '~> 2.0.0'
   gem 'guard'
   gem 'guard-rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -351,6 +351,8 @@ GEM
     slop (3.6.0)
     spring (2.0.2)
       activesupport (>= 4.2)
+    spring-commands-rspec (1.0.4)
+      spring (>= 0.9.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
@@ -443,6 +445,7 @@ DEPENDENCIES
   sentry-raven
   simplecov (~> 0.13)
   spring (~> 2.0)
+  spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data
   uglifier (>= 1.3.0)

--- a/bin/rspec
+++ b/bin/rspec
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+begin
+  load File.expand_path('../spring', __FILE__)
+rescue LoadError => e
+  raise unless e.message.include?('spring')
+end
+require 'bundler/setup'
+load Gem.bin_path('rspec-core', 'rspec')


### PR DESCRIPTION
Adds [Spring] config for RSpec.

Also adds optional [direnv] configuration. This adds the bin folder to your path so that running 'rake', 'rspec' etc will use the preferred binstubs. This only applies if you have [direnv] installed and you give permission to allow it to use this configuration.

[direnv]: https://direnv.net
[spring]: https://github.com/rails/spring