### PR TITLE
Make Publisher sign in link absolute

### DIFF
--- a/app/views/pages/publishers.html.erb
+++ b/app/views/pages/publishers.html.erb
@@ -19,7 +19,7 @@
     </p>
 
     <p>
-      <%= link_to 'Sign in', '/user?destination=page/publisher-tools', role: 'button', class: 'button', rel: %w(nofollow) %>
+      <%= link_to 'Sign in', 'https://data.gov.uk/user?destination=page/publisher-tools', role: 'button', class: 'button', rel: %w(nofollow) %>
     </p>
 
     <div role="note" aria-label="Publisher information" class="panel panel-border-narrow text">


### PR DESCRIPTION
Allows it to work under beta.data.gov.uk domain.