### PR TITLE
Upgrade Cloud Foundry buildpack

### DIFF
--- a/production-manifest.yml
+++ b/production-manifest.yml
@@ -2,7 +2,7 @@
 applications:
 - name: find-data-beta
   memory: 256M
-  buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.6.47
+  buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.7.13
   routes:
   - route: find-data-beta.cloudapps.digital
   - route: beta.data.gov.uk

--- a/staging-manifest.yml
+++ b/staging-manifest.yml
@@ -2,7 +2,7 @@
 applications:
 - name: find-data-beta-staging
   memory: 256M
-  buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.6.47
+  buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.7.13
   env:
     RAILS_ENV: staging
     RACK_ENV: staging


### PR DESCRIPTION
> **date: 20 February 2018 at 14:11**
> **subject: [paas-announce] Upcoming buildpack upgrades**
>
> Hi,
>
> We will be upgrading Cloud Foundry on or after 28th February 2018. We’re letting you know about the planned buildpack updates so you can make any changes to your application before the upgrade takes place. Please ensure that your version-pinning is compatible with versions cited in the planned releases. 
>
> ### ruby-buildpack
>
> New version: 1.7.8
>
> Release notes since the last buildpack change:
> https://github.com/cloudfoundry/ruby-buildpack/releases/tag/v1.7.11
> https://github.com/cloudfoundry/ruby-buildpack/releases/tag/v1.7.10
> https://github.com/cloudfoundry/ruby-buildpack/releases/tag/v1.7.9
>
> If you have any problems using the new versions in the buildpacks or working to these timelines, please contact us via our help desk.
>
> The GOV.UK PaaS team