### PR TITLE
Bug fix on the display of last updated

### DIFF
--- a/app/helpers/datasets_helper.rb
+++ b/app/helpers/datasets_helper.rb
@@ -17,8 +17,8 @@ module DatasetsHelper
     Time.parse(timestamp).strftime("%d %B %Y")
   end
 
-  def last_updated_datafile(dataset)
-    (dataset.datafiles.sort_by &:updated_at).last
+  def most_recent_datafile(dataset)
+    (dataset.datafiles.sort_by &:created_at).last
   end
 
   def dataset_location(dataset)

--- a/app/views/datasets/_meta_data.html.erb
+++ b/app/views/datasets/_meta_data.html.erb
@@ -26,7 +26,7 @@
           <% if @dataset.datafiles.none? %>
             <dd><%= format(@dataset.last_updated_at) %></dd>
           <% else %>
-            <dd><%= format(last_updated_datafile(@dataset).updated_at) %></dd>
+            <dd><%= format(most_recent_datafile(@dataset).created_at) %></dd>
           <% end %>
 
           <dt><%= t('.topic') %>:</dt>

--- a/spec/features/dataset_show_page_spec.rb
+++ b/spec/features/dataset_show_page_spec.rb
@@ -26,6 +26,27 @@ feature 'Dataset page', elasticsearch: true do
 
       expect(page).to have_content('Topic: Not added')
     end
+
+    context 'When a dataset has no datafiles' do
+      it 'Last Updated field displays last_updated_at' do
+        dataset = DatasetBuilder.new.build
+        index_and_visit(dataset)
+        expect(page).to have_content("Last updated: #{dataset['last_updated_at']}")
+      end
+    end
+
+    context 'When a dataset has datafiles' do
+      it 'Last Updated field is the most recent datafiles creation date' do
+        dataset = DatasetBuilder.new
+          .with_datafiles(DATA_FILES_WITH_START_AND_ENDDATE)
+          .build
+        index_and_visit(dataset)
+        datafiles = dataset[:datafiles]
+        last = datafiles.sort_by{ |datafile| datafile[:created_at]}.last
+        date = Time.parse(last["created_at"]).strftime("%d %B %Y")
+        expect(page).to have_content("Last updated: #{date}")
+      end
+    end
   end
 
   feature 'Datalinks' do
@@ -232,6 +253,7 @@ feature 'Dataset page', elasticsearch: true do
           'url' => "http://datafile-url",
           'start_date' => nil,
           'end_date' => nil,
+          'created_at' => '2017-07-31T14:40:57.528Z',
           'updated_at' => '2017-08-31T14:40:57.528Z'
         })
       end
@@ -249,6 +271,7 @@ feature 'Dataset page', elasticsearch: true do
           name: "Datafile 1",
           start_date: "2000/01/01",
           end_date: "2000/12/12",
+          created_at: "1999/12/12",
           updated_at: "2000/01/01"
         },
         {
@@ -257,6 +280,7 @@ feature 'Dataset page', elasticsearch: true do
           name: "Datafile 2",
           start_date: "2001/01/01",
           end_date: "2001/12/12",
+          created_at: "2000/12/12",
           updated_at: "2001/01/01"
         },
         {
@@ -265,6 +289,7 @@ feature 'Dataset page', elasticsearch: true do
           name: "Datafile 3",
           start_date: "2001/01/01",
           end_date: "2001/12/12",
+          created_at: "2000/12/12",
           updated_at: "2001/01/01"
         },
         {
@@ -273,6 +298,7 @@ feature 'Dataset page', elasticsearch: true do
           name: "Datafile 4",
           start_date: nil,
           end_date: nil,
+          created_at: "2000/12/12",
           updated_at: "2001/01/01"
         }
       ]
@@ -301,6 +327,7 @@ feature 'Dataset page', elasticsearch: true do
           name: "Datafile 1",
           start_date: nil,
           end_date: nil,
