### PR TITLE
Where a dataset has Access Constraints, show them.

### DIFF
--- a/app/views/datasets/_additional_info.html.erb
+++ b/app/views/datasets/_additional_info.html.erb
@@ -21,6 +21,11 @@
               <dt><%= t('.inspire_added') %></dt>
               <dd><%= i['metadata_date'] %></dd>
             <% end %>
+            <% if i['access_constraints'] %>
+              <% ref = JSON.parse(i['access_constraints']) %>
+              <dt><%= t('.inspire_access_constraints') %></dt>
+              <dd><%= ref.first || t('.inspire_access_constraints_unspecified') %></dd>
+            <% end %>
             <% if i['guid'] %>
               <dt><%= t('.inspire_guid') %></dt>
               <dd><%= i['guid'] %></dd>

--- a/config/locales/views/datasets/en.yml
+++ b/config/locales/views/datasets/en.yml
@@ -21,6 +21,8 @@ en:
       inspire_responsible_party: "Responsible party"
       inspire_iso_resource: "ISO 19139 resource type"
       inspire_metadata_lang: "Metadata language"
+      inspire_access_constraints: "Access contraints"
+      inspire_access_constraints_unspecified: "Not specified"
     breadcrumb:
       home: "Home"
       search: "Search"


### PR DESCRIPTION
If the dataset's inspire metadata has access constraints, we need to
show it in the Additional information section.