### PR TITLE
Replace text area with text field

### DIFF
--- a/app/views/tickets/new.html.erb
+++ b/app/views/tickets/new.html.erb
@@ -55,10 +55,9 @@
               <span class="error-message">Enter a name</span>
             <% end %>
           </label>
-          <%= f.text_area(:name,
+          <%= f.text_field(:name,
                           class: input_box_class_for(@ticket, :name),
-                          id: "example-name",
-                          rows: 1 ) %>
+                          id: "example-name") %>
         </div>
         <div class="form-group <% if @ticket.errors[:email].any? %> form-group-error <% end %>" >
           <label for="example-email" id="error-email">
@@ -67,11 +66,9 @@
               <span class="error-message">Enter a valid email address</span>
             <% end %>
           </label>
-          <span class="form-hint">We'll only use this to reply to your message.</span>
-          <%= f.text_area(:email,
+          <%= f.text_field(:email,
                           class: input_box_class_for(@ticket, :email),
-                          id: "example-email",
-                          rows: 1 ) %>
+                          id: "example-email") %>
         </div>
         <%= f.hidden_field(:support, :value => @support_queue) %>
           <%= f.submit "Submit", class: "button dgu-support__button" %>


### PR DESCRIPTION
Text areas are resizeable, which is not an intended behaviour for name and email fields.