### PR TITLE
Fix contact details bug

### DIFF
--- a/app/helpers/datasets_helper.rb
+++ b/app/helpers/datasets_helper.rb
@@ -108,6 +108,6 @@ module DatasetsHelper
   end
 
   def foi_web_address_for(dataset)
-    dataset.foi_web.presence || dataset.organisation.foi_web.presence
+    (dataset.foi_web.presence || dataset.organisation.foi_web.presence).to_s
   end
 end

--- a/app/views/datasets/_contact.html.erb
+++ b/app/views/datasets/_contact.html.erb
@@ -25,7 +25,7 @@
       <p>
         <span><%= foi_name_for(dataset) %></span>
         <span><%= mail_to(foi_email_for(dataset)) %></span>
-        <span><%= link_to(foi_web_address_for(dataset),foi_web_address_for(dataset)) %></span>
+        <span><%= link_to(foi_web_address_for(dataset), foi_web_address_for(dataset)) %></span>
       </p>
     </div>
   <% end %>


### PR DESCRIPTION
When neither the dataset nor the organisation have an FOI web address, we end up with `link_to(nil, nil)` which - strangely enough - gives us:

![screen shot 2018-03-16 at 5 23 32 pm](https://user-images.githubusercontent.com/3141541/37535327-4aefea60-293f-11e8-8412-fd8b437c4679.png)
