### PR TITLE
Attempt at fixing flaky elastic search query relevance test

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -67,6 +67,7 @@ end
 
 def index_settings
   {
+    number_of_shards: 1, # necessary so our relevance specs work (more info: https://www.elastic.co/guide/en/elasticsearch/guide/current/relevance-is-broken.html)
     analysis: {
       normalizer: {
         lowercase_normalizer: {


### PR DESCRIPTION
Make sure we set the index to use one and one only primary shard, to avoid scoring getting skewed by inverse document frequency.

More info: https://www.elastic.co/guide/en/elasticsearch/guide/current/relevance-is-broken.html