+          created_at: "1999/12/12",
           updated_at: "2000/01/01"
         },
         {
@@ -309,6 +336,7 @@ feature 'Dataset page', elasticsearch: true do
           name: "Datafile 2",
           start_date: nil,
           end_date: nil,
+          created_at: "2000/12/12",
           updated_at: "2001/01/01"
         },
         {
@@ -317,6 +345,7 @@ feature 'Dataset page', elasticsearch: true do
           name: "Datafile 3",
           start_date: nil,
           end_date: nil,
+          created_at: "2000/12/12",
           updated_at: "2001/01/01"
         }
       ]

--- a/spec/support/dataset_spec_builder.rb
+++ b/spec/support/dataset_spec_builder.rb
@@ -128,7 +128,7 @@ DATA_FILES_WITH_START_AND_ENDDATE = [
      'format' => 'HTML',
      'start_date' => '1/1/15',
      'end_date' => nil,
-     'created_at' => '2016-07-31T14:40:57.528Z',
+     'created_at' => '2016-05-03T00:00:00.000+01:00',
      'updated_at' => '2016-08-31T14:40:57.528Z',
      'uuid' => SecureRandom.uuid
     },
@@ -138,7 +138,7 @@ DATA_FILES_WITH_START_AND_ENDDATE = [
      'format' => 'CSV',
      'start_date' => '1/1/15',
      'end_date' => '24/03/2018',
-     'created_at' => '2016-07-31T14:40:57.528Z',
+     'created_at' => '2016-06-03T00:00:00.000+01:00',
      'updated_at' => '2016-08-31T14:40:57.528Z',
      'short_id' => SecureRandom.urlsafe_base64(6, true),
      'uuid' => SecureRandom.uuid
@@ -149,7 +149,7 @@ DATA_FILES_WITH_START_AND_ENDDATE = [
      'format' => '',
      'start_date' => '1/1/15',
      'end_date' => '01/12/2018',
-     'created_at' => '2016-07-31T14:40:57.528Z',
+     'created_at' => '2016-07-03T00:00:00.000+01:00',
      'updated_at' => '2016-08-31T14:40:57.528Z',
      'uuid' => SecureRandom.uuid
     }
@@ -161,6 +161,7 @@ DATAFILES_WITHOUT_START_AND_ENDDATE = [
      'url' => 'http://example.com',
      'start_date' => nil,
      'end_date' => nil,
+     'created_at' => '2016-07-31T00:00:00.000+01:00',
      'updated_at' => '2016-08-31T14:40:57.528Z',
      'uuid' => SecureRandom.uuid
     },
@@ -169,6 +170,7 @@ DATAFILES_WITHOUT_START_AND_ENDDATE = [
      'url' => 'http://example.com',
      'start_date' => nil,
      'end_date' => nil,
+     'created_at' => '2016-07-31T00:00:00.000+01:00',
      'updated_at' => '2016-08-31T14:40:57.528Z',
      'uuid' => SecureRandom.uuid
     }]
