### PR TITLE
Improve display of contact information

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -385,3 +385,23 @@ span.showHide-open-all {
   text-decoration: underline;
   cursor: pointer;
 }
+<<<<<<< HEAD
+=======
+
+
+// contact______
+.contact {
+  .column-one-half {
+    padding-left: 0;
+    span {
+      display: block;
+    }
+    h3 {
+      padding-bottom: 8px;
+    }
+    &.foi {
+      padding-right: 0;
+    }
+  }
+}
+>>>>>>> refactor of dataset helper

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -385,8 +385,6 @@ span.showHide-open-all {
   text-decoration: underline;
   cursor: pointer;
 }
-<<<<<<< HEAD
-=======
 
 
 // contact______
@@ -404,4 +402,3 @@ span.showHide-open-all {
     }
   }
 }
->>>>>>> refactor of dataset helper

--- a/app/helpers/datasets_helper.rb
+++ b/app/helpers/datasets_helper.rb
@@ -71,15 +71,23 @@ module DatasetsHelper
     "js-show-more-datafiles" unless datafiles.take(5).include? datafile
   end
 
-  def contact_details_exist?(dataset)
-    contact_email_exists?(dataset) || foi_email_exists?(dataset)
+  def contact_information_exists?(dataset)
+    contact_email_exists?(dataset) || foi_email_exists?(dataset) || foi_web_address_exists?(dataset)
   end
 
   def contact_email_exists?(dataset)
     dataset.contact_email.present? || dataset.organisation.contact_email.present?
   end
 
+  def foi_details_exist?(dataset)
+    foi_email_exists?(dataset) || foi_web_address_exists?(dataset)
+  end
+
   def foi_email_exists?(dataset)
     dataset.foi_email.present? || dataset.organisation.foi_email.present?
+  end
+
+  def foi_web_address_exists?(dataset)
+    dataset.foi_web.present? || dataset.organisation.foi_web.present?
   end
 end

--- a/app/helpers/datasets_helper.rb
+++ b/app/helpers/datasets_helper.rb
@@ -80,7 +80,7 @@ module DatasetsHelper
   end
 
   def contact_name_for(dataset)
-    dataset.contact_name.presence || dataset.organisation.contact_name
+    dataset.contact_name.presence || dataset.organisation.contact_name.presence
   end
 
   def contact_email_for(dataset)
@@ -100,7 +100,7 @@ module DatasetsHelper
   end
 
   def foi_name_for(dataset)
-    dataset.foi_name.presence || dataset.organisation.foi_name
+    dataset.foi_name.presence || dataset.organisation.foi_name.presence
   end
 
   def foi_email_for(dataset)

--- a/app/helpers/datasets_helper.rb
+++ b/app/helpers/datasets_helper.rb
@@ -72,11 +72,19 @@ module DatasetsHelper
   end
 
   def contact_information_exists?(dataset)
-    contact_email_exists?(dataset) || foi_email_exists?(dataset) || foi_web_address_exists?(dataset)
+    contact_email_exists?(dataset) || foi_details_exist?(dataset)
   end
 
   def contact_email_exists?(dataset)
     dataset.contact_email.present? || dataset.organisation.contact_email.present?
+  end
+
+  def contact_name_for(dataset)
+    dataset.contact_name.presence || dataset.organisation.contact_name
+  end
+
+  def contact_email_for(dataset)
+    dataset.contact_email.presence || dataset.organisation.contact_email
   end
 
   def foi_details_exist?(dataset)
@@ -89,5 +97,17 @@ module DatasetsHelper
 
   def foi_web_address_exists?(dataset)
     dataset.foi_web.present? || dataset.organisation.foi_web.present?
+  end
+
+  def foi_name_for(dataset)
+    dataset.foi_name.presence || dataset.organisation.foi_name
+  end
+
+  def foi_email_for(dataset)
+    dataset.foi_email.presence || dataset.organisation.foi_email
+  end
+
+  def foi_web_address_for(dataset)
+    dataset.foi_web.presence || dataset.organisation.foi_web
   end
 end

--- a/app/helpers/datasets_helper.rb
+++ b/app/helpers/datasets_helper.rb
@@ -76,7 +76,7 @@ module DatasetsHelper
   end
 
   def contact_email_exists?(dataset)
