### PR TITLE
Update to header bar

### DIFF
--- a/app/assets/stylesheets/govuk-overrides.scss
+++ b/app/assets/stylesheets/govuk-overrides.scss
@@ -15,28 +15,34 @@
     img {
       display: none;
     }
+
     .vertical-separator {
       display: inline-block;
       margin-left: 4px;
       color: black;
       border-left: thin solid $grey-2;
-    }
-    .dgu-phase-tag--responsive {
-      @media (max-width: 641px) {
+      @media (max-width: 646px) {
         display: block;
-        width: 10%;
+        line-height: 0;
+        font-size: 0;
+      }
+    }
+
+    .dgu-phase-tag--responsive {
+      @media (max-width: 769px) {
+        display: block;
+        width: 12%;
+      }
+    }
+
+    .header-proposition {
+      #proposition-links {
+        a {
+          font-family: Helvetica;
+        }
       }
     }
   }
-
-  .header-proposition {
-    #proposition-links {
-      a {
-        font-family: Helvetica;
-      }
-    }
-  }
-
 }
 
 #proposition-links {

--- a/app/assets/stylesheets/govuk-overrides.scss
+++ b/app/assets/stylesheets/govuk-overrides.scss
@@ -10,15 +10,25 @@
     font-weight: normal;
     background: none;
     border-bottom: none;
-    width: 110%;
+    width: 160%;
     font-family: Helvetica, Arial, sans-serif;
     img {
       display: none;
     }
+    .vertical-separator {
+      display: inline-block;
+      margin-left: 4px;
+      color: black;
+      border-left: thin solid $grey-2;
+    }
+    .dgu-phase-tag--responsive {
+      @media (max-width: 641px) {
+        display: block;
+        width: 10%;
+      }
+    }
   }
-}
 
-#global-header {
   .header-proposition {
     #proposition-links {
       a {
@@ -26,6 +36,7 @@
       }
     }
   }
+
 }
 
 #proposition-links {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,7 +21,10 @@
 <% end %>
 
 <% content_for :global_header_text do %>
-  <%= t('.global_header_text') %> <strong class="phase-tag">BETA</strong>
+  <%= t('.data_gov_uk')%>
+  <div class="vertical-separator">|</div>
+  <%= t('.find_open_data') %>
+  <strong class="phase-tag dgu-phase-tag--responsive">BETA</strong>
 <% end %>
 
 <% content_for :header_class do %>

--- a/app/views/layouts/search.html.erb
+++ b/app/views/layouts/search.html.erb
@@ -6,7 +6,10 @@
 <% end %>
 <% content_for :homepage_url do %>/<% end %>
 <% content_for :global_header_text do %>
-  <%= t('layouts.application.global_header_text') %> <strong class="phase-tag">BETA</strong>
+  <%= t('layouts.application.data_gov_uk')%>
+  <div class="vertical-separator">|</div>
+  <%= t('layouts.application.find_open_data') %>
+  <strong class="phase-tag dgu-phase-tag--responsive">BETA</strong>
 <% end %>
 <% content_for :header_class do %>with-proposition<% end %>
 <% content_for :proposition_header do %>

--- a/config/locales/views/layouts/en.yml
+++ b/config/locales/views/layouts/en.yml
@@ -8,4 +8,5 @@ en:
       menu: "Menu"
     application:
       page_title: "data.gov.uk"
-      global_header_text: "Find open data"
+      find_open_data: "Find open data"
+      data_gov_uk: "data.gov.uk"


### PR DESCRIPTION
- trello card: https://trello.com/c/uDMK8vZY/194-add-datagovuk-to-black-header-bar-s
- add vertical separator between old and new service name in global header

# Before
<img width="636" alt="screen shot 2018-03-06 at 13 37 41" src="https://user-images.githubusercontent.com/17908089/37035186-959b198a-2143-11e8-8cf0-addf0b41d117.png">

# After 
<img width="612" alt="screen shot 2018-03-06 at 13 36 34" src="https://user-images.githubusercontent.com/17908089/37035134-6f1f03f2-2143-11e8-8809-b21f58a60c5e.png">
