### PR TITLE
Use json-ld for schema.org metadata

### DIFF
--- a/app/helpers/datasets_helper.rb
+++ b/app/helpers/datasets_helper.rb
@@ -58,7 +58,54 @@ module DatasetsHelper
     title.truncate(70, separator: ' ', omission: ' ...')
   end
 
+  def to_json_ld(dataset)
+    dataset_metadata = {
+      :@context => "http://schema.org",
+      :@type => "Dataset",
+      :name => dataset.title,
+      :url => "#{request.protocol}#{request.host_with_port}#{request.fullpath}",
+      :includedInDataCatalog => {
+        :@type => "DataCatalog",
+        :url => request.host
+      },
+      :creator => {
+        :@type => "Organization",
+        :name => dataset.organisation.title
+      },
+      :description => dataset.summary,
+      :license => dataset.licence == 'uk-ogl' ? '' : dataset.licence_other,
+      :dateModified => displayed_date(dataset)
+    }
+    if dataset.licence == 'uk-ogl'
+      dataset_metadata[:license] = "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+    elsif dataset.licence_other
+      dataset_metadata[:license] = dataset.licence_other
+    end
+    if dataset.topic
+      dataset_metadata[:keywords] = dataset.topic['title']
+    end
+    files = metadata_files(dataset)
+    if files.length > 0
+      dataset_metadata[:distribution] = files
+    end
+    dataset_metadata.to_json
+  end
+
   private
+
+  def metadata_files(dataset)
+    files = []
+    dataset.datafiles.each do |file|
+      files.push(
+        {
+          :@type => 'DataDownload',
+          :contentUrl => file.url,
+          :fileFormat => file.format
+        }
+      )
+    end
+    files
+  end
 
   def locations(dataset)
     ['location1', 'location2', 'location3']

--- a/app/helpers/datasets_helper.rb
+++ b/app/helpers/datasets_helper.rb
@@ -60,21 +60,21 @@ module DatasetsHelper
 
   def to_json_ld(dataset)
     dataset_metadata = {
-      :@context => "http://schema.org",
-      :@type => "Dataset",
-      :name => dataset.title,
-      :url => "#{request.protocol}#{request.host_with_port}#{request.fullpath}",
-      :includedInDataCatalog => {
-        :@type => "DataCatalog",
-        :url => request.host
+      "@context": "http://schema.org",
+      "@type": "Dataset",
+      name: dataset.title,
+      url: "#{request.protocol}#{request.host_with_port}#{request.fullpath}",
+      includedInDataCatalog: {
+        "@type": "DataCatalog",
+        url: request.host
       },
-      :creator => {
-        :@type => "Organization",
-        :name => dataset.organisation.title
+      creator: {
+        "@type": "Organization",
+        name: dataset.organisation.title
       },
-      :description => dataset.summary,
-      :license => dataset.licence == 'uk-ogl' ? '' : dataset.licence_other,
-      :dateModified => displayed_date(dataset)
+      description: dataset.summary,
+      license: dataset.licence == 'uk-ogl' ? '' : dataset.licence_other,
+      dateModified: displayed_date(dataset)
     }
     if dataset.licence == 'uk-ogl'
       dataset_metadata[:license] = "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
@@ -98,9 +98,9 @@ module DatasetsHelper
     dataset.datafiles.each do |file|
       files.push(
         {
-          :@type => 'DataDownload',
-          :contentUrl => file.url,
-          :fileFormat => file.format
+          "@type": 'DataDownload',
+          contentUrl: file.url,
+          fileFormat: file.format
         }
       )
     end

--- a/app/views/datasets/_datafile_table.html.erb
+++ b/app/views/datasets/_datafile_table.html.erb
@@ -7,7 +7,7 @@
   </tr>
   <tbody>
     <% datafiles.each do |datafile| %>
-      <tr class="<%= show_more?(datafiles, datafile) %> dgu-datafile" itemscope itemtype="http://schema.org/DataDownload" itemprop="distribution">
+      <tr class="<%= show_more?(datafiles, datafile) %> dgu-datafile">
         <td class="title small">
           <%= link_to (datafile.name ? datafile.name : 'Data Link'),
             datafile.url,
@@ -15,14 +15,13 @@
               :'ga-event' => 'download',
               :'ga-format' => (datafile.format.presence || 'n/a').upcase,
               :'ga-publisher' => @dataset.organisation.name
-            },
-            :itemprop => "contentUrl"
+            }
           %>
         </td>
         <% if datafile.format.blank? %>
           <td class="dgu-secondary-text">N/A</td>
         <% else %>
