### PR TITLE
Redirect retired pages to site changes page

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,15 +2,23 @@ Rails.application.routes.draw do
   root to: 'home#index'
 
   scope module: 'legacy' do
-    get 'dataset/:legacy_name', to: 'datasets#redirect'
+    get 'dataset/:legacy_name',                                 to: 'datasets#redirect'
     get 'dataset/:legacy_dataset_name/resource/:datafile_uuid', to: 'datafiles#redirect'
-    get 'data/search',          to: 'search#redirect'
-    get 'contact',              to: redirect('support')
-    get 'cookies-policy',       to: redirect('cookies')
-    get 'accessibility-statement',       to: redirect('accessibility')
-    get 'technical-details',    to: redirect('about')
-    get 'terms-and-conditions', to: redirect('terms')
-    get 'faq',                  to: redirect('about')
+
+    get 'data/search',              to: 'search#redirect'
+    get 'contact',                  to: redirect('support')
+    get 'cookies-policy',           to: redirect('cookies')
+    get 'accessibility-statement',  to: redirect('accessibility')
+    get 'technical-details',        to: redirect('about')
+    get 'terms-and-conditions',     to: redirect('terms')
+    get 'faq',                      to: redirect('about')
+    get 'apps',                     to: redirect('site-changes')
+    get 'apps/*_app',               to: redirect('site-changes')
+    get 'node/*_node',              to: redirect('site-changes')
+    get 'reply/*_reply',            to: redirect('site-changes')
+    get 'comments/*_comment',       to: redirect('site-changes')
+    get 'forum/*_forum',            to: redirect('site-changes')
+    get 'dataset/issues/*_issue',   to: redirect('site-changes')
   end
 
   scope module: 'pages' do
@@ -38,5 +46,4 @@ Rails.application.routes.draw do
   get 'dataset/:dataset_short_id/:name/datafile/:datafile_short_id/preview', to: 'previews#show', as: 'datafile_preview'
 
   get 'acknowledge', to: 'messages#acknowledge'
-
 end

--- a/spec/requests/legacy/redirect_spec.rb
+++ b/spec/requests/legacy/redirect_spec.rb
@@ -118,11 +118,74 @@ describe 'legacy', :type => :request do
     end
   end
 
-   describe 'faqs page' do
+  describe 'faqs page' do
     it 'redirects to the about page' do
       get '/faq'
 
       expect(response).to redirect_to(about_url)
+      expect(response).to have_http_status(:moved_permanently)
+    end
+  end
+
+  describe 'apps page' do
+    it 'redirects to site changes page' do
+      get '/apps'
+
+      expect(response).to redirect_to(site_changes_url)
+      expect(response).to have_http_status(:moved_permanently)
+    end
+  end
+
+  describe 'individual app pages' do
+    it 'redirect to site changes page' do
+      get '/apps/foobar'
+
+      expect(response).to redirect_to(site_changes_url)
+      expect(response).to have_http_status(:moved_permanently)
+    end
+  end
+
+  describe 'node pages' do
+    it 'redirect to site changes page' do
+      get '/node/foobar'
+
+      expect(response).to redirect_to(site_changes_url)
+      expect(response).to have_http_status(:moved_permanently)
+    end
+  end
+
+  describe 'reply pages' do
+    it 'redirect to site changes page' do
+      get '/reply/foobar'
+
+      expect(response).to redirect_to(site_changes_url)
+      expect(response).to have_http_status(:moved_permanently)
+    end
+  end
+
+  describe 'comments pages' do
+    it 'redirect to site changes page' do
+      get '/comments/foobar'
+
+      expect(response).to redirect_to(site_changes_url)
+      expect(response).to have_http_status(:moved_permanently)
+    end
+  end
+
+  describe 'forum pages' do
+    it 'redirect to site changes page' do
+      get '/forum/foobar'
+
+      expect(response).to redirect_to(site_changes_url)
+      expect(response).to have_http_status(:moved_permanently)
+    end
+  end
+
+  describe 'issues pages' do
+    it 'redirect to site changes page' do
+      get '/dataset/issues/bar'
+
+      expect(response).to redirect_to(site_changes_url)
       expect(response).to have_http_status(:moved_permanently)
     end
   end


### PR DESCRIPTION
We have a page explaining the changes at /site-changes.

This PR makes sure we redirect the various retired urls to that page. 

https://trello.com/c/vvxfUcYY/268-redirects-for-retired-functionality