### PR TITLE
Make sure the apps bind the prometheus service

### DIFF
--- a/production-manifest.yml
+++ b/production-manifest.yml
@@ -14,3 +14,4 @@ applications:
   - find-production-secrets
   - logit-ssl-drain
   - beta-production-elasticsearch
+  - dgu-prometheus

--- a/staging-manifest.yml
+++ b/staging-manifest.yml
@@ -10,3 +10,4 @@ applications:
   - find-staging-secrets
   - beta-staging-elasticsearch
   - logit-ssl-drain
+  - dgu-prometheus


### PR DESCRIPTION
The staging and production apps should both bind to prometheus so that it can scrape the metrics at /metrics and be used in a dashboard.