### PR TITLE
Replace arrow function (not supported in IE11)

### DIFF
--- a/app/assets/javascripts/govuk.js
+++ b/app/assets/javascripts/govuk.js
@@ -125,7 +125,7 @@ FoldableText.prototype.toggle = function (event) {
 }
 
 FoldableText.prototype.init = function () {
-  $.each(this.els, (idx, el) => {
+  $.each(this.els, function(idx, el) {
     var $el = $(el)
     $el.css('max-height', '100000px')
     var originalHeight = $el.height()


### PR DESCRIPTION
IE11 does not support arrow function, so on the dataset page the datafiles grouped by year under the show/hide button could not get unfolded.

This PR fixes this.

There is only one occurrence of the `=>` in the codebase. We are still getting an error in IE8, but the site remains functional.

https://trello.com/c/ZRUKFRpL/366-urgent-ie-bug-in-year-expando

paired with @emmabeynon 