@@ -179,6 +181,7 @@ UNFORMATTED_DATASETS_MULTIYEAR = [
      'url' => 'http://example.com',
      'start_date' => '2017-09-24',
      'end_date' => nil,
+     'created_at' => '2016-07-31T00:00:00.000+01:00',
      'updated_at' => '2017-08-31T14:40:57.528Z'
     },
     {'id' => 2,
@@ -186,6 +189,7 @@ UNFORMATTED_DATASETS_MULTIYEAR = [
      'url' => 'http://example.com',
      'start_date' => '2015-09-25',
      'end_date' => nil,
+     'created_at' => '2015-07-31T00:00:00.000+01:00',
      'updated_at' => '2015-10-31T14:40:57.528Z'
     },
     {'id' => 3,
@@ -193,6 +197,7 @@ UNFORMATTED_DATASETS_MULTIYEAR = [
      'url' => 'http://example.com',
      'start_date' => '2015-09-24',
      'end_date' => nil,
+     'created_at' => '2015-07-31T00:00:00.000+01:00',
      'updated_at' => '2015-08-31T14:40:57.528Z'
     },
     {'id' => 4,
@@ -200,6 +205,7 @@ UNFORMATTED_DATASETS_MULTIYEAR = [
      'url' => 'http://example.com',
      'start_date' => nil,
      'end_date' => nil,
+     'created_at' => '2015-07-31T00:00:00.000+01:00',
      'updated_at' => '2015-10-31T14:40:57.528Z'
     }]
 
@@ -209,6 +215,7 @@ UNFORMATTED_DATASETS_SINGLEYEAR = [
      'url' => 'http://example.com',
      'start_date' => '2017-09-24',
      'end_date' => nil,
+     'created_at' => '2016-07-31T00:00:00.000+01:00',
      'updated_at' => '2017-08-31T14:40:57.528Z'
     },
     {'id' => 2,
@@ -216,6 +223,7 @@ UNFORMATTED_DATASETS_SINGLEYEAR = [
      'url' => 'http://example.com',
      'start_date' => '2017-09-25',
      'end_date' => nil,
+     'created_at' => '2015-07-31T00:00:00.000+01:00',
      'updated_at' => '2015-10-31T14:40:57.528Z'
     },
     {'id' => 3,
@@ -223,6 +231,7 @@ UNFORMATTED_DATASETS_SINGLEYEAR = [
      'url' => 'http://example.com',
      'start_date' => '2017-09-24',
      'end_date' => nil,
+     'created_at' => '2015-07-31T00:00:00.000+01:00',
      'updated_at' => '2015-08-31T14:40:57.528Z'
     }]
 
@@ -233,6 +242,7 @@ FORMATTED_DATASETS = {
                 'url' => 'http://example.com',
                 'start_date' => '2017-09-24',
                 'end_date' => nil,
+                'created_at' => '2016-07-31T00:00:00.000+01:00',
                 'updated_at' => '2017-08-31T14:40:57.528Z',
                 'start_year' => '2017'
                }],
@@ -241,6 +251,7 @@ FORMATTED_DATASETS = {
                 'url' => 'http://example.com',
                 'start_date' => '2015-09-25',
                 'end_date' => nil,
+                'created_at' => '2015-07-31T00:00:00.000+01:00',
                 'updated_at' => '2015-10-31T14:40:57.528Z',
                 'start_year' => '2015'},
                {'id' => 3,
@@ -248,6 +259,7 @@ FORMATTED_DATASETS = {
                 'url' => 'http://example.com',
                 'start_date' => '2015-09-24',
                 'end_date' => nil,
+                'created_at' => '2015-07-31T00:00:00.000+01:00',
                 'updated_at' => '2015-08-31T14:40:57.528Z',
                 'start_year' => '2015'
                }],
@@ -256,6 +268,7 @@ FORMATTED_DATASETS = {
          'url' => 'http://example.com',
          'start_date' => nil,
          'end_date' => nil,
+         'created_at' => '2015-07-31T00:00:00.000+01:00',
          'updated_at' => '2015-10-31T14:40:57.528Z',
          'start_year' => ''
         }]


### PR DESCRIPTION
Trello ticket: https://trello.com/c/qcUSjNkT/249-last-updated-field-not-working-properly

**Expected behaviour**:
When a dataset has no datafiles, the Last Updated field should display `dataset.last_updated_at`
When a dataset has some datafiles, the Last Updated field should display the most recent `created_at` date of all its datafiles, ie the same as is displayed in the File Added field. 

This pr fixes a bug which was creating the following sort of thing:
 
<img width="837" alt="screen shot 2018-02-26 at 16 52 28" src="https://user-images.githubusercontent.com/17908089/36684019-1215380c-1b17-11e8-8f71-1b6470d9cba0.png">

