### PR TITLE
google analytics: custom dimensions

### DIFF
--- a/app/views/datasets/_datafile_table.html.erb
+++ b/app/views/datasets/_datafile_table.html.erb
@@ -11,7 +11,10 @@
         <td class="title small">
           <%= link_to (datafile.name ? datafile.name : 'Data Link'),
             datafile.url,
-            :data => {:'ga-event' => "datafile-download"},
+            :data => {
+              :'ga-event' => "datafile-download",
+              :'ga-format' => datafile.format.upcase.presence || 'N/A',
+            },
             :itemprop => "contentUrl"
           %>
         </td>

--- a/app/views/datasets/_datafile_table.html.erb
+++ b/app/views/datasets/_datafile_table.html.erb
@@ -13,7 +13,7 @@
             datafile.url,
             :data => {
               :'ga-datafile' => datafile.url,
-              :'ga-format' => datafile.format.upcase.presence || 'N/A',
+              :'ga-format' => (datafile.format.presence || 'n/a').upcase
             },
             :itemprop => "contentUrl"
           %>

--- a/app/views/datasets/_datafile_table.html.erb
+++ b/app/views/datasets/_datafile_table.html.erb
@@ -12,7 +12,7 @@
           <%= link_to (datafile.name ? datafile.name : 'Data Link'),
             datafile.url,
             :data => {
-              :'ga-event' => "datafile-download",
+              :'ga-datafile' => datafile.url,
               :'ga-format' => datafile.format.upcase.presence || 'N/A',
             },
             :itemprop => "contentUrl"

--- a/app/views/layouts/_analytics.html.erb
+++ b/app/views/layouts/_analytics.html.erb
@@ -8,7 +8,6 @@
     })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
     ga('create', trackingId, 'auto');
-    ga('send', 'pageview');
 
     $(document).ready(function() {
 
@@ -17,11 +16,17 @@
         ga('set', 'dimension4', publisherOrganisation)
       }
 
-      $('[data-ga-event]').on('click', function() {
+      $('[data-ga-datafile]').on('click', function() {
         var datafileFormat = $(this).data('ga-format')
+        var datafileURL = $(this).data('ga-datafile')
         ga('set', 'dimension5', datafileFormat)
-        var eventDetails = $(this).data('ga-event').split('-')
-        ga.apply(this, ['send', 'event'].concat(eventDetails))
+        ga('send', {
+            hitType: 'event',
+            eventCategory: 'datafile',
+            eventAction: 'download',
+            eventLabel: datafileURL
+          });
+        ga('send', 'pageview');
       })
     })
   </script>

--- a/app/views/layouts/_analytics.html.erb
+++ b/app/views/layouts/_analytics.html.erb
@@ -10,27 +10,25 @@
    ga('create', trackingId, 'auto');
 
    $(document).ready(function() {
-
-     $('[data-ga-datafile]').on('click', function() {
-       var datafileFormat = $(this).data('ga-format')
-       var datafileURL = $(this).data('ga-datafile')
-       var eventParams = {
-         hitType: 'event',
-         eventCategory: 'datafile',
-         eventAction: 'download',
-         eventLabel: datafileURL,
-         dimension5: datafileFormat
-       };
-
-       if ( document.location.pathname.includes('/dataset/')) {
-         eventParams.dimension4 = '<%= @dataset.organisation.title %>'
-       }
-
-       ga('send', eventParams)
-     });
-
-     ga('send', 'pageview')
-   })
+     if (document.location.pathname.includes('/dataset/')) {
+       var orgTitle = '<%= @dataset.organisation.title %>'
+       ga('send', 'pageview', { dimension4: orgTitle } )
+       $('[data-ga-datafile]').on('click', function() {
+         var datafileFormat = $(this).data('ga-format')
+         var datafileURL = $(this).data('ga-datafile')
+         var eventParams = {
+           hitType: 'event',
+           eventCategory: 'datafile',
+           eventAction: 'download',
+           eventLabel: datafileURL,
+           dimension4: orgTitle,
+           dimension5: datafileFormat
+         };
+         ga('send', eventParams)
+       });
+     } else {
+       ga('send', 'pageview')
+     }
    })
   </script>
 <% end %>

