### PR TITLE
bug fix - reinstate http auth for private beta users

### DIFF
--- a/app/controllers/logged_area_controller.rb
+++ b/app/controllers/logged_area_controller.rb
@@ -10,7 +10,7 @@ class LoggedAreaController < ApplicationController
   end
 
   def authenticate
-    return if Rails.env.test? || !ENV.has_key?('PRIVATE_BETA_USER_SALT')
+    return if Rails.env.test? || !ENV['PRIVATE_BETA_USER_SALT']
 
     authenticate_or_request_with_http_basic('Please sign in with username and password provided to you') do |username, password|
       if admin_login?(username, password)


### PR DESCRIPTION
The http auth box is displayed if the private_beta_user_salt env var is present. 

Confusingly, this env var is present in the user_provided key of VCAP SERVICES, which is exported to the ENV.  But the method ENV.has_key?('PRIVATE_BETA_USER_SALT') is returning false. 
