### PR TITLE
Adds 'Preview on map' to WMS resources

### DIFF
--- a/app/helpers/map_preview_helper.rb
+++ b/app/helpers/map_preview_helper.rb
@@ -1,0 +1,20 @@
+module MapPreviewHelper
+  def map_preview_url(dataset, wms_resource)
+    urls = {
+      url: wms_resource.url,
+      n: dataset.inspire_dataset['bbox_north_lat'],
+      e: dataset.inspire_dataset['bbox_east_long'],
+      s: dataset.inspire_dataset['bbox_south_lat'],
+      w: dataset.inspire_dataset['bbox_west_long'],
+    }
+
+    wfs_resource = dataset.datafiles.select(&:wfs?).first
+    if wfs_resource
+        urls[:wfsurl] = wfs_resource.url
+        urls[:resid] = wfs_resource.uuid
+        urls[:resname] = wfs_resource.name
+    end
+
+    "https://data.gov.uk/data/map-preview?#{urls.to_query}"
+  end
+end

--- a/app/models/datafile.rb
+++ b/app/models/datafile.rb
@@ -42,6 +42,14 @@ class Datafile
     format&.upcase == 'CSV'
   end
 
+  def wms?
+    format&.upcase == 'WMS'
+  end
+
+  def wfs?
+    format&.upcase == 'WFS'
+  end
+
   def preview
     @preview ||= Preview.new(url: url, format: format)
   end

--- a/app/views/datasets/_datafile_table.html.erb
+++ b/app/views/datasets/_datafile_table.html.erb
@@ -48,6 +48,8 @@
                   :'ga-publisher' => @dataset.organisation.name
                   }
             %>
+          <% elsif datafile.wms? && @dataset.inspire_dataset.present? %>
+            <%= link_to t('.map_preview'), map_preview_url(@dataset, datafile) %>
           <% else %>
             <span class="dgu-secondary-text"><%= t('.not_available') %></span>
           <% end %>

--- a/config/locales/views/datasets/en.yml
+++ b/config/locales/views/datasets/en.yml
@@ -39,6 +39,7 @@ en:
       not_available: "Not available"
       go_to_site: "Go to site"
       preview: "Preview"
+      map_preview: "Preview on map"
     meta_data:
       availability: "Availability"
       publisher_datasets: "More from this publisher"

--- a/spec/features/dataset_show_page_spec.rb
+++ b/spec/features/dataset_show_page_spec.rb
@@ -8,6 +8,34 @@ feature 'Dataset page', elasticsearch: true do
     expect(page).to have_content('Page not found')
   end
 
+  feature 'Map preview links' do
+    scenario 'WMS Resources have a link to map preview if we have inspire metadata' do
+      dataset = DatasetBuilder
+        .new
+        .with_datafiles(GEO_DATAFILES.map { |f| Datafile.new(f) })
+        .with_inspire_metadata({
+          'bbox_north_lat' => '1.0',
+          'bbox_east_long' => '1.0',
+          'bbox_south_lat' => '2.0',
+          'bbox_west_long' => '2.0',
+        })
+        .build
+      index_and_visit(dataset)
+
+      expect(page).to have_content('Preview on map')
+    end
+
+    scenario 'WMS Resources have no link to map preview if we have no inspire metadata' do
+      dataset = DatasetBuilder
+        .new
+        .with_datafiles(GEO_DATAFILES.map { |f| Datafile.new(f) })
+        .build
+      index_and_visit(dataset)
+
+      expect(page).not_to have_content('Preview on map')
+    end
+  end
+
   feature 'Meta data' do
     before(:each) do
       dataset = DatasetBuilder.new.build

--- a/spec/support/dataset_spec_builder.rb
+++ b/spec/support/dataset_spec_builder.rb
@@ -86,6 +86,11 @@ class DatasetBuilder
     self
   end
 
+  def with_inspire_metadata(inspire)
+    @dataset[:inspire_dataset] = inspire
+    self
+  end
+
   def with_location(location)
     @dataset[:location1] = location
     self
@@ -306,6 +311,27 @@ FORMATTED_DATASETS = {
          'start_year' => ''
         }]
 }
+GEO_DATAFILES = [
+  {'id' => 1,
+   'name' => 'I am a WMS resources',
+   'url' => 'http://example.com',
+   'format' => 'WMS',
+   'start_date' => nil,
+   'end_date' => nil,
+   'created_at' => '2016-07-31T00:00:00.000+01:00',
+   'updated_at' => '2016-08-31T14:40:57.528Z',
+   'uuid' => SecureRandom.uuid
+  },
+  {'id' => 2,
+   'name' => 'I am a WFS resources',
+   'format' => 'WFS',
+   'url' => 'http://example.com',
+   'start_date' => nil,
+   'end_date' => nil,
+   'created_at' => '2016-07-31T00:00:00.000+01:00',
+   'updated_at' => '2016-08-31T14:40:57.528Z',
+   'uuid' => SecureRandom.uuid
+  }]
 CSV_DATAFILE = DATA_FILES_WITH_START_AND_ENDDATE[1]
 HTML_DATAFILE = DATA_FILES_WITH_START_AND_ENDDATE[0]
 NO_FORMAT_DATAFILE = DATA_FILES_WITH_START_AND_ENDDATE[2]


### PR DESCRIPTION
Where a dataset has a WMS resource, and also has the appropriate INSPIRE
metadata, this PR will add a link to the legacy (data.gov.uk) map
preview for that WMS.

The map-based-preview requires the urlencoded `url` for the WMS
resource as well as the  `wfsurl` or any WFS resource in the same
dataset.  The bounding box (n, w, e, and s) is taken from the bbox_*
parameters of the INSPIRE metadata.

Not all WMS endpoints are available, so on visiting the map preview it's
possible that there will be:

* No layers to select
* A red 'x' over the WMS URL on the left hand side
* Errors when loading after selecting a layer
* No feature data for some layers

The PR works okay for the 30-something datasets I tried it on, apart
from those WMS servers that are borked. Luckily (or unluckily if JS is
disabled) the map preview uses JS to navigate back to the previous page
so we shouldn't need to modify the legacy map-preview.