-    dataset.contact_email.present? || dataset.organisation.contact_email.present?
+    contact_email_for(dataset).present?
   end
 
   def contact_name_for(dataset)
@@ -84,7 +84,7 @@ module DatasetsHelper
   end
 
   def contact_email_for(dataset)
-    dataset.contact_email.presence || dataset.organisation.contact_email
+    dataset.contact_email.presence || dataset.organisation.contact_email.presence
   end
 
   def foi_details_exist?(dataset)
@@ -92,11 +92,11 @@ module DatasetsHelper
   end
 
   def foi_email_exists?(dataset)
-    dataset.foi_email.present? || dataset.organisation.foi_email.present?
+    foi_email_for(dataset).present?
   end
 
   def foi_web_address_exists?(dataset)
-    dataset.foi_web.present? || dataset.organisation.foi_web.present?
+    foi_web_address_for(dataset).present?
   end
 
   def foi_name_for(dataset)
@@ -104,10 +104,10 @@ module DatasetsHelper
   end
 
   def foi_email_for(dataset)
-    dataset.foi_email.presence || dataset.organisation.foi_email
+    dataset.foi_email.presence || dataset.organisation.foi_email.presence
   end
 
   def foi_web_address_for(dataset)
-    dataset.foi_web.presence || dataset.organisation.foi_web
+    dataset.foi_web.presence || dataset.organisation.foi_web.presence
   end
 end

--- a/app/views/datasets/_additional_info.html.erb
+++ b/app/views/datasets/_additional_info.html.erb
@@ -1,19 +1,16 @@
-<% if @dataset.notes.present? || @dataset.inspire_dataset.present? %>
 
   <section class="dgu-additional-info">
     <h2 class="heading-medium">
       <%= t('.additional_info') %>
     </h2>
-
-    <% if @dataset.notes.present? %>
+    <% if dataset.notes.present? %>
       <p class="dgu-additional-info__notes">
-        <%= @dataset.notes %>
+        <%= dataset.notes %>
       </p>
     <% end %>
 
-
-    <% if @dataset.inspire_dataset.present? %>
-      <% i = @dataset.inspire_dataset %>
+    <% if dataset.inspire_dataset.present? %>
+      <% i = dataset.inspire_dataset %>
 
       <details>
         <summary><span class="summary"><%= t('.view_additional_metadata')%></span></summary>
@@ -85,5 +82,3 @@
       </details>
     <% end %>
   </section>
-
-<% end %>

--- a/app/views/datasets/_contact.html.erb
+++ b/app/views/datasets/_contact.html.erb
@@ -11,8 +11,8 @@
         </h3>
 
         <p>
-          <%= @dataset.contact_name.presence || @dataset.organisation.contact_name %></br>
-          <%= mail_to(@dataset.contact_email.presence || @dataset.organisation.contact_email) %>
+          <%= contact_name_for(@dataset) %></br>
+          <%= mail_to(contact_email_for(@dataset)) %>
         </p>
       </div>
     <% end %>
@@ -24,11 +24,10 @@
         </h3>
 
         <p>
-          <%= @dataset.foi_name.presence || @dataset.organisation.foi_name %></br>
-          <%= mail_to(@dataset.foi_email.presence || @dataset.organisation.foi_email) %></br>
-          <a href= "<%= (@dataset.foi_web.presence || @dataset.organisation.foi_web) %>">
-            <%= (@dataset.foi_web.presence || @dataset.organisation.foi_web) %>
-          </a>
+          <%= foi_name_for(@dataset) %></br>
+          <%= mail_to(foi_email_for(@dataset)) %></br>
+          <%= link_to(foi_web_address_for(@dataset),foi_web_address_for(@dataset)) %>
+        </p>
       </div>
     <% end %>
   </div>

--- a/app/views/datasets/_contact.html.erb
+++ b/app/views/datasets/_contact.html.erb
@@ -1,34 +1,32 @@
 <section class="contact">
-  <div>
-    <h2 class="heading-medium">
-      <%= t('datasets.contact.contact') %>
-    </h2>
+  <h2 class="heading-medium">
+    <%= t('datasets.contact.contact') %>
+  </h2>
 
