### PR TITLE
replace blue green deploy with autopilot

### DIFF
--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -2,6 +2,5 @@
 
 rm manifest.yml || true
 ln -s production-manifest.yml manifest.yml
-cf bgd find-data-beta production-manifest.yml
-
+cf zero-downtime-push $CF_APP -f manifest.yml
 rm manifest.yml

--- a/scripts/deploy-staging.sh
+++ b/scripts/deploy-staging.sh
@@ -2,6 +2,5 @@
 
 rm manifest.yml || true
 ln -s staging-manifest.yml manifest.yml
-cf bgd find-data-beta-staging staging-manifest.yml
-
+cf zero-downtime-push $CF_APP -f manifest.yml
 rm manifest.yml

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -57,10 +57,11 @@ rm manifest.yml || true
 
 cf login -a $CF_API -u $CF_USER -p $CF_PASS -s $CF_SPACE
 cf add-plugin-repo CF-Community https://plugins.cloudfoundry.org
-cf install-plugin blue-green-deploy -r CF-Community -f
+cf install-plugin autopilot -r CF-Community -f
 
-# For some reason the blue-green deploy breaks if there's no manifest.yml present
+# autopilot requires a manifest.yml to be present
 ln -s $CF_ENV-manifest.yml manifest.yml
 
-cf bgd $CF_APP -f $CF_ENV-manifest.yml
+cf zero-downtime-push $CF_APP -f manifest.yml
+
 rm manifest.yml


### PR DESCRIPTION
There is an intermittent problem with our deployment to production. When we create a new release, travis picks up the tag (if it has a `v` at the start) and runs our custom `deploy.sh` script.  

The problems we've been seeing are:
1.  The url is deleted (running `cf apps` the app `find-data-beta` has no url). 
2. Sometimes the url is not deleted, but refreshing the page loads both the old and the new version randomly.

This is an [issue with the bgd plugin](https://github.com/bluemixgaragelondon/cf-blue-green-deploy/issues/58). There is a fix, but perhaps it's worth switching to [autopilot](https://github.com/contraband/autopilot) anyway.

Autopilot renames the current application `<APP_NAME>-venerable`, creates the new app, points to it, and deletes the venerable. 

The advantage of this over bgd is we don't end up with two versions (an old and a current) for each app, saving on space. But then if we need to roll back to an old release, we will have to redeploy a previous release. 


 

