### PR TITLE
Upgrade ruby buildpack

### DIFF
--- a/production-manifest.yml
+++ b/production-manifest.yml
@@ -2,7 +2,7 @@
 applications:
 - name: find-data-beta
   memory: 256M
-  buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.6.47
+  buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.7.14
   routes:
   - route: find-data-beta.cloudapps.digital
   - route: beta.data.gov.uk

--- a/staging-manifest.yml
+++ b/staging-manifest.yml
@@ -2,7 +2,7 @@
 applications:
 - name: find-data-beta-staging
   memory: 256M
-  buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.6.47
+  buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.7.14
   env:
     RAILS_ENV: staging
     RACK_ENV: staging


### PR DESCRIPTION
Upgrades the Ruby buildpack for Cloudfoundry to v1.7.14.