--- a/app/views/layouts/_analytics.html.erb
+++ b/app/views/layouts/_analytics.html.erb
@@ -11,7 +11,15 @@
     ga('send', 'pageview');
 
     $(document).ready(function() {
+
+      if ( document.location.pathname.includes('/dataset/')) {
+        var publisherOrganisation = '<%= @dataset.organisation.title %>'
+        ga('set', 'dimension4', publisherOrganisation)
+      }
+
       $('[data-ga-event]').on('click', function() {
+        var datafileFormat = $(this).data('ga-format')
+        ga('set', 'dimension5', datafileFormat)
         var eventDetails = $(this).data('ga-event').split('-')
         ga.apply(this, ['send', 'event'].concat(eventDetails))
       })

--- a/app/views/layouts/_analytics.html.erb
+++ b/app/views/layouts/_analytics.html.erb
@@ -10,8 +10,8 @@
    ga('create', trackingId, 'auto');
 
    $(document).ready(function() {
-     if (document.location.pathname.includes('/dataset/')) {
-       var orgTitle = '<%= @dataset.organisation.title %>'
+     if (document.location.pathname.indexOf('/dataset/') === 0) {
+       var orgTitle = '<% if @dataset %><%= @dataset.organisation.name %><% end %>'
        ga('send', 'pageview', { dimension4: orgTitle } )
        $('[data-ga-datafile]').on('click', function() {
          var datafileFormat = $(this).data('ga-format')

--- a/app/views/layouts/_analytics.html.erb
+++ b/app/views/layouts/_analytics.html.erb
@@ -1,33 +1,36 @@
 <% if (Rails.application.config.analytics_tracking_id.present? || Rails.application.config.analytics_test_tracking_id.present?) %>
   <script>
-    var trackingId = (document.location.hostname === 'beta.data.gov.uk') ? '<%= Rails.application.config.analytics_tracking_id %>' : '<%= Rails.application.config.analytics_test_tracking_id %>';
+   var trackingId = (document.location.hostname === 'beta.data.gov.uk') ? '<%= Rails.application.config.analytics_tracking_id %>' : '<%= Rails.application.config.analytics_test_tracking_id %>';
 
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+                            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+   })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-    ga('create', trackingId, 'auto');
+   ga('create', trackingId, 'auto');
 
-    $(document).ready(function() {
+   $(document).ready(function() {
 
-      if ( document.location.pathname.includes('/dataset/')) {
-        var publisherOrganisation = '<%= @dataset.organisation.title %>'
-        ga('set', 'dimension4', publisherOrganisation)
-      }
+     $('[data-ga-datafile]').on('click', function() {
+       var datafileFormat = $(this).data('ga-format')
+       var datafileURL = $(this).data('ga-datafile')
+       var eventParams = {
+         hitType: 'event',
+         eventCategory: 'datafile',
+         eventAction: 'download',
+         eventLabel: datafileURL,
+         dimension5: datafileFormat
+       };
 
-      $('[data-ga-datafile]').on('click', function() {
-        var datafileFormat = $(this).data('ga-format')
-        var datafileURL = $(this).data('ga-datafile')
-        ga('set', 'dimension5', datafileFormat)
-        ga('send', {
-            hitType: 'event',
-            eventCategory: 'datafile',
-            eventAction: 'download',
-            eventLabel: datafileURL
-          });
-        ga('send', 'pageview');
-      })
-    })
+       if ( document.location.pathname.includes('/dataset/')) {
+         eventParams.dimension4 = '<%= @dataset.organisation.title %>'
+       }
+
+       ga('send', eventParams)
+     });
+
+     ga('send', 'pageview')
+   })
+   })
   </script>
 <% end %>

--- a/app/views/layouts/_analytics.html.erb
+++ b/app/views/layouts/_analytics.html.erb
@@ -11,8 +11,8 @@
 
    $(document).ready(function() {
      if (document.location.pathname.indexOf('/dataset/') === 0) {
-       var orgTitle = '<% if @dataset %><%= @dataset.organisation.name %><% end %>'
-       ga('send', 'pageview', { dimension4: orgTitle } )
+       var orgName = '<% if @dataset %> <%= @dataset.organisation.name %> <% end %>'
+       ga('send', 'pageview', { dimension4: orgName } )
        $('[data-ga-datafile]').on('click', function() {
          var datafileFormat = $(this).data('ga-format')
          var datafileURL = $(this).data('ga-datafile')
@@ -21,7 +21,7 @@
            eventCategory: 'datafile',
            eventAction: 'download',
            eventLabel: datafileURL,
-           dimension4: orgTitle,
+           dimension4: orgName,
            dimension5: datafileFormat
          };
          ga('send', eventParams)


### PR DESCRIPTION
Trello cards: 
https://trello.com/c/wTEqxzQw/307-add-custom-dimension-tracking-to-google-analytics
https://trello.com/c/nTn5uCvf/293-add-event-label-for-download-ga-event-s

Add Google Analytics custom dimension tracking for:

- publisher organisation
- datafile format

Add Event Label to the datafile download event. The label is the datafile's URL.

