### PR TITLE
Use 2 instances in production

### DIFF
--- a/production-manifest.yml
+++ b/production-manifest.yml
@@ -1,6 +1,7 @@
 ---
 applications:
 - name: find-data-beta
+  instances: 2
   memory: 256M
   buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.7.14
   routes:


### PR DESCRIPTION
PaaS support say that 2 instances should be enough considering our usage load.