### PR TITLE
Add GDS footer link in search result pages

### DIFF
--- a/app/views/layouts/search.html.erb
+++ b/app/views/layouts/search.html.erb
@@ -38,6 +38,7 @@
     <li><%= link_to 'Privacy', privacy_path %></li>
     <li><%= link_to 'Terms and conditions', terms_path %></li>
     <li><%= link_to 'Support', support_path %></li>
+    <li>Built by the <%= link_to 'Government Digital Service', 'https://www.gov.uk/government/organisations/government-digital-service' %></li>
   </ul>
 <% end %>
 


### PR DESCRIPTION
https://trello.com/c/xHv07SqL/175-add-built-by-gds-to-footer