### PR TITLE
Make sure label and input IDs match

### DIFF
--- a/app/views/search/_filters.html.erb
+++ b/app/views/search/_filters.html.erb
@@ -1,17 +1,17 @@
 <h2 class="heading-medium"> <%= t('.filter_by') %></h2>
 
 <div class="form-group">
-  <%= label_tag 'filters[publisher]', t('.filter_by_publisher'), class: 'form-label' %>
+  <%= label_tag 'publisher', t('.filter_by_publisher'), class: 'form-label' %>
   <%= select_tag('filters[publisher]', options_for_select(dataset_publishers_for_select, selected_publisher), id: 'publisher', class: 'form-control dgu-filters__filter') %>
 </div>
 
 <div class="form-group">
-  <%= label_tag 'filters[topic]', t('.filter_by_topic'), class: 'form-label' %>
+  <%= label_tag 'topic', t('.filter_by_topic'), class: 'form-label' %>
   <%= select_tag('filters[topic]', options_for_select(dataset_topics_for_select, selected_topic), id: 'topic', class: 'form-control dgu-filters__filter') %>
 </div>
 
 <div class="form-group">
-  <%= label_tag 'filters[format]', t('.filter_by_format'), class: 'form-label' %>
+  <%= label_tag 'format', t('.filter_by_format'), class: 'form-label' %>
   <%= select_tag('filters[format]', options_for_select(datafile_formats_for_select, selected_format), id: 'format', class: 'form-control dgu-filters__filter') %>
 </div>
 


### PR DESCRIPTION
So users with screen readers can identify the purpose of each filter.

https://trello.com/c/vImJiMqt/333-search-filter-form-elements-are-unlabelled