### PR TITLE
Only have main content in <main>

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -405,8 +405,5 @@ span.showHide-open-all {
 
 
 .dgu-top-non-content {
-  background: $highlight-colour;
-  &__inner {
-    @extend %site-width-container;
-  }
+  @extend %site-width-container;
 }

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -65,7 +65,7 @@
     margin: auto;
     max-width: 960px;
     color: white;
-    padding: 18px 0px 10px 0px;
+    padding: 18px 15px 10px 15px;
     a:link {
       color: white;
     }

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -402,3 +402,8 @@ span.showHide-open-all {
     }
   }
 }
+
+
+.dgu-top-non-content {
+  @extend %site-width-container;
+}

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -143,7 +143,7 @@
 .dgu-metadata__box {
 
   &--in-dataset {
-    background: #F8F8F8;
+    background: $highlight-colour;
     padding: 25px 30px 15px 30px;
   }
 
@@ -258,7 +258,7 @@
       h3 {
         margin: 0;
         padding-top: 30px;
-        border-top: 10px solid #F8F8F8;
+        border-top: 10px solid $highlight-colour;
       }
 
     }
@@ -355,7 +355,7 @@ section .year-expand {
   overflow: hidden;
   border-bottom: 1px solid #BFC1C3;
   &:hover {
-    background: #F8F8F8;
+    background: $highlight-colour;
   }
   h3 {
     color: #005ea5;
@@ -405,5 +405,8 @@ span.showHide-open-all {
 
 
 .dgu-top-non-content {
-  @extend %site-width-container;
+  background: $highlight-colour;
+  &__inner {
+    @extend %site-width-container;
+  }
 }

--- a/app/views/datasets/show.html.erb
+++ b/app/views/datasets/show.html.erb
@@ -3,7 +3,6 @@
 <% end %>
 
 <div class="dgu-top-non-content">
-  <%= render partial: 'layouts/feedback_survey_banner' if flash[:beta_message] == 'hide'%>
   <%= render "breadcrumb" %>
 </div>
 

--- a/app/views/datasets/show.html.erb
+++ b/app/views/datasets/show.html.erb
@@ -3,7 +3,10 @@
 <% end %>
 
 <div class="dgu-top-non-content">
-  <%= render "breadcrumb" %>
+  <div class="dgu-top-non-content__inner">
+    <%= render partial: 'layouts/feedback_survey_banner' if flash[:beta_message] == 'hide' %>
+    <%= render "breadcrumb" %>
+  </div>
 </div>
 
 <main role="main" id="content">

--- a/app/views/datasets/show.html.erb
+++ b/app/views/datasets/show.html.erb
@@ -2,9 +2,12 @@
   <%= @dataset.title %> -
 <% end %>
 
-<main role="main" id="content">
+<div class="dgu-top-non-content">
   <%= render partial: 'layouts/feedback_survey_banner' if flash[:beta_message] == 'hide'%>
   <%= render "breadcrumb" %>
+</div>
+
+<main role="main" id="content">
   <div itemscope itemtype="http://schema.org/Dataset">
     <link itemprop="url" href="<%= "#{request.protocol}#{request.host_with_port}#{request.fullpath}" %>"/>
     <meta itemprop="includedInDataCatalog" itemtype="http://schema.org/DataCatalog" content="<%= request.host %>"/>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -40,8 +40,11 @@
 <% content_for :content do %>
   <%= render 'layouts/staging_ribbon' if Rails.env.staging? %>
   <%= render partial: 'layouts/beta_message' if flash[:beta_message] == 'show'%>
+
   <div class="dgu-top-non-content">
-    <%= render partial: 'layouts/feedback_survey_banner' if flash[:beta_message] == 'hide' %>
+    <div class="dgu-top-non-content__inner">
+      <%= render partial: 'layouts/feedback_survey_banner' if flash[:beta_message] == 'hide' %>
+    </div>
   </div>
   <%= yield %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -40,7 +40,9 @@
 <% content_for :content do %>
   <%= render 'layouts/staging_ribbon' if Rails.env.staging? %>
   <%= render partial: 'layouts/beta_message' if flash[:beta_message] == 'show'%>
-
+  <div class="dgu-top-non-content">
+    <%= render partial: 'layouts/feedback_survey_banner' if flash[:beta_message] == 'hide' %>
+  </div>
   <%= yield %>
 
   <div id="global-app-error" class="app-error hidden"></div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -41,11 +41,6 @@
   <%= render 'layouts/staging_ribbon' if Rails.env.staging? %>
   <%= render partial: 'layouts/beta_message' if flash[:beta_message] == 'show'%>
 
-  <div class="dgu-top-non-content">
-    <div class="dgu-top-non-content__inner">
-      <%= render partial: 'layouts/feedback_survey_banner' if flash[:beta_message] == 'hide' %>
-    </div>
-  </div>
   <%= yield %>
 
   <div id="global-app-error" class="app-error hidden"></div>

--- a/app/views/pages/_search.html.erb
+++ b/app/views/pages/_search.html.erb
@@ -1,6 +1,5 @@
 <div class="dgu-split-background__top">
   <div class="dgu-split-background__top-inner">
-    <%= render partial: 'layouts/feedback_survey_banner' if flash[:beta_message] == 'hide'%>
     <div class="dgu-home-search">
       <div class="grid-row">
         <div class="column-two-thirds">

--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -2,10 +2,14 @@
   About -
 <% end %>
 
+<div class="dgu-top-non-content">
+  <%= render partial: 'layouts/feedback_survey_banner' if flash[:beta_message] == 'hide' %>
+</div>
+
+
 <main role="main" id="content">
 
   <div class="text">
-
 
    <h1 class="heading-large">
      About Find open data

--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -3,11 +3,10 @@
 <% end %>
 
 <main role="main" id="content">
-  <%= render partial: 'layouts/feedback_survey_banner' if flash[:beta_message] == 'hide' %>
 
   <div class="text">
 
-    
+
    <h1 class="heading-large">
      About Find open data
    </h1>

--- a/app/views/pages/accessibility.html.erb
+++ b/app/views/pages/accessibility.html.erb
@@ -2,6 +2,10 @@
   Accessibility -
 <% end %>
 
+<div class="dgu-top-non-content">
+  <%= render partial: 'layouts/feedback_survey_banner' if flash[:beta_message] == 'hide' %>
+</div>
+
 <main role="main" id="content">
 
   <div class="text">

--- a/app/views/pages/accessibility.html.erb
+++ b/app/views/pages/accessibility.html.erb
@@ -3,7 +3,6 @@
 <% end %>
 
 <main role="main" id="content">
-  <%= render partial: 'layouts/feedback_survey_banner' if flash[:beta_message] == 'hide' %>
 
   <div class="text">
 

--- a/app/views/pages/cookies.html.erb
+++ b/app/views/pages/cookies.html.erb
@@ -3,7 +3,6 @@
 <% end %>
 
 <main role="main" id="content">
-  <%= render partial: 'layouts/feedback_survey_banner' if flash[:beta_message] == 'hide' %>
 
   <div class="text">
 

--- a/app/views/pages/cookies.html.erb
+++ b/app/views/pages/cookies.html.erb
@@ -2,6 +2,10 @@
   Cookies -
 <% end %>
 
+<div class="dgu-top-non-content">
+  <%= render partial: 'layouts/feedback_survey_banner' if flash[:beta_message] == 'hide' %>
+</div>
+
 <main role="main" id="content">
 
   <div class="text">

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -3,6 +3,11 @@
 <% end %>
 
 <div class="dgu-split-background">
+  <div class="dgu-split-background__top">
+    <div class="dgu-top-non-content">
+      <%= render partial: 'layouts/feedback_survey_banner' if flash[:beta_message] == 'hide' %>
+    </div>
+  </div>
   <main role="main" id="content">
     <%= render 'search' %>
     <%= render 'topics' %>

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -3,7 +3,6 @@
 <% end %>
 
 <main role="main" id="content">
-  <%= render partial: 'layouts/feedback_survey_banner' if flash[:beta_message] == 'hide' %>
 
   <div class="text">
 

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -2,6 +2,10 @@
   Privacy -
 <% end %>
 
+<div class="dgu-top-non-content">
+  <%= render partial: 'layouts/feedback_survey_banner' if flash[:beta_message] == 'hide' %>
+</div>
+
 <main role="main" id="content">
 
   <div class="text">

--- a/app/views/pages/publishers.html.erb
+++ b/app/views/pages/publishers.html.erb
@@ -2,6 +2,10 @@
   Publishers -
 <% end %>
 
+<div class="dgu-top-non-content">
+  <%= render partial: 'layouts/feedback_survey_banner' if flash[:beta_message] == 'hide' %>
+</div>
+
 <main role="main" id="content">
 
   <div class="text">

--- a/app/views/pages/publishers.html.erb
+++ b/app/views/pages/publishers.html.erb
@@ -3,7 +3,6 @@
 <% end %>
 
 <main role="main" id="content">
-  <%= render 'layouts/feedback_survey_banner' if flash[:beta_message] == 'hide' %>
 
   <div class="text">
     <h1 class="heading-large">

--- a/app/views/pages/site_changes.html.erb
+++ b/app/views/pages/site_changes.html.erb
@@ -3,7 +3,6 @@
 <% end %>
 
 <main role="main" id="content">
-  <%= render partial: 'layouts/feedback_survey_banner' if flash[:beta_message] == 'hide' %>
 
   <div class="text">
 

--- a/app/views/pages/site_changes.html.erb
+++ b/app/views/pages/site_changes.html.erb
@@ -2,6 +2,10 @@
   Site changes -
 <% end %>
 
+<div class="dgu-top-non-content">
+  <%= render partial: 'layouts/feedback_survey_banner' if flash[:beta_message] == 'hide' %>
+</div>
+
 <main role="main" id="content">
 
   <div class="text">

--- a/app/views/pages/support.html.erb
+++ b/app/views/pages/support.html.erb
@@ -2,6 +2,10 @@
   Support -
 <% end %>
 
+<div class="dgu-top-non-content">
+  <%= render partial: 'layouts/feedback_survey_banner' if flash[:beta_message] == 'hide' %>
+</div>
+
 <main role="main" id="content">
 
   <div class="grid-row inner">

--- a/app/views/pages/support.html.erb
+++ b/app/views/pages/support.html.erb
@@ -3,7 +3,6 @@
 <% end %>
 
 <main role="main" id="content">
-  <%= render partial: 'layouts/feedback_survey_banner' if flash[:beta_message] == 'hide' %>
 
   <div class="grid-row inner">
     <div class="column-two-thirds">

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -2,6 +2,10 @@
   Terms and conditions -
 <% end %>
 
+<div class="dgu-top-non-content">
+  <%= render partial: 'layouts/feedback_survey_banner' if flash[:beta_message] == 'hide' %>
+</div>
+
 <main role="main" id="content">
 
   <div class="text">

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -3,7 +3,6 @@
 <% end %>
 
 <main role="main" id="content">
-  <%= render partial: 'layouts/feedback_survey_banner' if flash[:beta_message] == 'hide' %>
 
   <div class="text">
     <h1 class="heading-large">

--- a/app/views/previews/show.html.erb
+++ b/app/views/previews/show.html.erb
@@ -1,6 +1,11 @@
 <% content_for :page_title do %>
   <%= @datafile.name %> -
 <% end %>
+
+<div class="dgu-top-non-content">
+  <%= render partial: 'layouts/feedback_survey_banner' if flash[:beta_message] == 'hide' %>
+</div>
+
 <main role="main" id="content">
   <div class="grid-row">
     <div class="column-two-thirds">


### PR DESCRIPTION
Move things away from the main element so that the "skip to main content" actually skips to the main content.

https://trello.com/c/n3xWUfQx/334-skiplink-doesnt-skip-to-main-content-and-focus-remains-on-it