-          <td><span itemprop="fileFormat"><%= datafile.format.upcase %></span>
+          <td><%= datafile.format.upcase %>
           <% if datafile.size %>
             (<%= datafile.size.number_to_human_size %> )
           <% end %>

--- a/app/views/datasets/_meta_data.html.erb
+++ b/app/views/datasets/_meta_data.html.erb
@@ -8,7 +8,7 @@
 <section class="meta-data">
   <div class="grid-row">
     <div class="column-two-thirds">
-      <h1 class="heading-large" itemprop="name" property="dc:title">
+      <h1 class="heading-large" property="dc:title">
         <%= unescape(@dataset.title) %>
       </h1>
     </div>
@@ -26,7 +26,7 @@
           <% end %>
           <dt><%= t('.published_by') %>:</dt>
 
-          <dd itemprop="creator" property="dc:creator" itemscope itemtype="http://schema.org/Organization">
+          <dd property="dc:creator">
             <%= @dataset.organisation.title %>
           </dd>
 
@@ -44,13 +44,13 @@
 
           <dt><%= t('.licence') %>:</dt>
           <% if @dataset.licence == 'uk-ogl' %>
-            <dd itemprop="license" property="dc:rights">
+            <dd property="dc:rights">
               <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="dc:rights">
                 <%= t('.uk_ogl') %>
               </a>
             </dd>
           <% elsif @dataset.licence_other %>
-            <dd itemprop="license">
+            <dd>
               <%= @dataset.licence_other %>
             </dd>
           <% else %>
@@ -63,7 +63,7 @@
         <h3 class="heading-small">
           <%= t('.summary') %>
         </h3>
-        <p class="summary" style="max-height: 250px; overflow: hidden" itemprop="description" property="dc:description">
+        <p class="summary" style="max-height: 250px; overflow: hidden" property="dc:description">
           <%= unescape(@dataset.summary) %>
         </p>
       </div>
@@ -72,8 +72,8 @@
     <div class="column-one-third dgu-dataset-right">
       <div class="dgu-dataset-right__sidebar__publisher_datasets">
         <h3 class="heading-small"><%= t('.publisher_datasets') %></h3>
-        <%= link_to search_path(filters: { publisher: @dataset.organisation.title }), :itemprop => 'url' do %>
-          <span itemprop="name"><%= "All datasets from #{@dataset.organisation.title}" %></span>
+        <%= link_to search_path(filters: { publisher: @dataset.organisation.title }) do %>
+          <%= "All datasets from #{@dataset.organisation.title}" %>
         <% end %>
       </div>
 

--- a/app/views/datasets/show.html.erb
+++ b/app/views/datasets/show.html.erb
@@ -2,12 +2,14 @@
   <%= @dataset.title %> -
 <% end %>
 
+<script type="application/ld+json">
+  <%= raw to_json_ld(@dataset) %>
+</script>
+
 <main role="main" id="content">
   <%= render partial: 'layouts/feedback_survey_banner' if flash[:beta_message] == 'hide'%>
   <%= render "breadcrumb" %>
-  <div itemscope itemtype="http://schema.org/Dataset">
-    <link itemprop="url" href="<%= "#{request.protocol}#{request.host_with_port}#{request.fullpath}" %>"/>
-    <meta itemprop="includedInDataCatalog" itemtype="http://schema.org/DataCatalog" content="<%= request.host %>"/>
+  <div>
     <%= render "meta_data" %>
 
     <div class="grid-row">


### PR DESCRIPTION
Easier to maintains because all in one place, and better suported by search engines