### PR TITLE
Render custom message when user coming from legacy after dataset creation

### DIFF
--- a/app/views/datasets/_additional_info.html.erb
+++ b/app/views/datasets/_additional_info.html.erb
@@ -61,23 +61,6 @@
               <dd><%= i['metadata_language'] %></dd>
             <% end %>
           </dl>
-
-          <!--
-               Missing: (from https://data.gov.uk/dataset/lidar-for-scotland-phase-i)
-             - theme
-             - harvest URL
-             - harvest date
-             - Access constraints
-             - import source
-             - themes (secondary)
-             - temporal coverage
-             - schema/vocabulary
-             - code list
-             - service level
-             - coupled services
-             -->
-
-
         </div>
       </details>
     <% end %>

--- a/app/views/legacy/datasets/available_soon.html.erb
+++ b/app/views/legacy/datasets/available_soon.html.erb
@@ -1,0 +1,16 @@
+<% content_for :page_title do %>
+  Available Soon
+<% end %>
+
+<main role="main" id="content">
+  <div>
+    <div class="grid-row">
+      <div class="column-full">
+        <section class="dgu-datalinks">
+          <h2 class="heading-medium">Available Soon</h2>
+          <p>Your dataset</p>
+        </section>
+      </div>
+    </div>
+  </div>
+</main>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,10 @@ Rails.application.routes.draw do
   get 'dataset/:uuid', to: 'datasets#show', uuid: /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/
 
   scope module: 'legacy' do
+    get 'dataset/:legacy_name',
+        to: 'datasets#available_soon',
+        constraints: lambda { |req| req.referrer.present? && URI.parse(req.referrer).path == '/dataset/new' }
+
     get 'dataset/:legacy_name',                                 to: 'datasets#redirect'
     get 'dataset/:legacy_dataset_name/resource/:datafile_uuid', to: 'datafiles#redirect'
 

--- a/spec/requests/legacy/dataset_creation_spec.rb
+++ b/spec/requests/legacy/dataset_creation_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+describe 'legacy', type: :request do
+  describe 'dataset creation' do
+    it 'shows a page informing the user the newly created dataset will be available soon' do
+      get '/dataset/foo-bar', params: {}, headers: { 'HTTP_REFERER' => "http://foobar.com/dataset/new" }
+
+      expect(response.body).to include("Available Soon")
+    end
+  end
+end


### PR DESCRIPTION
When a user creates a new dataset on legacy, they are redirected to the corresponding dataset page on Find.

However, because legacy -> Find sync is not instantaneous and we cannot modify legacy, we render a page informing the user their dataset will be available for view soon.

https://trello.com/c/A1LTiZQS/316-display-a-message-to-publishers-after-dataset-creation-m