### PR TITLE
Customise cookie message

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,6 +13,13 @@
   <%= root_path %>
 <% end %>
 
+<% content_for :cookie_message do %>
+  <p>
+    data.gov.uk uses cookies to make the site simpler.
+    <%= link_to 'Find out more about cookies', cookies_path %>
+  </p>
+<% end %>
+
 <% content_for :global_header_text do %>
   <%= t('.global_header_text') %> <strong class="phase-tag">BETA</strong>
 <% end %>


### PR DESCRIPTION
Changes the cookie message so that it references "data.gov.uk" not "GOV.UK" and links to the guidance about cookies on data.gov.uk and not gov.uk.

Before:

![screen shot 2018-02-20 at 16 25 04](https://user-images.githubusercontent.com/2715/36435972-f977544e-165a-11e8-9bbe-4903b0d9e6a4.png)

After:

![screen shot 2018-02-20 at 16 25 26](https://user-images.githubusercontent.com/2715/36435980-ff4410c4-165a-11e8-8449-2f89fdf9daef.png)
