### PR TITLE
Fix definition lists alignment

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -152,6 +152,7 @@
   dt, dd {
     display: inline-block;
     margin-bottom: 5px;
+    vertical-align: text-top;
   }
   dt {
     width: 30%;
@@ -334,11 +335,13 @@
     float: left;
     width: 35%;
     font-weight: bold;
+    vertical-align: text-top;
   }
   dd {
     display: inline-block;
     float: right;
     width: 65%;
+    vertical-align: text-top;
   }
 }
 


### PR DESCRIPTION
## Before

<img width="636" alt="screen shot 2018-02-26 at 11 57 53" src="https://user-images.githubusercontent.com/2715/36669324-5f696f36-1aec-11e8-901f-0fdb1c1f6112.png">
<img width="662" alt="screen shot 2018-02-26 at 11 57 31" src="https://user-images.githubusercontent.com/2715/36669326-613f1496-1aec-11e8-9a89-1ab1a1742e01.png">

## After

<img width="650" alt="screen shot 2018-02-26 at 11 56 58" src="https://user-images.githubusercontent.com/2715/36669329-6579f68e-1aec-11e8-8010-513d18b908ec.png">
<img width="653" alt="screen shot 2018-02-26 at 11 57 06" src="https://user-images.githubusercontent.com/2715/36669331-67b35670-1aec-11e8-82aa-bc5d761672c6.png">
