### PR TITLE
google analytics - tracking contact detail clicks and service name

### DIFF
--- a/app/views/datasets/_contact.html.erb
+++ b/app/views/datasets/_contact.html.erb
@@ -11,7 +11,7 @@
 
       <p>
         <span><%= contact_name_for(dataset) %></span>
-        <span><%= mail_to(contact_email_for(dataset)) %></span>
+        <span><%= mail_to(contact_email_for(dataset), nil, {class: 'ga-contact'}) %></span>
       </p>
     </div>
   <% end %>
@@ -24,8 +24,13 @@
 
       <p>
         <span><%= foi_name_for(dataset) %></span>
-        <span><%= mail_to(foi_email_for(dataset)) %></span>
-        <span><%= link_to(foi_web_address_for(dataset), foi_web_address_for(dataset)) %></span>
+        <span><%= mail_to(foi_email_for(dataset), nil, {class: 'ga-contact'}) %></span>
+        <span>
+          <%= link_to(foi_web_address_for(dataset),
+              foi_web_address_for(dataset),
+              {class: 'ga-contact'})
+          %>
+        </span>
       </p>
     </div>
   <% end %>

--- a/app/views/datasets/show.html.erb
+++ b/app/views/datasets/show.html.erb
@@ -2,6 +2,10 @@
   <%= @dataset.title %> -
 <% end %>
 
+<% content_for :body_end do %>
+  <%= render partial: 'layouts/dataset_analytics' %>
+<% end %>
+
 <main role="main" id="content">
   <%= render partial: 'layouts/feedback_survey_banner' if flash[:beta_message] == 'hide'%>
   <%= render "breadcrumb" %>

--- a/app/views/layouts/_analytics.html.erb
+++ b/app/views/layouts/_analytics.html.erb
@@ -13,13 +13,13 @@
      if (document.location.pathname.indexOf('/dataset/') === 0) {
        sendDatasetPageAnalytics()
      } else {
-       ga('send', 'pageview')
+       ga('send', 'pageview', { dimension11: 'find-open-data'})
      }
    });
 
    function sendDatasetPageAnalytics(){
      var orgName = '<% if @dataset %> <%= @dataset.organisation.name %> <% end %>'
-     ga('send', 'pageview', { dimension4: orgName } )
+     ga('send', 'pageview', { dimension4: orgName, dimension11: 'find-open-data' } )
      sendDatafileDownloadAnalytics(orgName)
      sendContactDetailAnalytics(orgName)
    };

--- a/app/views/layouts/_analytics.html.erb
+++ b/app/views/layouts/_analytics.html.erb
@@ -5,24 +5,24 @@
    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
                             m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-   })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+   })(window,document,'script','https://www.google-analytics.com/analytics.js','ga')
 
-   ga('create', trackingId, 'auto');
+   ga('create', trackingId, 'auto')
 
    $(document).ready(function() {
      if (document.location.pathname.indexOf('/dataset/') === 0) {
-       sendDatasetPageAnalytics()
+      var orgName = '<% if @dataset %> <%= @dataset.organisation.name %> <% end %>'
+      sendDatasetPageAnalytics(orgName)
      } else {
        ga('send', 'pageview', { dimension11: 'find-open-data'})
      }
-   });
+   })
 
-   function sendDatasetPageAnalytics(){
-     var orgName = '<% if @dataset %> <%= @dataset.organisation.name %> <% end %>'
+   function sendDatasetPageAnalytics(orgName){
      ga('send', 'pageview', { dimension4: orgName, dimension11: 'find-open-data' } )
      sendDatafileDownloadAnalytics(orgName)
      sendContactDetailAnalytics(orgName)
-   };
+   }
 
    function sendDatafileDownloadAnalytics(orgName){
      $('[data-ga-datafile]').on('click', function() {
@@ -35,21 +35,22 @@
          eventLabel: datafileURL,
          dimension4: orgName,
          dimension5: datafileFormat
-       };
+       }
        ga('send', eventParams)
      })
    }
 
    function sendContactDetailAnalytics(orgName){
-     $('.ga-contact').on('click', function(orgName){
+     $('.ga-contact').on('click', function(){
        var eventParams = {
          hitType: 'event',
          eventCategory: 'contact-details',
-         eventAction: 'mail_to',
+         eventAction: 'click',
          eventLabel: orgName
-       };
+       }
        ga('send', eventParams)
      })
+
    }
 
   </script>

--- a/app/views/layouts/_analytics.html.erb
+++ b/app/views/layouts/_analytics.html.erb
@@ -11,24 +11,33 @@
 
    $(document).ready(function() {
      if (document.location.pathname.indexOf('/dataset/') === 0) {
-       var orgName = '<% if @dataset %> <%= @dataset.organisation.name %> <% end %>'
-       ga('send', 'pageview', { dimension4: orgName } )
-       $('[data-ga-datafile]').on('click', function() {
-         var datafileFormat = $(this).data('ga-format')
-         var datafileURL = $(this).data('ga-datafile')
-         var eventParams = {
-           hitType: 'event',
-           eventCategory: 'datafile',
-           eventAction: 'download',
-           eventLabel: datafileURL,
-           dimension4: orgName,
-           dimension5: datafileFormat
-         };
-         ga('send', eventParams)
-       });
+       sendDatasetPageAnalytics()
      } else {
        ga('send', 'pageview')
      }
-   })
+   });
+
+   function sendDatasetPageAnalytics(){
+     var orgName = '<% if @dataset %> <%= @dataset.organisation.name %> <% end %>'
+     ga('send', 'pageview', { dimension4: orgName } )
+     sendDatafileDownloadAnalytics(orgName)
+   };
+
+   function sendDatafileDownloadAnalytics(orgName){
+     $('[data-ga-datafile]').on('click', function() {
+       var datafileFormat = $(this).data('ga-format')
+       var datafileURL = $(this).data('ga-datafile')
+       var eventParams = {
+         hitType: 'event',
+         eventCategory: 'datafile',
+         eventAction: 'download',
+         eventLabel: datafileURL,
+         dimension4: orgName,
+         dimension5: datafileFormat
+       };
+       ga('send', eventParams)
+     })
+   }
+
   </script>
 <% end %>

