### PR TITLE
Make page titles targets of jump-to-content links

### DIFF
--- a/app/views/datasets/_meta_data.html.erb
+++ b/app/views/datasets/_meta_data.html.erb
@@ -8,7 +8,7 @@
 <section class="meta-data">
   <div class="grid-row">
     <div class="column-two-thirds">
-      <h1 class="heading-large" itemprop="name" property="dc:title">
+      <h1 tabindex="-1" id="content" class="heading-large" itemprop="name" property="dc:title">
         <%= unescape(@dataset.title) %>
       </h1>
     </div>

--- a/app/views/datasets/show.html.erb
+++ b/app/views/datasets/show.html.erb
@@ -2,7 +2,7 @@
   <%= @dataset.title %> -
 <% end %>
 
-<main role="main" id="content">
+<main role="main">
   <%= render partial: 'layouts/feedback_survey_banner' if flash[:beta_message] == 'hide'%>
   <%= render "breadcrumb" %>
   <div itemscope itemtype="http://schema.org/Dataset">

--- a/app/views/errors/internal_server_error.en.html.erb
+++ b/app/views/errors/internal_server_error.en.html.erb
@@ -2,10 +2,10 @@
   Service unavailable -
 <% end %>
 
-<main id="content" role="main">
+<main role="main">
   <div class="grid-row">
     <div class="column-two-thirds">
-      <h1 class="heading-large">Service unavailable</h1>
+      <h1 tabindex="-1" id="content" class="heading-large">Service unavailable</h1>
       <p>Sorry you can't use this service because of a technical problem.</p>
       <p>We're working on a fix. Please try again later.</p>
     </div>

--- a/app/views/errors/not_found.en.html.erb
+++ b/app/views/errors/not_found.en.html.erb
@@ -2,10 +2,10 @@
   Page not found -
 <% end %>
 
-<main id="content" role="main">
+<main role="main">
   <div class="grid-row">
     <div class="column-two-thirds">
-      <h1 class="heading-large">Page not found</h1>
+      <h1 tabindex="-1" id="content" class="heading-large">Page not found</h1>
       <p>If you entered a web address, please check it's correct.</p>
       <p>You can also find government data by either:</p>
       <div>

--- a/app/views/layouts/search.html.erb
+++ b/app/views/layouts/search.html.erb
@@ -21,7 +21,7 @@
     <%= render 'layouts/staging_ribbon' if Rails.env.staging? %>
     <%= render 'layouts/beta_message' if flash[:beta_message] == 'show' %>
       <div class="dgu-beta__message--<%=flash[:beta_message] %>">
-        <main role="main" id="content">
+        <main role="main">
           <%= yield %>
         </main>
       </div>

--- a/app/views/legacy/datasets/available_soon.html.erb
+++ b/app/views/legacy/datasets/available_soon.html.erb
@@ -2,7 +2,7 @@
   Available Soon
 <% end %>
 
-<main role="main" id="content">
+<main role="main">
   <div>
     <div class="grid-row">
       <div class="column-full">

--- a/app/views/pages/_search.html.erb
+++ b/app/views/pages/_search.html.erb
@@ -4,7 +4,7 @@
     <div class="dgu-home-search">
       <div class="grid-row">
         <div class="column-two-thirds">
-          <h1 class="heading-xlarge">
+          <h1 tabindex="-1" id="content" class="heading-xlarge">
             <%= t('.find_gov_data') %>
           </h1>
           <p class="lede">

--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -2,13 +2,13 @@
   About -
 <% end %>
 
-<main role="main" id="content">
+<main role="main">
   <%= render partial: 'layouts/feedback_survey_banner' if flash[:beta_message] == 'hide' %>
 
   <div class="text">
 
-    
-   <h1 class="heading-large">
+
+   <h1 tabindex="-1" id="content" class="heading-large">
      About Find open data
    </h1>
 

