### PR TITLE
Add data attributes to preview link

### DIFF
--- a/app/views/datasets/_datafile_table.html.erb
+++ b/app/views/datasets/_datafile_table.html.erb
@@ -41,7 +41,11 @@
           <% elsif datafile.csv? %>
             <%= link_to t('.preview'),
                 datafile_preview_path(@dataset.uuid, @dataset.name, datafile.uuid),
-                class: 'ga-preview'
+                :data => {
+                  :'ga-event' => 'preview',
+                  :'ga-format' => (datafile.format.presence || 'n/a').upcase,
+                  :'ga-publisher' => @dataset.organisation.name
+                  }
             %>
           <% else %>
             <span class="dgu-secondary-text"><%= t('.not_available') %></span>


### PR DESCRIPTION
Data attributes for the GA datafile preview event have been lost by a recent merge. Reinstating them. 

[Trello card #328](https://trello.com/c/WLA2YUze/328-add-ga-event-tracking-to-dataset-preview-links-s)