### PR TITLE
Switch contact email link if it's not an email

### DIFF
--- a/app/helpers/datasets_helper.rb
+++ b/app/helpers/datasets_helper.rb
@@ -1,4 +1,5 @@
 require 'uri'
+require 'mail'
 
 module DatasetsHelper
 
@@ -91,8 +92,6 @@ module DatasetsHelper
     dataset_metadata.to_json
   end
 
-  private
-
   def format_of(datafile)
     (datafile.format.presence || 'n/a').upcase
   end
@@ -132,11 +131,15 @@ module DatasetsHelper
   end
 
   def contact_name_for(dataset)
-    dataset.contact_name.presence || dataset.organisation.contact_name.presence
+    dataset.contact_name.presence || dataset.organisation.contact_name
+  end
+
+  def contact_email_is_email?(dataset)
+    contact_email_for(dataset) =~ /@/
   end
 
   def contact_email_for(dataset)
-    dataset.contact_email.presence || dataset.organisation.contact_email.presence
+    dataset.contact_email.presence || dataset.organisation.contact_email
   end
 
   def foi_details_exist?(dataset)
@@ -152,15 +155,15 @@ module DatasetsHelper
   end
 
   def foi_name_for(dataset)
-    dataset.foi_name.presence || dataset.organisation.foi_name.presence
+    dataset.foi_name.presence || dataset.organisation.foi_name
   end
 
   def foi_email_for(dataset)
-    dataset.foi_email.presence || dataset.organisation.foi_email.presence
+    dataset.foi_email.presence || dataset.organisation.foi_email
   end
 
   def foi_web_address_for(dataset)
-    (dataset.foi_web.presence || dataset.organisation.foi_web.presence).to_s
+    (dataset.foi_web.presence || dataset.organisation.foi_web).to_s
   end
 
   private

--- a/app/views/datasets/_contact.html.erb
+++ b/app/views/datasets/_contact.html.erb
@@ -11,7 +11,13 @@
 
       <p>
         <span><%= contact_name_for(dataset) %></span>
-        <span><%= mail_to(contact_email_for(dataset), nil, {'data-ga-event': 'contact', 'data-ga-publisher': @dataset.organisation.name}) %></span>
+        <span>
+          <% if contact_email_is_email?(dataset) %>
+            <%= mail_to(contact_email_for(dataset), nil, {'data-ga-event': 'contact', 'data-ga-publisher': @dataset.organisation.name}) %>
+          <% else %>
+            <%= link_to(contact_email_for(dataset), nil, {'data-ga-event': 'contact', 'data-ga-publisher': @dataset.organisation.name}) %>
+          <% end %>
+        </span>
       </p>
     </div>
   <% end %>

--- a/spec/helpers/datasets_helper_spec.rb
+++ b/spec/helpers/datasets_helper_spec.rb
@@ -32,4 +32,16 @@ RSpec.describe DatasetsHelper do
       it { is_expected.to eq('https://data.gov.uk/unpublished/edit-item/abc123') }
     end
   end
+
+  describe '#contact_email_is_email?' do
+    it 'returns true when the email is valid' do
+      dataset = Dataset.new(DatasetBuilder.new.with_contact_email('foo@bar.com').build)
+      expect(helper.contact_email_is_email?(dataset)).to be_truthy
+    end
+
+    it 'returns false when the email is invalid' do
+      dataset = Dataset.new(DatasetBuilder.new.with_contact_email('http://foo.com').build)
+      expect(helper.contact_email_is_email?(dataset)).to be_falsey
+    end
+  end
 end

--- a/spec/support/dataset_spec_builder.rb
+++ b/spec/support/dataset_spec_builder.rb
@@ -16,6 +16,7 @@ class DatasetBuilder
         harvested: false,
         created_at: '2013-08-31T00:56:15.435Z',
         last_updated_at: '2017-07-24T14:47:25.975Z',
+        contact_email: '',
         uuid: SecureRandom.uuid,
         organisation: {
             id: 582,
@@ -72,7 +73,7 @@ class DatasetBuilder
   end
 
   def with_contact_email(contact_email)
-    @dataset[:organisation][:contact_email] = contact_email
+    @dataset[:contact_email] = contact_email
     self
   end
 


### PR DESCRIPTION
The contact_email field of a dataset/organisation has historically had
no validation to ensure it's actually an email, leading to some datsets
showing a website URL as a mailto link.

https://trello.com/c/eV9Djuxh/381-all-publisher-contact-details-are-mailto-links-even-when-its-a-url-not-an-email-address