### PR TITLE
Remove all tabindexes

### DIFF
--- a/app/views/consents/new.html.erb
+++ b/app/views/consents/new.html.erb
@@ -1,4 +1,4 @@
-<main role="main" tabindex="-1" id="content">
+<main role="main" id="content">
   <div class="grid-row inner">
     <%= render partial: 'layouts/feedback_survey_banner' if flash[:beta_message] == 'hide'%>
 

--- a/app/views/datasets/show.html.erb
+++ b/app/views/datasets/show.html.erb
@@ -2,7 +2,7 @@
   <%= @dataset.title %> -
 <% end %>
 
-<main role="main" tabindex="-1" id="content">
+<main role="main" id="content">
   <%= render partial: 'layouts/feedback_survey_banner' if flash[:beta_message] == 'hide'%>
   <%= render "breadcrumb" %>
   <div itemscope itemtype="http://schema.org/Dataset">

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,5 +1,5 @@
 <div class="dgu-split-background">
-  <main role="main" tabindex="-1" id="content">
+  <main role="main" id="content">
     <%= render 'search' %>
     <%= render 'topics' %>
   </main>

--- a/app/views/layouts/search.html.erb
+++ b/app/views/layouts/search.html.erb
@@ -18,7 +18,7 @@
     <%= render 'layouts/staging_ribbon' if Rails.env.staging? %>
     <%= render 'layouts/beta_message' if flash[:beta_message] == 'show' %>
       <div class="dgu-beta__message--<%=flash[:beta_message] %>">
-        <main role="main" tabindex="-1" id="content">
+        <main role="main" id="content">
           <%= yield %>
         </main>
       </div>

--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -2,7 +2,7 @@
   About data.gov.uk -
 <% end %>
 
-<main role="main" tabindex="-1" id="content">
+<main role="main" id="content">
   <%= render partial: 'layouts/feedback_survey_banner' if flash[:beta_message] == 'hide'%>
 
   <h1 class="heading-large">

--- a/app/views/pages/accessibility.html.erb
+++ b/app/views/pages/accessibility.html.erb
@@ -2,7 +2,7 @@
   Accessibility -
 <% end %>
 
-<main role="main" tabindex="-1" id="content">
+<main role="main" id="content">
   <%= render partial: 'layouts/feedback_survey_banner' if flash[:beta_message] == 'hide'%>
 
   <h1 class="heading-large">

--- a/app/views/pages/cookies.html.erb
+++ b/app/views/pages/cookies.html.erb
@@ -2,7 +2,7 @@
   Cookies -
 <% end %>
 
-<main role="main" tabindex="-1" id="content">
+<main role="main" id="content">
   <%= render partial: 'layouts/feedback_survey_banner' if flash[:beta_message] == 'hide'%>
 
   <h1 class="heading-xlarge">

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -2,7 +2,7 @@
   Privacy -
 <% end %>
 
-<main role="main" tabindex="-1" id="content">
+<main role="main" id="content">
   <%= render partial: 'layouts/feedback_survey_banner' if flash[:beta_message] == 'hide'%>
 
   <h1 class="heading-large">

--- a/app/views/pages/support.html.erb
+++ b/app/views/pages/support.html.erb
@@ -2,7 +2,7 @@
   Support -
 <% end %>
 
-<main role="main" tabindex="-1" id="content">
+<main role="main" id="content">
   <%= render partial: 'layouts/feedback_survey_banner' if flash[:beta_message] == 'hide'%>
 
   <div class="grid-row inner">

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -2,7 +2,7 @@
   Terms and conditions -
 <% end %>
 
-<main role="main" tabindex="-1" id="content">
+<main role="main" id="content">
   <%= render partial: 'layouts/feedback_survey_banner' if flash[:beta_message] == 'hide'%>
 
   <h1 class="heading-large">

--- a/app/views/tickets/new.html.erb
+++ b/app/views/tickets/new.html.erb
@@ -2,7 +2,7 @@
   Send a data request -
 <% end %>
 
-<main role="main" tabindex="-1" id="content">
+<main role="main" id="content">
   <div class="grid-row inner">
     <div class="column-full">
 
@@ -14,7 +14,7 @@
         </ol>
       </div>
       <% if @ticket.errors.any? %>
-        <div class="error-summary" role="alert" aria-labelledby="error-summary-heading" tabindex="-1">
+        <div class="error-summary" role="alert" aria-labelledby="error-summary-heading">
           <h2 class="heading-medium error-summary-heading" id="error-summary-heading">
             There was a problem
           </h2>


### PR DESCRIPTION
no longer used on gov.uk, and created issues with
accessible-autocomplete

https://trello.com/c/SVPJPTbE/246-fix-dropdown-scrolling