### PR TITLE
Remove search result explanation

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -135,7 +135,7 @@
     margin-top: 5px;
   }
 
-  &__result {
+  &__zero, &__result {
     margin-top: 30px;
   }
 }

--- a/app/views/search/search.html.erb
+++ b/app/views/search/search.html.erb
@@ -30,7 +30,7 @@
       </div>
 
       <div class="column-two-thirds dgu-results">
-        <%= render 'sort' %>
+        <%= render 'sort' if @num_results > 1 %>
 
         <% if @query.present? %>
           <span class="dgu-results__summary">

--- a/app/views/search/search.html.erb
+++ b/app/views/search/search.html.erb
@@ -40,12 +40,14 @@
         <% end %>
 
         <div>
-          <% if @num_results == 0 %>
-            <h2 class="heading-medium"> <%= t('.zero_result_tips.try') %>:</h2>
-            <ul class="list list-bullet">
-              <li><%= t('.zero_result_tips.different_words') %></li>
-              <li><%= t('.zero_result_tips.clear_filters') %></li>
-            </ul>
+          <% if @num_results.zero? %>
+            <div class="dgu-results__zero">
+              <h2 class="heading-medium"> <%= t('.zero_result_tips.try') %>:</h2>
+              <ul class="list list-bullet">
+                <li><%= t('.zero_result_tips.different_words') %></li>
+                <li><%= t('.zero_result_tips.clear_filters') %></li>
+              </ul>
+            </div>
           <% else %>
             <% @datasets.each do |d| %>
               <div class="dgu-results__result">

--- a/app/views/search/search.html.erb
+++ b/app/views/search/search.html.erb
@@ -35,20 +35,8 @@
         <% if @query.present? %>
           <span class="dgu-results__summary">
             <span class="bold-small"><%= number_with_delimiter(@num_results) %></span>
-            <%= t('.results_summary') %> <span class="bold-small">‘<%= @query %>’</span>
+            <%= t('.result').pluralize(@num_results) %> <%= t('.found') %>
           </span>
-        <% end %>
-
-        <% if @query.empty? && selected_filters.any? %>
-          <%= t('.datasets') %>
-        <% end %>
-
-        <% if @organisation.present? %>
-          <%= t('.published_by') %> <span class="bold-small">‘<%= @organisation %>’</span>
-        <% end %>
-
-        <% if selected_filters.any? %>
-          <%= t('.filtered_by') %> <%= selected_filters.to_sentence %>
         <% end %>
 
         <div>

--- a/config/locales/views/search/en.yml
+++ b/config/locales/views/search/en.yml
@@ -6,11 +6,9 @@ en:
       accessibility:
         search_box_label: "Search"
         search_button_label: "Find data"
-      results_summary: "results found for"
+      result: "result"
+      found: "found"
       availability: "availability"
-      published_by: "published by"
-      filtered_by: "filtered by"
-      datasets: 'Datasets'
       zero_result_tips:
         try: "Please try"
         different_words: "searching again using different words"

--- a/spec/features/search_page_spec.rb
+++ b/spec/features/search_page_spec.rb
@@ -9,7 +9,7 @@ feature 'Search page', elasticsearch: true do
     search_for(query)
 
     expect(page).to have_css('h1', text: 'Search results')
-    expect(page).to have_content("0 results found for ‘#{query}’")
+    expect(page).to have_content("0 results found")
   end
 
   scenario 'Displays search results' do
@@ -179,7 +179,6 @@ feature 'Search page', elasticsearch: true do
     search_results_headings = all('h2 a').map(&:text)
     expect(search_results_headings.length).to be(1)
     expect(search_results_headings).to contain_exactly 'First Dataset Title'
-    expect(page).to have_content 'Datasets filtered by FOO'
   end
 
   scenario 'Searching for a phrase' do


### PR DESCRIPTION
Removes the messaging that explains the criteria for the search that generated the results being shown. This follows the pattern used on GOV.UK.

Also now only allows search results to be filtered when there are some. Also increased margin around zero search results help.

## Before

<img width="1366" alt="results for test - data gov uk 2018-03-02 12-16-04" src="https://user-images.githubusercontent.com/2715/36898678-c1a9ad26-1e13-11e8-8f46-48ee57f8a806.png">

<img width="1366" alt="results for foobar - data gov uk 2018-03-02 12-15-24" src="https://user-images.githubusercontent.com/2715/36898713-dfabe1fe-1e13-11e8-9896-09b34b5ff0cc.png">

<img width="1366" alt="results for driver testing outcomes for cars by test centre - data gov uk 2018-03-02 12-15-05" src="https://user-images.githubusercontent.com/2715/36899056-581b9b92-1e15-11e8-8121-395b0bdaa35a.png">

## After

<img width="1366" alt="results for test - data gov uk 2018-03-02 12-16-22" src="https://user-images.githubusercontent.com/2715/36898696-d1e4059c-1e13-11e8-9c78-08dd3710a121.png">

<img width="1366" alt="results for foobar - data gov uk 2018-03-02 12-13-46" src="https://user-images.githubusercontent.com/2715/36898722-e4fab630-1e13-11e8-9732-33dd08998bbc.png">

<img width="1366" alt="results for driver testing outcomes for cars by test centre - data gov uk 2018-03-02 12-30-12" src="https://user-images.githubusercontent.com/2715/36899096-7b7faf38-1e15-11e8-9acf-e4373d87f1d3.png">

See https://trello.com/c/LbWXHMdT and https://trello.com/c/YSkSBugv