### PR TITLE
English query analysis

### DIFF
--- a/app/services/search/query.rb
+++ b/app/services/search/query.rb
@@ -191,6 +191,7 @@ module Search
         query[:query][:bool][:should] ||= []
         query[:query][:bool][:should] << organisation_category_filter('ministerial-department', boost: 2)
         query[:query][:bool][:should] << organisation_category_filter('non-ministerial-department', boost: 2)
+        query[:query][:bool][:should] << organisation_category_filter('executive-ndpb', boost: 2)
         query[:query][:bool][:should] << organisation_category_filter('local-council', boost: 1)
       end
 

--- a/app/services/search/query.rb
+++ b/app/services/search/query.rb
@@ -1,6 +1,7 @@
 module Search
   class Query
     MULTI_MATCH_FIELDS = %w(title summary description location*^2)
+    MULTI_MATCH_FIELDS_ENGLISH = %w(title.english^2 summary.english description.english)
     TERMS_SIZE = 10_000
 
     attr_accessor :clauses
@@ -320,8 +321,9 @@ module Search
           path: 'organisation',
           query: {
             match: {
-              "organisation.title" => {
+              "organisation.title.english" => {
                 query: organisation_title,
+                analyzer: 'english',
                 boost: boost,
               },
             },
@@ -349,7 +351,8 @@ module Search
       {
         multi_match: {
           query: terms,
-          fields: MULTI_MATCH_FIELDS,
+          fields: MULTI_MATCH_FIELDS_ENGLISH,
+          analyzer: 'english',
         }
       }
     end

--- a/spec/features/search_page_spec.rb
+++ b/spec/features/search_page_spec.rb
@@ -202,6 +202,30 @@ feature 'Search page', elasticsearch: true do
     )
   end
 
+  scenario 'Searching with a plural query' do
+    index(DatasetBuilder.new.with_title('Maps').build)
+
+    search_for('Map')
+
+    assert_search_results_headings('Maps')
+  end
+
+  scenario 'Search with a possessive query' do
+    index(DatasetBuilder.new.with_title('Government').build)
+
+    search_for("Government's")
+
+    assert_search_results_headings('Government')
+  end
+
+  scenario 'Search with lowercase query' do
+    index(DatasetBuilder.new.with_title('DEFRA').build)
+
+    search_for("defra")
+
+    assert_search_results_headings('DEFRA')
+  end
+
   scenario 'Prominence of datasets based on organisation category' do
     ministerial_dataset = DatasetBuilder
                             .new

--- a/spec/features/search_page_spec.rb
+++ b/spec/features/search_page_spec.rb
@@ -224,19 +224,37 @@ feature 'Search page', elasticsearch: true do
                               )
                               .build
 
-    index(ministerial_dataset, non_ministerial_dataset, local_council_dataset)
+    non_departmental_public_body_dataset = DatasetBuilder
+                                             .new
+                                             .with_non_departmental_public_body(
+                                               'English Heritage'
+                                             )
+                                             .build
+
+    index(
+      ministerial_dataset,
+      non_ministerial_dataset,
+      local_council_dataset,
+      non_departmental_public_body_dataset
+    )
 
     search_for('data')
 
     publishers = all('dd.published_by').map(&:text)
 
     expect(publishers[0]).to eq('Department for Environment Food & Rural Affairs')
-                               .or eq('Forestry Commission')
+                               .or eq('English Heritage')
+                                     .or eq('Forestry Commission')
 
     expect(publishers[1]).to eq('Department for Environment Food & Rural Affairs')
-                               .or eq('Forestry Commission')
+                               .or eq('English Heritage')
+                                     .or eq('Forestry Commission')
 
-    expect(publishers[2]).to eq('Plymouth City Council')
+    expect(publishers[2]).to eq('Department for Environment Food & Rural Affairs')
+                               .or eq('English Heritage')
+                                     .or eq('Forestry Commission')
+
+    expect(publishers[3]).to eq('Plymouth City Council')
   end
 
   def assert_data_set_length_is(count)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -86,6 +86,45 @@ def index_mappings
           type: "keyword",
           index: true,
         },
+        title: {
+          type: 'text',
+          fields: {
+            keyword: {
+              type: 'keyword',
+              index: true,
+            },
+            english: {
+              type: 'text',
+              analyzer: 'english',
+            },
+          },
+        },
+        summary: {
+          type: 'text',
+          fields: {
+            keyword: {
+              type: 'keyword',
+              index: true,
+            },
+            english: {
+              type: 'text',
+              analyzer: 'english',
+            },
+          },
+        },
+        description: {
+          type: 'text',
+          fields: {
+            keyword: {
+              type: 'keyword',
+              index: true,
+            },
+            english: {
+              type: 'text',
+              analyzer: 'english',
+            },
+          },
+        },
         legacy_name: {
           type: "keyword",
           index: true,
@@ -126,9 +165,26 @@ def index_mappings
                 raw: {
                   type: "keyword",
                   index: true,
+                },
+                english: {
+                  type: 'text',
+                  analyzer: 'english',
                 }
               }
-            }
+            },
+            description: {
+              type: 'text',
+              fields: {
+                raw: {
+                  type: 'keyword',
+                  index: true,
+                },
+                english: {
+                  type: 'text',
+                  analyzer: 'english',
+                },
+              },
+            },
           }
         },
         datafiles: {

--- a/spec/support/dataset_spec_builder.rb
+++ b/spec/support/dataset_spec_builder.rb
@@ -138,6 +138,13 @@ class DatasetBuilder
     self
   end
 
+  def with_non_departmental_public_body(non_departmental_public_body)
+    @dataset[:organisation][:name] = non_departmental_public_body
+    @dataset[:organisation][:title] = non_departmental_public_body
+    @dataset[:organisation][:category] = 'executive-ndpb'
+    self
+  end
+
   def with_licence(licence)
     @dataset[:licence] = licence
     self


### PR DESCRIPTION
This switches the analyser used for search queries to one that understands the English language.

Doing so means that “tree in Birmingham”, “trees in birmingham”, “tree birmingham”, “trees birmingham”, “Birmingham's trees”, are all treated the same.

See https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-lang-analyzer.html#english-analyzer

Paired with @laurentqro 
Requires https://github.com/alphagov/datagovuk_publish/tree/v1.4.0
Trello https://trello.com/c/EwF9fPiJ