### PR TITLE
Fixing towns and cities typo

### DIFF
--- a/app/views/home/_topics.html.erb
+++ b/app/views/home/_topics.html.erb
@@ -57,7 +57,7 @@
             <p><%= t('.society_description') %></p>
           </li>
           <li>
-            <h3><%= link_to t('.towns_and_cities_label'), search_path(filters: { topic: 'Towns an cities' }) %></h3>
+            <h3><%= link_to t('.towns_and_cities_label'), search_path(filters: { topic: 'Towns and cities' }) %></h3>
             <p><%= t('.towns_and_cities_description') %></p>
           </li>
           <li>


### PR DESCRIPTION
QUick typo fix to stop the link from the homepage not returning results https://trello.com/c/3CKhKtpq/236-towns-and-cities-typo-on-homepage-means-search-doesnt-work