-    <% if contact_email_exists?(@dataset) %>
-      <div class="column-one-half">
-        <h3 class="heading-small">
-          <%= t('datasets.contact.enquiries') %>
-        </h3>
+  <% if contact_email_exists?(dataset) %>
+    <div class="column-one-half">
+      <h3 class="heading-small">
+        <%= t('datasets.contact.enquiries') %>
+      </h3>
 
-        <p>
-          <%= contact_name_for(@dataset) %></br>
-          <%= mail_to(contact_email_for(@dataset)) %>
-        </p>
-      </div>
-    <% end %>
+      <p>
+        <%= contact_name_for(dataset) %></br>
+        <%= mail_to(contact_email_for(dataset)) %>
+      </p>
+    </div>
+  <% end %>
 
-    <% if foi_details_exist?(@dataset) %>
-      <div class="column-one-half foi">
-        <h3 class="heading-small">
-          <%= t('datasets.contact.foi_requests') %>
-        </h3>
+  <% if foi_details_exist?(dataset) %>
+    <div class="column-one-half foi">
+      <h3 class="heading-small">
+        <%= t('datasets.contact.foi_requests') %>
+      </h3>
 
-        <p>
-          <%= foi_name_for(@dataset) %></br>
-          <%= mail_to(foi_email_for(@dataset)) %></br>
-          <%= link_to(foi_web_address_for(@dataset),foi_web_address_for(@dataset)) %>
-        </p>
-      </div>
-    <% end %>
-  </div>
+      <p>
+        <%= foi_name_for(dataset) %></br>
+        <%= mail_to(foi_email_for(dataset)) %></br>
+        <%= link_to(foi_web_address_for(dataset),foi_web_address_for(dataset)) %>
+      </p>
+    </div>
+  <% end %>
 </section>

--- a/app/views/datasets/_contact.html.erb
+++ b/app/views/datasets/_contact.html.erb
@@ -10,8 +10,8 @@
       </h3>
 
       <p>
-        <%= contact_name_for(dataset) %></br>
-        <%= mail_to(contact_email_for(dataset)) %>
+        <span><%= contact_name_for(dataset) %></span>
+        <span><%= mail_to(contact_email_for(dataset)) %></span>
       </p>
     </div>
   <% end %>
@@ -23,9 +23,9 @@
       </h3>
 
       <p>
-        <%= foi_name_for(dataset) %></br>
-        <%= mail_to(foi_email_for(dataset)) %></br>
-        <%= link_to(foi_web_address_for(dataset),foi_web_address_for(dataset)) %>
+        <span><%= foi_name_for(dataset) %></span>
+        <span><%= mail_to(foi_email_for(dataset)) %></span>
+        <span><%= link_to(foi_web_address_for(dataset),foi_web_address_for(dataset)) %></span>
       </p>
     </div>
   <% end %>

--- a/app/views/datasets/_contact.html.erb
+++ b/app/views/datasets/_contact.html.erb
@@ -1,22 +1,34 @@
 <section class="contact">
   <div>
     <h2 class="heading-medium">
-      <%= t('.contact') %>
+      <%= t('datasets.contact.contact') %>
     </h2>
-    <div class="column-one-half">
-      <h3 class="heading-small">
-      <%= t('.enquiries') %>
-      </h3>
-      <p><%= @dataset.organisation['contact_name'] %> </br>
-        <a href=""><%= @dataset.organisation['contact_email'] %></a></p>
-    </div>
-    <% if @dataset.organisation['foi_name'] || @dataset.organisation['foi_email'] %>
+
+    <% if contact_email_exists?(@dataset) %>
+      <div class="column-one-half">
+        <h3 class="heading-small">
+          <%= t('datasets.contact.enquiries') %>
+        </h3>
+
+        <p>
+          <%= @dataset.contact_name.presence || @dataset.organisation.contact_name %></br>
+          <%= mail_to(@dataset.contact_email.presence || @dataset.organisation.contact_email) %>
+        </p>
+      </div>
+    <% end %>
+
+    <% if foi_details_exist?(@dataset) %>
       <div class="column-one-half foi">
         <h3 class="heading-small">
-          <%= t('.foi_requests') %>
+          <%= t('datasets.contact.foi_requests') %>
         </h3>
