### PR TITLE
add gds metrics gem to enable prometheus metrics

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,14 +14,14 @@ gem 'govuk_template'
 gem 'audited', '~> 4.5'
 gem 'kaminari', '~> 1.0.1'
 gem 'rest-client', '~> 2.0.2'
-gem 'mime-types', '~> 3.1'  
+gem 'mime-types', '~> 3.1'
 gem 'friendly_id', '~> 5.2.1'
 gem "elasticsearch", "~> 5.0.4"
 gem "elasticsearch-model", "~> 5.0.1"
 gem "elasticsearch-rails", "~> 5.0.1"
 gem "elasticsearch-persistence", "~> 5", require: "elasticsearch/persistence/model"
 gem 'elasticsearch-dsl', "~> 0.1.5"
-gem 'htmlentities', "~> 4.3"
+gem 'htmlentities', '~> 4.3'
 gem 'faraday'
 gem 'faraday_middleware'
 gem 'sentry-raven'
@@ -29,6 +29,7 @@ gem 'lograge', '~> 0.7'
 gem 'logstash-event', '~> 1.2'
 gem 'zendesk_api'
 gem 'parslet'
+gem 'gds_metrics', '~> 0.0.2'
 
 group :development, :test do
   gem 'byebug', '~> 9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,6 +145,8 @@ GEM
     formtastic_i18n (0.6.0)
     friendly_id (5.2.1)
       activerecord (>= 4.0.0)
+    gds_metrics (0.0.2)
+      prometheus-client-mmap (= 0.9.1)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     govuk_elements_rails (3.1.0)
@@ -247,6 +249,7 @@ GEM
     pg (0.21.0)
     polyamorous (1.3.1)
       activerecord (>= 3.0)
+    prometheus-client-mmap (0.9.1)
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -421,6 +424,7 @@ DEPENDENCIES
   faraday
   faraday_middleware
   friendly_id (~> 5.2.1)
+  gds_metrics (~> 0.0.2)
   govuk_elements_rails
   govuk_template
   guard


### PR DESCRIPTION
trello card [#348](https://trello.com/c/T7RcEwS3/348-install-the-re-prometheus-metrics-gem)

Once the gds_metrics gem is added to the application, visit `/metrics` to see app metrics. 

Currently this is configured to display default metrics, but we can configure. See the [gem documentation](https://github.com/alphagov/gds_metrics_ruby)