### PR TITLE
Setting up Publishers page

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -14,7 +14,10 @@ class PagesController < ApplicationController
   def accessibility
   end
 
-  def site_changes 
+  def site_changes
+  end
+
+  def publishers
   end
 
   def dashboard

--- a/app/views/layouts/_proposition_header.html.erb
+++ b/app/views/layouts/_proposition_header.html.erb
@@ -1,9 +1,10 @@
 <div class="header-proposition">
   <div class="content">
-    <a href="#proposition-links" class="js-header-toggle menu"> <%= t('.menu') %> </a>
+    <a href="#proposition-links" class="js-header-toggle menu"><%= t('.menu') %></a>
     <nav id="proposition-menu">
       <ul id="proposition-links">
-        <%= link_to 'Support', support_path %>
+        <li><%= link_to t('.publishers'), publishers_path %></li>
+        <li><%= link_to t('.support'), support_path %></li>
       </ul>
     </nav>
   </div>

--- a/app/views/pages/publishers.html.erb
+++ b/app/views/pages/publishers.html.erb
@@ -1,0 +1,41 @@
+<% content_for :page_title do %>
+  Publishers -
+<% end %>
+
+<main role="main" id="content">
+  <%= render 'layouts/feedback_survey_banner' if flash[:beta_message] == 'hide' %>
+
+  <div class="text">
+    <h1 class="heading-large">
+      Publish your data
+    </h1>
+
+    <p>
+      We’re changing the publishing tool and plan to launch a new improved
+      service by June 2018. Until then, publishers can sign in using their
+      current username (or email address). New and changed datasets will appear
+      as normal on the newly-designed data.gov.uk, now called the Find open data
+      service.
+    </p>
+
+    <p>
+      <%= link_to 'Sign in', '/user?destination=page/publisher-tools', role: 'button', class: 'button', rel: %w(nofollow) %>
+    </p>
+
+    <div role="note" aria-label="Publisher information" class="panel panel-border-narrow text">
+      <p>
+        To make any changes to existing datasets, publishers must sign in at the
+        bottom of the page in the Edit this dataset section.
+      </p>
+    </div>
+
+    <h2 class="heading-medium">
+      Become a publisher
+    </h2>
+
+    <p>
+      To get started, take a look at the <%= link_to 'information about publishing datasets', 'https://guidance.data.gov.uk/publishing_on_data_gov_uk_overview.html', target: '_blank' %>.
+      You can also <%= link_to 'ask us for help', support_path %>.
+    </p>
+  </div>
+</main>

--- a/config/locales/views/layouts/en.yml
+++ b/config/locales/views/layouts/en.yml
@@ -6,6 +6,8 @@ en:
       survey_url: "http://www.smartsurvey.co.uk/s/3SEXD/"
     proposition_header:
       menu: "Menu"
+      publishers: "Publish your data"
+      support: "Support"
     application:
       page_title: "data.gov.uk"
       global_header_text: "Find open data"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,11 +17,12 @@ Rails.application.routes.draw do
     get 'about'
     get 'accessibility'
     get 'cookies'
+    get 'dashboard'
     get 'privacy'
+    get 'publishers'
+    get 'site-changes', to: :site_changes
     get 'support'
     get 'terms'
-    get 'dashboard'
-    get 'site-changes', to: :site_changes
   end
 
   match "404", to: "errors#not_found", via: :all


### PR DESCRIPTION
This makes the page for Publishers and adds it to the navigation.

The content references functionality introduced in #434 

https://trello.com/c/V53vd6JZ/7-publisher-sign-in-page-and-link-from-find