-        <p><%= @dataset.organisation['foi_name'] %> </br> <a href=""><%= @dataset.organisation['foi_email'] %></a>
-        </p>
+
+        <p>
+          <%= @dataset.foi_name.presence || @dataset.organisation.foi_name %></br>
+          <%= mail_to(@dataset.foi_email.presence || @dataset.organisation.foi_email) %></br>
+          <a href= "<%= (@dataset.foi_web.presence || @dataset.organisation.foi_web) %>">
+            <%= (@dataset.foi_web.presence || @dataset.organisation.foi_web) %>
+          </a>
       </div>
     <% end %>
   </div>

--- a/app/views/datasets/_no_datafiles.html.erb
+++ b/app/views/datasets/_no_datafiles.html.erb
@@ -1,0 +1,10 @@
+<div class="panel panel-border-narrow">
+  <p><%= t('datasets.show.not_released') %><br />
+  <% if contact_information_exists?(dataset) %>
+    <%= t('datasets.show.contact_the_publisher') %>
+  <% else %>
+    <%= t('datasets.show.contact_the_team') %>
+    <%= link_to 'data.gov.uk/support', support_path %>
+    <%= t('datasets.show.if_you_have_questions') %>
+  <% end %>
+</div>

--- a/app/views/datasets/_supporting_docs.html.erb
+++ b/app/views/datasets/_supporting_docs.html.erb
@@ -12,7 +12,7 @@
     </tr>
     </thead>
     <tbody>
-    <% @dataset.docs.each do |doc| %>
+    <% dataset.docs.each do |doc| %>
       <tr>
         <td class="title">
           <a href="<%= doc.url%>"><%= doc.name %></a>

--- a/app/views/datasets/show.html.erb
+++ b/app/views/datasets/show.html.erb
@@ -31,7 +31,7 @@
           <% if @dataset.datafiles.empty? %>
             <div class="panel panel-border-narrow">
               <p>This data hasn't been released to the public by the publisher yet.<br />
-              <% if contact_details_exist?(@dataset) %>
+              <% if contact_email_exists?(@dataset) || foi_email_exists?(@dataset)%>
                 Contact the publisher for more information.
               <% else %>
                 Contact the team on <%= link_to 'data.gov.uk/support', support_path %> if you have any questions.
@@ -48,6 +48,7 @@
       <%= render "supporting_docs" %>
     <% end %>
 
+<<<<<<< HEAD
     <% if contact_details_exist?(@dataset) %>
       <section>
         <div class="grid-row">
@@ -97,5 +98,11 @@
         </div>
       </div>
     </section>
+=======
+    <% if contact_information_exists?(@dataset) %>
+      <%= render "contact" %>
+    <% end %>
+
+>>>>>>> display foi_web information if it's available
   </div>
 </main>

--- a/app/views/datasets/show.html.erb
+++ b/app/views/datasets/show.html.erb
@@ -44,43 +44,8 @@
       <%= render partial: "supporting_docs", locals: { dataset: @dataset } %>
     <% end %>
 
-<<<<<<< HEAD
-    <% if contact_details_exist?(@dataset) %>
-      <section>
-        <div class="grid-row">
-          <div class="column-full">
-            <h2 class="heading-medium">
-              <%= t('datasets.contact.contact') %>
-            </h2>
-          </div>
-
-          <% if contact_email_exists?(@dataset) %>
-            <div class="column-half">
-              <h3 class="heading-small">
-                <%= t('datasets.contact.enquiries') %>
-              </h3>
-
-              <p>
-                <%= @dataset.contact_name.presence || @dataset.organisation.contact_name %></br>
-                <%= mail_to(@dataset.contact_email.presence || @dataset.organisation.contact_email) %>
-              </p>
-            </div>
-          <% end %>
-
-          <% if foi_email_exists?(@dataset) %>
-            <div class="column-half">
-              <h3 class="heading-small">
-                <%= t('datasets.contact.foi_requests') %>
-              </h3>
-
-              <p>
-                <%= @dataset.foi_name.presence || @dataset.organisation.foi_name %></br>
-                <%= mail_to(@dataset.foi_email.presence || @dataset.organisation.foi_email) %>
-              </p>
-            </div>
-          <% end %>
-        </div>
-      </section>
+    <% if contact_information_exists?(@dataset) %>
+      <%= render partial: "contact", locals: { dataset: @dataset } %>
     <% end %>
 
     <section>