--- a/app/views/pages/accessibility.html.erb
+++ b/app/views/pages/accessibility.html.erb
@@ -2,12 +2,12 @@
   Accessibility -
 <% end %>
 
-<main role="main" id="content">
+<main role="main">
   <%= render partial: 'layouts/feedback_survey_banner' if flash[:beta_message] == 'hide' %>
 
   <div class="text">
 
-    <h1 class="heading-large">
+    <h1 tabindex="-1" id="content" class="heading-large">
       Accessibility
     </h1>
 

--- a/app/views/pages/cookies.html.erb
+++ b/app/views/pages/cookies.html.erb
@@ -2,12 +2,12 @@
   Cookies -
 <% end %>
 
-<main role="main" id="content">
+<main role="main">
   <%= render partial: 'layouts/feedback_survey_banner' if flash[:beta_message] == 'hide' %>
 
   <div class="text">
 
-    <h1 class="heading-large">
+    <h1 tabindex="-1" id="content" class="heading-large">
       Cookies
     </h1>
 

--- a/app/views/pages/dashboard.html.erb
+++ b/app/views/pages/dashboard.html.erb
@@ -2,8 +2,8 @@
   What's available in Find
 <% end %>
 
-<main role="main" id="content">
-  <h1 class="heading-large">Datasets stats</h1>
+<main role="main">
+  <h1 tabindex="-1" id="content" class="heading-large">Datasets stats</h1>
 
   <div class="grid-row">
     <div class="column-one-third">

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <div class="dgu-split-background">
-  <main role="main" id="content">
+  <main role="main">
     <%= render 'search' %>
     <%= render 'topics' %>
   </main>

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -2,12 +2,12 @@
   Privacy -
 <% end %>
 
-<main role="main" id="content">
+<main role="main">
   <%= render partial: 'layouts/feedback_survey_banner' if flash[:beta_message] == 'hide' %>
 
   <div class="text">
 
-    <h1 class="heading-large">
+    <h1 tabindex="-1" id="content" class="heading-large">
       Privacy
     </h1>
 

--- a/app/views/pages/publishers.html.erb
+++ b/app/views/pages/publishers.html.erb
@@ -2,11 +2,11 @@
   Publishers -
 <% end %>
 
-<main role="main" id="content">
+<main role="main">
   <%= render 'layouts/feedback_survey_banner' if flash[:beta_message] == 'hide' %>
 
   <div class="text">
-    <h1 class="heading-large">
+    <h1 tabindex="-1" id="content" class="heading-large">
       Publish your data
     </h1>
 

--- a/app/views/pages/site_changes.html.erb
+++ b/app/views/pages/site_changes.html.erb
@@ -2,12 +2,12 @@
   Site changes -
 <% end %>
 
-<main role="main" id="content">
+<main role="main">
   <%= render partial: 'layouts/feedback_survey_banner' if flash[:beta_message] == 'hide' %>
 
   <div class="text">
 
-    <h1 class="heading-large">
+    <h1 tabindex="-1" id="content" class="heading-large">
       Update about changes to data.gov.uk
     </h1>
 

--- a/app/views/pages/support.html.erb
+++ b/app/views/pages/support.html.erb
@@ -2,12 +2,12 @@
   Support -
 <% end %>
 
-<main role="main" id="content">
+<main role="main">
   <%= render partial: 'layouts/feedback_survey_banner' if flash[:beta_message] == 'hide' %>
 
   <div class="grid-row inner">
     <div class="column-two-thirds">
-      <h1 class='heading-large'>Support</h1>
+      <h1 tabindex="-1" id="content" class='heading-large'>Support</h1>
 
       <p>
         The Government Digital Service (GDS) maintains the service behind data.gov.uk and helps
@@ -33,7 +33,7 @@
           <fieldset>
 
             <legend>
-              <h1 class="heading-medium">How can we help you?</h1>
+              <h2 class="heading-medium">How can we help you?</h2>
             </legend>
 
             <div class="multiple-choice">

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -2,11 +2,11 @@
   Terms and conditions -
 <% end %>
 
