### PR TITLE
Bump Loofah gem from 2.2.0 -> 2.2.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -220,7 +220,7 @@ GEM
       railties (>= 4, < 5.2)
       request_store (~> 1.0)
     logstash-event (1.2.02)
-    loofah (2.2.0)
+    loofah (2.2.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     lumberjack (1.0.12)


### PR DESCRIPTION
2.2.0 has a security vulnerability. Bumping to patch 

`bundle update loofah --patch`