### PR TITLE
Display available soon message for POST requests

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,11 +4,8 @@ Rails.application.routes.draw do
   get 'dataset/:uuid', to: 'datasets#show', uuid: /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/
 
   scope module: 'legacy' do
-    get 'dataset/:legacy_name',
-        to: 'datasets#available_soon',
-        constraints: lambda { |req| req.referrer.present? && URI.parse(req.referrer).path == '/dataset/new' }
-
     get 'dataset/:legacy_name',                                 to: 'datasets#redirect'
+    post 'dataset/:legacy_name',                                to: 'datasets#available_soon'
     get 'dataset/:legacy_dataset_name/resource/:datafile_uuid', to: 'datafiles#redirect'
 
     get 'data/search',                     to: 'search#redirect'

--- a/spec/requests/legacy/dataset_creation_spec.rb
+++ b/spec/requests/legacy/dataset_creation_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe 'legacy', type: :request do
   describe 'dataset creation' do
     it 'shows a page informing the user the newly created dataset will be available soon' do
-      get '/dataset/foo-bar', params: {}, headers: { 'HTTP_REFERER' => "http://foobar.com/dataset/new" }
+      post '/dataset/foo-bar'
 
       expect(response.body).to include("Available Soon")
     end


### PR DESCRIPTION
We have configured CKAN to use `package_new_return_url` and `package_edit_return_url` config variables. It now POSTS to `/dataset/<NAME>?utm_source=ckan`.