### PR TITLE
Correctly escape secrets.yml

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -1,11 +1,14 @@
+default: &default
+  secret_key_base: '<%= ENV["SECRET_KEY_BASE"] %>'
+
 development:
-  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+  <<: *default
 
 test:
-  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+  <<: *default
 
 staging:
-  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+  <<: *default
 
 production:
-  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+  <<: *default


### PR DESCRIPTION
If the SECRET_KEY_BASE value contains special characters we'll be unable to parse the JSON file.

This was causing errors with libyaml.

This will fix https://travis-ci.org/alphagov/datagovuk_find/builds/347706760