### PR TITLE
Zendesk error logging

### DIFF
--- a/config/initializers/zendesk.rb
+++ b/config/initializers/zendesk.rb
@@ -5,18 +5,15 @@ def zendesk_config_from_vcap
   begin
     vcap = JSON.parse(ENV["VCAP_SERVICES"])
     vcap['user-provided'].each do |elem|
-      if (elem.has_key? 'credentials') && (elem['credentials'].has_key? 'ZENDESK_USERNAME')
-        zendesk_config["username"] = elem['credentials']['ZENDESK_USERNAME']
-        zendesk_config["password"] = elem['credentials']['ZENDESK_PASSWORD']
-        zendesk_config["api_key"] = elem['credentials']['ZENDESK_API_KEY']
-        zendesk_config["end_point"] = elem['credentials']['ZENDESK_END_POINT']
-      end
+      zendesk_config["username"] = elem['credentials']['ZENDESK_USERNAME']
+      zendesk_config["password"] = elem['credentials']['ZENDESK_PASSWORD']
+      zendesk_config["api_key"] = elem['credentials']['ZENDESK_API_KEY']
+      zendesk_config["end_point"] = elem['credentials']['ZENDESK_END_POINT']
     end
   rescue => e
-    Rails.logger.fatal 'Failed to extract zendesk creds from VCAP_SERVICES. Exiting'
-    Rails.logger.fatal vcap
-    Rails.logger.fatal e
-    raise e
+    Rails.logger.info "Failed to extract zendesk creds from VCAP_SERVICES. RAILS_ENV = #{ENV['RAILS_ENV']}"
+    Rails.logger.info "VCAP_SERVICES: '#{vcap}'"
+    Rails.logger.info "ERROR --> '#{e}'"
   end
   zendesk_config
 end
@@ -31,12 +28,19 @@ def build_zendesk_client(username, password, api_key, end_point)
 end
 
 if Rails.env.production?
-  config = zendesk_config_from_vcap
-  username = config['username']
-  password = config['password']
-  api_key = config['api_key']
-  end_point = config['end_point']
-  GDS_ZENDESK_CLIENT = build_zendesk_client(username, password, api_key, end_point)
+  begin
+    config = zendesk_config_from_vcap
+    username = config['username']
+    password = config['password']
+    api_key = config['api_key']
+    end_point = config['end_point']
+    GDS_ZENDESK_CLIENT = build_zendesk_client(username, password, api_key, end_point)
+  rescue => e
+    Rails.logger.info "Failed to initialise zendesk client. Using dummy client"
+    Rails.logger.info "zendesk config = '#{config}'"
+    Rails.logger.info "ERROR --> '#{e}'"
+    GDS_ZENDESK_CLIENT = ZendeskDummyClient.new
+  end
 end
 
 if Rails.env.test?


### PR DESCRIPTION
- The zendesk client is used to send support tickets in a production environment. In staging and development a dummy client is initialised instead. 

- Because our review apps have a production environment, they are blowing up if the zendesk credentials aren't available. 

- This PR raises an error if the zendesk creds aren't available, but instead of blowing up a dummy client is used instead. 
