### PR TITLE
Add source metadata link to Additional info

### DIFF
--- a/app/views/datasets/_additional_info.html.erb
+++ b/app/views/datasets/_additional_info.html.erb
@@ -60,6 +60,12 @@
               <dt><%= t('.inspire_metadata_lang') %></dt>
               <dd><%= i['metadata_language'] %></dd>
             <% end %>
+            <% if i['harvest_object_id'] %>
+              <dt><%= t('.inspire_gemini_record') %></dt>
+              <dd>
+                <%= link_to t('.xml'), "/api/2/rest/harvestobject/#{ i['harvest_object_id'] }/xml" %>
+              </dd>
+            <% end %>
           </dl>
         </div>
       </details>

--- a/config/locales/views/datasets/en.yml
+++ b/config/locales/views/datasets/en.yml
@@ -21,6 +21,8 @@ en:
       inspire_responsible_party: "Responsible party"
       inspire_iso_resource: "ISO 19139 resource type"
       inspire_metadata_lang: "Metadata language"
+      inspire_gemini_record: "Source Metadata"
+      xml: "XML"
     breadcrumb:
       home: "Home"
       search: "Search"


### PR DESCRIPTION
When something is harvested, we can provide a link to the metadata we
harvested - the source metadata.  This appears to be valuable to people
and so I've added it back in, but hidden within Additional information.