### PR TITLE
shift focus correctly when show more is clicked

### DIFF
--- a/app/assets/javascripts/govuk.js
+++ b/app/assets/javascripts/govuk.js
@@ -160,6 +160,7 @@ LimitDatasets.prototype.toggle = function (event) {
   if (folded === 'folded') {
     $target.text('Show less')
     this.moreFiles.show()
+    $(this.moreFiles[0]).attr('tabindex', -1).focus();
     $target.data('folded', 'unfolded')
   } else {
     $target.text('Show more')


### PR DESCRIPTION
Trello card [#340](https://trello.com/c/8ZIHc1aB/340-issues-with-expandable-link) 

**Suggested in accessibility audit:**

Once the `Show more` link has been initiated, focus should then lead users to the next selectable element, which is for example `September 2013`