### PR TITLE
Boost ranking of datasets based on their organisation category

### DIFF
--- a/app/views/search/search.html.erb
+++ b/app/views/search/search.html.erb
@@ -57,17 +57,17 @@
                 <dl class="dgu-metadata__box">
                   <% if dataset.datafiles.none? %>
                     <dt><%= t('.meta_data_box.availability') %>:</dt>
-                    <dd>
+                    <dd class="availability">
                       <span class="dgu-highlight">Not released</span>
                     </dd>
                   <% end %>
                   <dt><%= t('.meta_data_box.published_by') %>:</dt>
-                  <dd><%= dataset.organisation['title'] %></dd>
+                  <dd class="published_by"><%= dataset.organisation['title'] %></dd>
                   <dt><%= t('.meta_data_box.last_updated') %>:</dt>
                   <% if dataset.last_updated_at.present? %>
-                    <dd><%= format_timestamp(dataset.last_updated_at) %></dd>
+                    <dd class="last_updated"><%= format_timestamp(dataset.last_updated_at) %></dd>
                   <% else %>
-                    <dd class="dgu-secondary-text"> <%= t('.meta_data_box.not_applicable') %></dd>
+                    <dd class="last_updated dgu-secondary-text"> <%= t('.meta_data_box.not_applicable') %></dd>
                   <% end %>
                 </dl>
                 <p><%= truncate(strip_tags(dataset.summary), length: 200, separator: ' ') %></p>

--- a/spec/features/search_page_spec.rb
+++ b/spec/features/search_page_spec.rb
@@ -202,6 +202,43 @@ feature 'Search page', elasticsearch: true do
     )
   end
 
+  scenario 'Prominence of datasets based on organisation category' do
+    ministerial_dataset = DatasetBuilder
+                            .new
+                            .with_ministerial_department(
+                              'Department for Environment Food & Rural Affairs'
+                            )
+                            .build
+
+    non_ministerial_dataset = DatasetBuilder
+                                .new
+                                .with_non_ministerial_department(
+                                  'Forestry Commission'
+                                )
+                                .build
+
+    local_council_dataset = DatasetBuilder
+                              .new
+                              .with_local_council(
+                                'Plymouth City Council'
+                              )
+                              .build
+
+    index(ministerial_dataset, non_ministerial_dataset, local_council_dataset)
+
+    search_for('data')
+
+    publishers = all('dd.published_by').map(&:text)
+
+    expect(publishers[0]).to eq('Department for Environment Food & Rural Affairs')
+                               .or eq('Forestry Commission')
+
+    expect(publishers[1]).to eq('Department for Environment Food & Rural Affairs')
+                               .or eq('Forestry Commission')
+
+    expect(publishers[2]).to eq('Plymouth City Council')
+  end
+
   def assert_data_set_length_is(count)
     datasets = all('h2 a')
     expect(datasets.length).to be(count)

--- a/spec/support/dataset_spec_builder.rb
+++ b/spec/support/dataset_spec_builder.rb
@@ -117,6 +117,27 @@ class DatasetBuilder
     self
   end
 
+  def with_ministerial_department(ministerial_department)
+    @dataset[:organisation][:name] = ministerial_department
+    @dataset[:organisation][:title] = ministerial_department
+    @dataset[:organisation][:category] = 'ministerial-department'
+    self
+  end
+
+  def with_non_ministerial_department(non_ministerial_department)
+    @dataset[:organisation][:name] = non_ministerial_department
+    @dataset[:organisation][:title] = non_ministerial_department
+    @dataset[:organisation][:category] = 'non-ministerial-department'
+    self
+  end
+
+  def with_local_council(local_council)
+    @dataset[:organisation][:name] = local_council
+    @dataset[:organisation][:title] = local_council
+    @dataset[:organisation][:category] = 'local-council'
+    self
+  end
+
   def with_licence(licence)
     @dataset[:licence] = licence
     self


### PR DESCRIPTION
This adds additional should clauses to the Elasticsearch query to boost the score if the dataset belongs to a ministerial department, non-ministerial department or local council.

See https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-bool-query.html
Trello https://trello.com/c/rhB9ZPMa