### PR TITLE
gem update --system in Travis before_install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ services:
 - elasticsearch
 addons:
   chrome: stable
+before_install:
+- gem update --system
 before_script:
 - sleep 10
 - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64


### PR DESCRIPTION
`gem update --system` in Travis `before_install`.

Fixes this error on Travis CI:

```
bundler: failed to load command: rake (/home/travis/build/alphagov/datagovuk_find/vendor/bundle/ruby/2.5.0/bin/rake)
LoadError: cannot load such file -- bundler/dep_proxy
```

Documented issue: https://github.com/travis-ci/travis-ci/issues/8978