### PR TITLE
Redirect legacy forum page to /site-changes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
     get 'node/*_node',                     to: redirect('site-changes')
     get 'reply/*_reply',                   to: redirect('site-changes')
     get 'comments/*_comment',              to: redirect('site-changes')
+    get 'forum',                           to: redirect('site-changes')
     get 'forum/*_forum',                   to: redirect('site-changes')
     get 'dataset/*_slug/issues/*_issue',   to: redirect('site-changes')
   end

--- a/spec/requests/legacy/redirect_spec.rb
+++ b/spec/requests/legacy/redirect_spec.rb
@@ -172,7 +172,16 @@ describe 'legacy', :type => :request do
     end
   end
 
-  describe 'forum pages' do
+  describe 'forum home page' do
+    it 'redirect to site changes page' do
+      get '/forum'
+
+      expect(response).to redirect_to(site_changes_url)
+      expect(response).to have_http_status(:moved_permanently)
+    end
+  end
+
+  describe 'individual forum pages' do
     it 'redirect to site changes page' do
       get '/forum/foobar'
 


### PR DESCRIPTION
Redirect legacy forum page to /site-changes.

Part of https://trello.com/c/vvxfUcYY/268-redirects-for-retired-functionality.