### PR TITLE
Adds CSP header and secure cookies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,8 +21,8 @@ gem "elasticsearch-model", "~> 5.0.1"
 gem "elasticsearch-rails", "~> 5.0.1"
 gem "elasticsearch-persistence", "~> 5", require: "elasticsearch/persistence/model"
 gem 'elasticsearch-dsl', "~> 0.1.5"
-gem 'htmlentities', "~> 4.3"
-gem 'secure_headers', "~> 5.0"
+gem 'htmlentities', '~> 4.3'
+gem 'secure_headers', '~> 5.0'
 gem 'faraday'
 gem 'faraday_middleware'
 gem 'sentry-raven'

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'govuk_template'
 gem 'audited', '~> 4.5'
 gem 'kaminari', '~> 1.0.1'
 gem 'rest-client', '~> 2.0.2'
-gem 'mime-types', '~> 3.1'  
+gem 'mime-types', '~> 3.1'
 gem 'friendly_id', '~> 5.2.1'
 gem "elasticsearch", "~> 5.0.4"
 gem "elasticsearch-model", "~> 5.0.1"
@@ -22,6 +22,7 @@ gem "elasticsearch-rails", "~> 5.0.1"
 gem "elasticsearch-persistence", "~> 5", require: "elasticsearch/persistence/model"
 gem 'elasticsearch-dsl', "~> 0.1.5"
 gem 'htmlentities', "~> 4.3"
+gem 'secure_headers', "~> 5.0"
 gem 'faraday'
 gem 'faraday_middleware'
 gem 'sentry-raven'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -338,6 +338,8 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    secure_headers (5.0.5)
+      useragent (>= 0.15.0)
     selenium-webdriver (3.5.2)
       childprocess (~> 0.5)
       rubyzip (~> 1.0)
@@ -374,6 +376,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.4)
+    useragent (0.16.10)
     virtus (1.0.5)
       axiom-types (~> 0.1)
       coercible (~> 1.0)
@@ -444,6 +447,7 @@ DEPENDENCIES
   rspec (~> 3.6)
   rspec-rails (~> 3.6)
   sass-rails (~> 5.0)
+  secure_headers (~> 5.0)
   sentry-raven
   simplecov (~> 0.13)
   spring (~> 2.0)

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -1,0 +1,28 @@
+SecureHeaders::Configuration.default do |config|
+  config.cookies = {
+    secure: true,
+    httponly: true,
+    samesite: {
+      lax: true
+    }
+  }
+  config.hsts = "max-age=#{1.week.to_i}"
+  config.x_frame_options = "DENY"
+  config.x_content_type_options = "nosniff"
+  config.x_xss_protection = "1; mode=block"
+  config.x_download_options = "noopen"
+  config.x_permitted_cross_domain_policies = "none"
+  config.referrer_policy = %w(origin-when-cross-origin strict-origin-when-cross-origin)
+  config.csp = {
+    preserve_schemes: true,
+    default_src: %w('none'),
+    connect_src: %w('self' www.google-analytics.com),
+    font_src: %w('self' data:),
+    img_src: %w('self' www.google-analytics.com),
+    manifest_src: %w('self'),
+    media_src: %w('self'),
+    object_src: %w('self'),
+    script_src: %w('unsafe-inline' 'self' www.google-analytics.com),
+    style_src: %w('unsafe-inline' 'self')
+  }
+end


### PR DESCRIPTION
Uses twitter/secureheaders to implement the CSP header for find-data.
The library also provides support for secure cookies.

Failed to write tests because the selenium driver in capybara does not expose the response (or response headers) and controller tests require on your mocking the response headers - otherwise you just get content-type.