### PR TITLE
Add hint to email tickets form field

### DIFF
--- a/app/views/tickets/new.html.erb
+++ b/app/views/tickets/new.html.erb
@@ -66,6 +66,7 @@
               <span class="error-message">Enter a valid email address</span>
             <% end %>
           </label>
+          <span class="form-hint">We'll only use this to reply to your message.</span>
           <%= f.text_area(:email,
                           class: input_box_class_for(@ticket, :email),
                           id: "example-email",


### PR DESCRIPTION
https://trello.com/c/216mDC7l/250-add-sentence-about-data-use-on-support-form-s

![screen shot 2018-03-16 at 3 12 27 pm](https://user-images.githubusercontent.com/3141541/37528432-8aaaa158-292c-11e8-91ef-f1e4fb04fd1d.png)

> Hint text
don’t use placeholder text in form fields, as this will disappear once content is entered into the form field
use hint text for supporting contextual help, this will always be shown
hint text should sit above a form field
ensure hint text can be read correctly by screen readers

http://govuk-elements.herokuapp.com/form-elements/#form-fields