### PR TITLE
Override NTA with Helvetica

### DIFF
--- a/app/assets/stylesheets/govuk-overrides.scss
+++ b/app/assets/stylesheets/govuk-overrides.scss
@@ -1,5 +1,9 @@
 // govuk-* overrides
 
+body {
+  font-family: $helvetica-regular;
+}
+
 // Homepage header overides__________________
 
 #global-header {
@@ -11,7 +15,7 @@
     background: none;
     border-bottom: none;
     width: 160%;
-    font-family: Helvetica, Arial, sans-serif;
+
     img {
       display: none;
     }
@@ -34,20 +38,17 @@
         width: 12%;
       }
     }
+  }
 
-    .header-proposition {
-      #proposition-links {
-        a {
-          font-family: Helvetica;
-        }
+  .header-proposition {
+    #proposition-links {
+      float: right;
+
+      a {
+        font-family: $helvetica-regular;
       }
     }
   }
-}
-
-#proposition-links {
-  float: right;
-  font-family: Helvetica;
 }
 
 #global-header-bar {
@@ -65,10 +66,17 @@
   margin-bottom: 40px;
 }
 
-#footer .footer-meta .footer-meta-inner .open-government-licence p {
-  font-family: Helvetica, Arial, sans-serif;
-}
+#footer {
+  * {
+    font-family: $helvetica-regular;
+  }
 
+    .footer-meta .footer-meta-inner {
+      .open-government-licence p {
+        font-family: $helvetica-regular;
+    }
+  }
+}
 
 details {
   margin-bottom: 30px;

--- a/app/views/layouts/_beta_message.html.erb
+++ b/app/views/layouts/_beta_message.html.erb
@@ -1,7 +1,7 @@
 <div class="dgu-beta__banner">
   <div class="dgu-beta__message">
     <p>
-      We’ve been improving data.gov.uk to help you find and use open government data.
+      We’ve been improving data.gov.uk to help you find and use open government data.<br />
       <%= link_to "Discover what’s changed", about_path %> and <%= link_to "get in touch", support_path %> to give us your feedback.
     </p>
     <p>


### PR DESCRIPTION
We don't have the licence to use NTA, so we use helvetica instead.

* Override NTA with Helvetica
* Make sure message is no wider than 75 chars