### PR TITLE
Use English analyser when searching

### DIFF
--- a/app/services/search/query.rb
+++ b/app/services/search/query.rb
@@ -196,6 +196,7 @@ module Search
       {
         multi_match: {
           query: query,
+          analyzer: 'english',
           fields: %w(title summary description organisation^2 location*^2)
         }
       }


### PR DESCRIPTION
This switches the analyser used for search queries to one that undertands the English language.

Doing so means that “tree in birmingham”, “trees in birmingham”, “tree birmingham”, “trees birmingham” are all treated the same.

See https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-lang-analyzer.html#english-analyzer