### PR TITLE
add form hint to the email address field on support page

### DIFF
--- a/app/views/tickets/confirmation.html.erb
+++ b/app/views/tickets/confirmation.html.erb
@@ -1,12 +1,12 @@
 <main role="main" id="content">
   <div class="grid-row inner">
     <div class="column-two-thirds">
-      <h1 class='heading-large'>Thanks for contacting data.gov.uk</h1>
+      <h1 class='heading-large'><%= t('.thanks_for_contacting') %></h1>
       <p>
-        Data.gov.uk is built and supported by a team here to help you at the Government Digital Service.
+        <%= t('.built_by_gds') %>
       </p>
       <p>
-        GDS provides operational support from 9am to 5pm, Monday to Friday.
+        <%= t('.operational_support') %>
       </p>
       <%= link_to 'Go back to support', support_path %>
     </div>

--- a/app/views/tickets/new.html.erb
+++ b/app/views/tickets/new.html.erb
@@ -17,7 +17,7 @@
       <% if @ticket.errors.any? %>
         <div class="error-summary" role="alert" aria-labelledby="error-summary-heading">
           <h2 class="heading-medium error-summary-heading" id="error-summary-heading">
-            There was a problem
+            <%= t('.problem')%>
           </h2>
           <ul class="error-summary-list">
             <% @ticket.errors.messages.each do |attr, error| %>
@@ -29,18 +29,18 @@
 
       <h1 class='heading-medium'>
         <% if @support_queue == 'data'%>
-          Send a data request
+          <%= t('.send_data_request') %>
         <% else %>
-          Report a problem or give feedback
+          <%= t('.report_a_problem') %>
         <% end %>
       </h1>
 
       <%= form_for @ticket, url: { action: "create", controller: "tickets" } do |f| %>
         <div class="form-group <% if @ticket.errors[:content].any? %> form-group-error <% end %>">
           <label for="example-content" id="error-content">
-            <span class="form-label dgu-support__form-label">Your message</span>
+            <span class="form-label dgu-support__form-label"><%= t('.your_message') %></span>
             <% if @ticket.errors[:content].any? %>
-              <span class="error-message">Enter a message</span>
+              <span class="error-message"><%= t('.enter_a_message') %></span>
             <% end %>
           </label>
           <%= f.text_area(:content,
@@ -50,9 +50,9 @@
         </div>
         <div class="form-group <% if @ticket.errors[:name].any? %> form-group-error <% end %>">
           <label for="example-name" id="error-name">
-            <span class="form-label dgu-support__form-label">Name</span>
+            <span class="form-label dgu-support__form-label"><%= t('.name') %></span>
             <% if @ticket.errors[:name].any? %>
-              <span class="error-message">Enter a name</span>
+              <span class="error-message"><%= t('.enter_a_name') %></span>
             <% end %>
           </label>
           <%= f.text_field(:name,
@@ -61,18 +61,18 @@
         </div>
         <div class="form-group <% if @ticket.errors[:email].any? %> form-group-error <% end %>" >
           <label for="example-email" id="error-email">
-            <span class="form-label dgu-support__form-label">Email address</span>
+            <span class="form-label dgu-support__form-label"><%= t('.email_address') %></span>
             <% if @ticket.errors[:email].any? %>
-              <span class="error-message">Enter a valid email address</span>
+              <span class="error-message"><%= t('.enter_an_email') %></span>
             <% end %>
           </label>
-          <span class="form-hint">We'll only use this to reply to your message.</span>
+          <span class="form-hint"><%= t('.use_this_to_reply') %></span>
           <%= f.text_field(:email,
                           class: input_box_class_for(@ticket, :email),
                           id: "example-email") %>
         </div>
         <%= f.hidden_field(:support, :value => @support_queue) %>
-          <%= f.submit "Submit", class: "button dgu-support__button" %>
+          <%= f.submit t('.submit'), class: "button dgu-support__button" %>
       <% end %>
     </div>
   </div>

--- a/app/views/tickets/new.html.erb
+++ b/app/views/tickets/new.html.erb
@@ -66,6 +66,7 @@
               <span class="error-message">Enter a valid email address</span>
             <% end %>
           </label>
+          <span class="form-hint">We'll only use this to reply to your message.</span>
           <%= f.text_field(:email,
                           class: input_box_class_for(@ticket, :email),
                           id: "example-email") %>

--- a/config/locales/views/datasets/en.yml
+++ b/config/locales/views/datasets/en.yml
@@ -64,7 +64,7 @@ en:
     show:
       open_all: "Open all"
       data_links: "Data links"
-      not_released: "This data hasn't been released by the publisher."
+      not_released: "This data hasn’t been released by the publisher."
       contact_the_publisher: "Contact the publisher for more information."
       contact_the_team: "Contact the team on"
       if_you_have_questions: "if you have any questions."

--- a/config/locales/views/tickets/en.yml
+++ b/config/locales/views/tickets/en.yml
@@ -1,0 +1,18 @@
+en:
+  tickets:
+    new:
+      problem: "There was a problem"
+      send_data_request: "Send a data request"
+      report_a_problem: "Report a problem or give feedback"
+      your_message: "Your message"
+      enter_a_message: "Enter a message"
+      name: "Name"
+      enter_a_name: "Enter a name"
+      email_address: "Email address"
+      enter_an_email: "Enter a valid email address"
+      use_this_to_reply: "We’ll only use this to reply to your message."
+      submit: "Submit"
+    confirmation:
+      thanks_for_contacting: "Thanks for contacting data.gov.uk"
+      built_by_gds: "Data.gov.uk is built and supported by a team here to help you at the Government Digital Service."
+      operational_support: "GDS provides operational support from 9am to 5pm, Monday to Friday."

--- a/spec/features/dataset_show_page_spec.rb
+++ b/spec/features/dataset_show_page_spec.rb
@@ -66,7 +66,7 @@ feature 'Dataset page', elasticsearch: true do
 
       index_and_visit(dataset)
 
-      expect(page).to have_content("This data hasn't been released by the publisher.")
+      expect(page).to have_content("This data hasn’t been released by the publisher.")
     end
 
     scenario 'display if some information is missing' do


### PR DESCRIPTION
Ticket [#250](https://trello.com/c/216mDC7l/250-add-sentence-about-data-use-on-support-form-s) 

<img width="640" alt="screen shot 2018-03-21 at 15 06 04" src="https://user-images.githubusercontent.com/17908089/37717903-68ae8f38-2d19-11e8-869f-6a97b280ea99.png">
