### PR TITLE
Fix search result page bugs

### DIFF
--- a/app/views/search/_sort.html.erb
+++ b/app/views/search/_sort.html.erb
@@ -1,6 +1,6 @@
 <div class="dgu-sort">
   <div class="dgu-sort__apply js-hidden">
-    <input type="submit" value=<%= t('.accessibility.submit') %>/>
+    <input type="submit" value=<%= t('.accessibility.submit_button') %>/>
   </div>
 
   <div class="dgu-sort__sort-type">

--- a/app/views/search/_sort.html.erb
+++ b/app/views/search/_sort.html.erb
@@ -1,5 +1,5 @@
 <div class="dgu-sort">
-  <div class="dgu-sort__apply js-hidden">
+  <div class="dgu-sort__apply visuallyhidden">
     <input type="submit" value=<%= t('.accessibility.submit_button') %>/>
   </div>
 


### PR DESCRIPTION
For https://trello.com/c/YfnI3Qnw/369-ie-bug-html-showing-on-search-page

This fixes a couple of bugs:

* Broken HTML appearing next to the sorting options
* A submit button appearing next to the sorting options which when it shouldn't

Example page: /search?q=dogs&filters%5Bpublisher%5D=&filters%5Btopic%5D=&filters%5Bformat%5D=&sort=recent

Paired with @laurentqro 