--- a/app/views/layouts/_analytics.html.erb
+++ b/app/views/layouts/_analytics.html.erb
@@ -8,50 +8,11 @@
    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga')
 
    ga('create', trackingId, 'auto')
+   var dimensions = {}
 
    $(document).ready(function() {
-     if (document.location.pathname.indexOf('/dataset/') === 0) {
-      var orgName = '<% if @dataset %> <%= @dataset.organisation.name %> <% end %>'
-      sendDatasetPageAnalytics(orgName)
-     } else {
-       ga('send', 'pageview', { dimension11: 'find-open-data'})
-     }
+     dimensions['dimension11'] = 'find-open-data'
+     ga('send', 'pageview', dimensions)
    })
-
-   function sendDatasetPageAnalytics(orgName){
-     ga('send', 'pageview', { dimension4: orgName, dimension11: 'find-open-data' } )
-     sendDatafileDownloadAnalytics(orgName)
-     sendContactDetailAnalytics(orgName)
-   }
-
-   function sendDatafileDownloadAnalytics(orgName){
-     $('[data-ga-datafile]').on('click', function() {
-       var datafileFormat = $(this).data('ga-format')
-       var datafileURL = $(this).data('ga-datafile')
-       var eventParams = {
-         hitType: 'event',
-         eventCategory: 'datafile',
-         eventAction: 'download',
-         eventLabel: datafileURL,
-         dimension4: orgName,
-         dimension5: datafileFormat
-       }
-       ga('send', eventParams)
-     })
-   }
-
-   function sendContactDetailAnalytics(orgName){
-     $('.ga-contact').on('click', function(){
-       var eventParams = {
-         hitType: 'event',
-         eventCategory: 'contact-details',
-         eventAction: 'click',
-         eventLabel: orgName
-       }
-       ga('send', eventParams)
-     })
-
-   }
-
   </script>
 <% end %>

--- a/app/views/layouts/_analytics.html.erb
+++ b/app/views/layouts/_analytics.html.erb
@@ -21,6 +21,7 @@
      var orgName = '<% if @dataset %> <%= @dataset.organisation.name %> <% end %>'
      ga('send', 'pageview', { dimension4: orgName } )
      sendDatafileDownloadAnalytics(orgName)
+     sendContactDetailAnalytics(orgName)
    };
 
    function sendDatafileDownloadAnalytics(orgName){
@@ -34,6 +35,18 @@
          eventLabel: datafileURL,
          dimension4: orgName,
          dimension5: datafileFormat
+       };
+       ga('send', eventParams)
+     })
+   }
+
+   function sendContactDetailAnalytics(orgName){
+     $('.ga-contact').on('click', function(orgName){
+       var eventParams = {
+         hitType: 'event',
+         eventCategory: 'contact-details',
+         eventAction: 'mail_to',
+         eventLabel: orgName
        };
        ga('send', eventParams)
      })

--- a/app/views/layouts/_dataset_analytics.html.erb
+++ b/app/views/layouts/_dataset_analytics.html.erb
@@ -1,0 +1,41 @@
+<% if (Rails.application.config.analytics_tracking_id.present? || Rails.application.config.analytics_test_tracking_id.present?) %>
+  <script>
+     $(document).ready(function() {
+       var orgName = '<%= @dataset.organisation.name %>'
+       dimensions['dimension4'] = orgName
+       sendDatafileDownloadAnalytics(orgName)
+       sendContactDetailAnalytics(orgName)
+      })
+
+     function sendDatafileDownloadAnalytics(orgName){
+       $('[data-ga-datafile]').on('click', function() {
+         var datafileFormat = $(this).data('ga-format')
+         var datafileURL = $(this).data('ga-datafile')
+         var eventParams = {
+           hitType: 'event',
+           eventCategory: 'datafile',
+           eventAction: 'download',
+           eventLabel: datafileURL,
+           dimension4: orgName,
+           dimension5: datafileFormat,
+           dimension11: 'find-open-data'
+         }
+         ga('send', eventParams)
+       })
+     }
+
+     function sendContactDetailAnalytics(orgName){
+       $('.ga-contact').on('click', function(){
+         var eventParams = {
+           hitType: 'event',
+           eventCategory: 'contact-details',
+           eventAction: 'click',
+           eventLabel: orgName,
+           dimension4: orgName,
+           dimension11: 'find-open-data'
+         }
+         ga('send', eventParams)
+       })
+     }
+    </script>
+  <% end %>


### PR DESCRIPTION
Trello tickets: [#315](https://trello.com/c/MucptC0M/315-add-new-custom-dimension-for-tracking-visits-to-legacy-vs-find) and [#292](https://trello.com/c/kbHrvsGR/292-add-ga-event-tracking-to-publisher-contact-links-s)

This PR:
- adds custom dimension 11 (service_name) to all page views
- adds an event tracker to clicks on contact details, with an event label that is the organisation name. 
<img width="514" alt="screen shot 2018-03-20 at 14 47 04" src="https://user-images.githubusercontent.com/17908089/37661910-bb71b56e-2c4d-11e8-90a3-b4bdf8e60933.png">
<img width="457" alt="screen shot 2018-03-20 at 14 46 14" src="https://user-images.githubusercontent.com/17908089/37661911-bb87e460-2c4d-11e8-9a2f-4dd9745db2b9.png">




