### PR TITLE
Remove redundant ignores from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,53 +1,11 @@
-*.rbc
-capybara-*.html
-.rspec
-/log
-/tmp
-/db/*.sqlite3
-/db/*.sqlite3-journal
-/public/system
-/public/assets
-/coverage/
-/spec/tmp
-*.orig
-rerun.txt
-pickle-email-*.html
-node_modules/
-
-# TODO Comment out this rule if you are OK with secrets being uploaded to the repo
-config/initializers/secret_token.rb
-
-# Only include if you have production secrets in this file, which is no longer a Rails default
-# config/secrets.yml
-
-# dotenv
-# TODO Comment out this rule if environment variables can be committed
 .env
-
-## Environment normalization:
-/.bundle
-/vendor/bundle
-
-# these should all be checked in to normalize the environment:
-# Gemfile.lock, .ruby-version, .ruby-gemset
-
-# unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
-.rvmrc
-
-# if using bower-rails ignore default bower_components path bower.json files
-/vendor/assets/bower_components
-*.bowerrc
-bower.json
-
-# Ignore pow environment settings
-.powenv
-
-# Ignore Byebug command history file.
 .byebug_history
 
-#Ignore Intellij
-.idea/
-*.iml
+/coverage/
+/vendor/bundle
+/log
+/tmp
+/public/assets
+/node_modules/
 
 .DS_Store
-*.iml


### PR DESCRIPTION
Most of these definitely aren't required e.g. this app doesn't use an
sqlite database.

Having a shorter file makes it easier to find out if a
file is being ignored.