@@ -94,11 +59,6 @@
         </div>
       </div>
     </section>
-=======
-    <% if contact_information_exists?(@dataset) %>
-      <%= render partial: "contact", locals: { dataset: @dataset } %>
-    <% end %>
 
->>>>>>> display foi_web information if it's available
   </div>
 </main>

--- a/app/views/datasets/show.html.erb
+++ b/app/views/datasets/show.html.erb
@@ -30,11 +30,13 @@
 
           <% if @dataset.datafiles.empty? %>
             <div class="panel panel-border-narrow">
-              <p>This data hasn't been released to the public by the publisher yet.<br />
+              <p><%= t('.not_released')%><br />
               <% if contact_email_exists?(@dataset) || foi_email_exists?(@dataset)%>
-                Contact the publisher for more information.
+                <%= t('.contact_the_publisher')%>
               <% else %>
-                Contact the team on <%= link_to 'data.gov.uk/support', support_path %> if you have any questions.
+                <%= t('.contact_the_team')%>
+                <%= link_to 'data.gov.uk/support', support_path %>
+                <%= t('.if_you_have_questions') %>
               <% end %>
             </div>
           <% end %>

--- a/app/views/datasets/show.html.erb
+++ b/app/views/datasets/show.html.erb
@@ -29,25 +29,19 @@
           <% end %>
 
           <% if @dataset.datafiles.empty? %>
-            <div class="panel panel-border-narrow">
-              <p><%= t('.not_released')%><br />
-              <% if contact_email_exists?(@dataset) || foi_email_exists?(@dataset)%>
-                <%= t('.contact_the_publisher')%>
-              <% else %>
-                <%= t('.contact_the_team')%>
-                <%= link_to 'data.gov.uk/support', support_path %>
-                <%= t('.if_you_have_questions') %>
-              <% end %>
-            </div>
+            <%= render partial: "no_datafiles", locals: { dataset: @dataset } %>
           <% end %>
+
         </section>
       </div>
     </div>
 
-    <%= render "additional_info" %>
+    <% if @dataset.notes.present? || @dataset.inspire_dataset.present? %>
+      <%= render partial: "additional_info", locals: { dataset: @dataset } %>
+    <% end %>
 
     <% unless @dataset.docs.empty? %>
-      <%= render "supporting_docs" %>
+      <%= render partial: "supporting_docs", locals: { dataset: @dataset } %>
     <% end %>
 
 <<<<<<< HEAD
@@ -102,7 +96,7 @@
     </section>
 =======
     <% if contact_information_exists?(@dataset) %>
-      <%= render "contact" %>
+      <%= render partial: "contact", locals: { dataset: @dataset } %>
     <% end %>
 
 >>>>>>> display foi_web information if it's available

--- a/config/locales/views/datasets/en.yml
+++ b/config/locales/views/datasets/en.yml
@@ -64,7 +64,11 @@ en:
     show:
       open_all: "Open all"
       data_links: "Data links"
+      not_released: "This data hasn't been released to the public by the publisher yet."
+      contact_the_publisher: "Contact the publisher for more information."
+      contact_the_team: "Contact the team on"
+      if_you_have_questions: "if you have any questions."
     publishers:
-      title: "Edit this dataset"
-      information: "You must have an account for this publisher on data.gov.uk to make any changes to a dataset."
-      button: "Sign in"
+        title: "Edit this dataset"
+        information: "You must have an account for this publisher on data.gov.uk to make any changes to a dataset."
+        button: "Sign in"

--- a/config/locales/views/datasets/en.yml
+++ b/config/locales/views/datasets/en.yml
@@ -69,6 +69,6 @@ en:
       contact_the_team: "Contact the team on"
       if_you_have_questions: "if you have any questions."
     publishers:
-        title: "Edit this dataset"
-        information: "You must have an account for this publisher on data.gov.uk to make any changes to a dataset."
-        button: "Sign in"
+      title: "Edit this dataset"
+      information: "You must have an account for this publisher on data.gov.uk to make any changes to a dataset."
+      button: "Sign in"


### PR DESCRIPTION
Trello: https://trello.com/c/CBAblHX3/270-some-organisation-contact-details-not-on-find

- Adds the foi_web field to the contact details section of the dataset show page
- Moves markup from the show page into the `contact` partial which was not being called anymore.
