### PR TITLE
Fix deployment script failure

### DIFF
--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -2,7 +2,4 @@
 
 set -e
 
-rm manifest.yml || true
-ln -s production-manifest.yml manifest.yml
-cf zero-downtime-push $CF_APP -f manifest.yml
-rm manifest.yml
+cf zero-downtime-push $CF_APP -f production-manifest.yml

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm manifest.yml || true
 ln -s production-manifest.yml manifest.yml
 cf zero-downtime-push $CF_APP -f manifest.yml

--- a/scripts/deploy-staging.sh
+++ b/scripts/deploy-staging.sh
@@ -2,7 +2,4 @@
 
 set -e
 
-rm manifest.yml || true
-ln -s staging-manifest.yml manifest.yml
-cf zero-downtime-push $CF_APP -f manifest.yml
-rm manifest.yml
+cf zero-downtime-push $CF_APP -f staging-manifest.yml

--- a/scripts/deploy-staging.sh
+++ b/scripts/deploy-staging.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm manifest.yml || true
 ln -s staging-manifest.yml manifest.yml
 cf zero-downtime-push $CF_APP -f manifest.yml

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -55,15 +55,7 @@ then
   CF_ENV='staging'
 fi
 
-rm manifest.yml || true
-
 cf login -a $CF_API -u $CF_USER -p $CF_PASS -s $CF_SPACE
 cf add-plugin-repo CF-Community https://plugins.cloudfoundry.org
 cf install-plugin autopilot -r CF-Community -f
-
-# autopilot requires a manifest.yml to be present
-ln -s $CF_ENV-manifest.yml manifest.yml
-
-cf zero-downtime-push $CF_APP -f manifest.yml
-
-rm manifest.yml
+cf zero-downtime-push $CF_APP -f $CF_ENV-manifest.yml

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # Usage: deploy.sh <app_name> <manifest_prefix>
 #
 #   Command-line arguments:


### PR DESCRIPTION
Refactors the deployment scripts to exit immediately if a step fails and to pass the manifest directly to the Cloudfoundry deployment script as an argument.

We want the deployment to fail if any of the deploy steps fail.

This should address issues we have seen where builds are green despite a deployment failing.