### PR TITLE
Raven exclude exceptions

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -38,13 +38,5 @@ module FindDataBeta
     config.filter_parameters << :password_confirmation
 
     config.elasticsearch = config_for(:elasticsearch)
-
-    Raven.configure do |config|
-      if ENV['SENTRY_DSN']
-        config.dsn = ENV['SENTRY_DSN']
-      end
-
-      config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
-    end
   end
 end

--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -1,4 +1,5 @@
 Raven.configure do |config|
   config.dsn = ENV['SENTRY_DSN'] if ENV['SENTRY_DSN']
+  config.rails_report_rescued_exceptions = false
   config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
 end

--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -1,0 +1,4 @@
+Raven.configure do |config|
+  config.dsn = ENV['SENTRY_DSN'] if ENV['SENTRY_DSN']
+  config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
+end


### PR DESCRIPTION
These are handled by the exception app so we don't need to report them to Sentry.

Follow up to #462