### PR TITLE
Make `.ruby-version` the canonical Ruby version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ env:
 sudo: false
 language: ruby
 cache: bundler
-rvm:
-- 2.5
 branches:
   only:
   - master

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.5.0'
+ruby IO.read('.ruby-version').strip
 
 gem 'rails', '~> 5.1.5'
 gem 'pg', '~> 0.18'


### PR DESCRIPTION
Load the configured Ruby version via the `.ruby-version` file to ensure that is the single source of truth.

See https://docs.travis-ci.com/user/languages/ruby/#Using-.ruby-version