### PR TITLE
Fix: add valid ARIA roles for breadcrumbs

### DIFF
--- a/app/views/datasets/_breadcrumb.html.erb
+++ b/app/views/datasets/_breadcrumb.html.erb
@@ -3,7 +3,7 @@
     <!-- Only display breadcrumb if the referrer host matches the application host  -->
     <div class="column-full">
       <div class="datagov_breadcrumb">
-        <ol role="breadcrumb">
+        <nav aria-label="Breadcrumb">
           <li>
             <%= link_to t('.home'), root_path %>
           </li>
@@ -14,10 +14,10 @@
               <%= link_to t('.search'), "/search?#{@referrer}" %>
             <% end %>
           </li>
-          <li>
+          <li aria-current="page">
             <%= shorten_title(@dataset.title) %>
           </li>
-        </ol>
+        </nav>
       </div>
     </div>
   </div>

--- a/app/views/tickets/new.html.erb
+++ b/app/views/tickets/new.html.erb
@@ -7,12 +7,13 @@
     <div class="column-full">
 
       <div class="datagov_breadcrumb">
-        <ol role="breadcrumb">
+        <nav aria-label="Breadcrumb">
           <li>
             <%= link_to 'Back', support_path %>
           </li>
-        </ol>
+        </nav>
       </div>
+
       <% if @ticket.errors.any? %>
         <div class="error-summary" role="alert" aria-labelledby="error-summary-heading">
           <h2 class="heading-medium error-summary-heading" id="error-summary-heading">


### PR DESCRIPTION
This came up in automated accessibility testing on dataset page:

```
<ol role="breadcrumb"> <li> <a href="/">Home</a>
</li> <li> <a href="/search?">Search</a> </li>
```

https://trello.com/c/BuhLtrXU/241-fix-role-must-be-one-of-the-valid-aria-roles-rolebreadcrumb