-<main role="main" id="content">
+<main role="main">
   <%= render partial: 'layouts/feedback_survey_banner' if flash[:beta_message] == 'hide' %>
 
   <div class="text">
-    <h1 class="heading-large">
+    <h1 tabindex="-1" id="content" class="heading-large">
       Terms and conditions
     </h1>
 

--- a/app/views/previews/show.html.erb
+++ b/app/views/previews/show.html.erb
@@ -1,11 +1,11 @@
 <% content_for :page_title do %>
   <%= @datafile.name %> -
 <% end %>
-<main role="main" id="content">
+<main role="main">
   <div class="grid-row">
     <div class="column-two-thirds">
       <%= link_to t('.back_link'), dataset_path(@dataset.uuid, @dataset.name), class: 'link-back' %>
-      <h1 class="heading-large">
+      <h1 tabindex="-1" id="content" class="heading-large">
         <%= @dataset.title %>
         <span class="heading-secondary dgu-home-spacer__bottom"><%= @datafile.name %></span>
       </h1>

--- a/app/views/search/search.html.erb
+++ b/app/views/search/search.html.erb
@@ -6,7 +6,7 @@
   <div class="dgu-split-background__top">
     <div class="dgu-split-background__top-inner">
       <%= render partial: 'layouts/feedback_survey_banner' if flash[:beta_message] == 'hide'%>
-      <h1 class="heading-large"> <%= t('.search_results_heading') %></h1>
+      <h1 tabindex="-1" id="content" class="heading-large"> <%= t('.search_results_heading') %></h1>
       <div class="grid-row">
         <div class="column-two-thirds dgu-search-box">
           <label for="q" class="visuallyhidden"> <%= t('.accessibility.search_box_label') %></label>

--- a/app/views/tickets/confirmation.html.erb
+++ b/app/views/tickets/confirmation.html.erb
@@ -1,7 +1,7 @@
-<main role="main" id="content">
+<main role="main">
   <div class="grid-row inner">
     <div class="column-two-thirds">
-      <h1 class='heading-large'><%= t('.thanks_for_contacting') %></h1>
+      <h1 tabindex="-1" id="content" class='heading-large'><%= t('.thanks_for_contacting') %></h1>
       <p>
         <%= t('.built_by_gds') %>
       </p>

--- a/app/views/tickets/new.html.erb
+++ b/app/views/tickets/new.html.erb
@@ -2,7 +2,7 @@
   Send a data request -
 <% end %>
 
-<main role="main" id="content">
+<main role="main">
   <div class="grid-row inner">
     <div class="column-full">
 
@@ -27,7 +27,7 @@
         </div>
       <% end %>
 
-      <h1 class='heading-medium'>
+      <h1 tabindex="-1" id="content" class='heading-medium'>
         <% if @support_queue == 'data'%>
           <%= t('.send_data_request') %>
         <% else %>

--- a/spec/support/dataset_spec_helper.rb
+++ b/spec/support/dataset_spec_helper.rb
@@ -18,7 +18,7 @@ end
 
 def search_for(query)
   visit '/'
-  within '#content' do
+  within 'main' do
     fill_in 'q', with: query
     find('.dgu-search-box__button').click
   end
@@ -26,7 +26,7 @@ end
 
 def filtered_search_for(query, sort_method)
   visit '/search'
-  within '#content' do
+  within 'main' do
     fill_in 'q', with: query
     select sort_method, from: 'Sorting type'
     find('.dgu-search-box__button').click


### PR DESCRIPTION
Previously links pointer to <main>, but it doesn't always start the actual content of a page, for instance when there's a feedback banner

https://trello.com/c/n3xWUfQx/334-skiplink-doesnt-skip-to-main-content-and-focus-remains-on-it

Reviewers please make sure that the dropdowns and autocomplete still work
