### PR TITLE
add topics to the search results page title

### DIFF
--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -33,6 +33,10 @@ module SearchHelper
     params[:filters].except(:publisher).values.reject(&:blank?)
   end
 
+  def search_term
+    params[:q].presence || selected_topic.presence
+  end
+
   private
 
   def no_filters_selected?

--- a/app/views/search/search.html.erb
+++ b/app/views/search/search.html.erb
@@ -1,5 +1,9 @@
 <% content_for :page_title do %>
-   <%= t('.results_page_title', :query => @topic ) %>
+  <% if search_term.present? %>
+   <%= t('.results_page_title', :query => search_term ) %>
+  <% else %>
+    <%= t('.search_results') %>
+  <% end %>
 <% end %>
 
 <form action="/search" method="GET">

--- a/app/views/search/search.html.erb
+++ b/app/views/search/search.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-   <%= t('.results_page_title', :query => @query ) %>
+   <%= t('.results_page_title', :query => @topic ) %>
 <% end %>
 
 <form action="/search" method="GET">

--- a/config/locales/views/search/en.yml
+++ b/config/locales/views/search/en.yml
@@ -2,6 +2,7 @@ en:
   search:
     search:
       results_page_title: 'Results for "%{query}" - data.gov.uk'
+      search_results: 'Search Results'
       search_results_heading: "Search results"
       accessibility:
         search_box_label: "Search"

--- a/spec/features/search_page_spec.rb
+++ b/spec/features/search_page_spec.rb
@@ -281,6 +281,27 @@ feature 'Search page', elasticsearch: true do
     expect(publishers[3]).to eq('Plymouth City Council')
   end
 
+  scenario 'search results title', js:true do
+    index(DatasetBuilder.new.with_topic({id: 1, name: "government", title: "Government"}).build)
+
+    search_for("apple")
+    expect(page).to have_title('Results for "apple"')
+
+    search_for("")
+    expect(page).to have_title('Search Results')
+
+    execute_script "window.location = '#topic'"
+    find_field('topic').send_keys('Gov', :down, :enter)
+    click_button 'Apply filters'
+
+    expect(page).to have_title('Results for "Government"')
+    within '#content' do
+      fill_in 'q', with: 'bear'
+      find('.dgu-search-box__button').click
+    end
+    expect(page).to have_title('Results for "bear"')
+  end
+
   def assert_data_set_length_is(count)
     datasets = all('h2 a')
     expect(datasets.length).to be(count)


### PR DESCRIPTION
[trello card #331](https://trello.com/c/Cfv99DZM/331-search-results-page-title-from-category-search-should-be-more-descriptive)

Make the search results page title more descriptive when search by topic