### PR TITLE
Order datafiles in datables by created_at desc

### DIFF
--- a/app/helpers/datasets_helper.rb
+++ b/app/helpers/datasets_helper.rb
@@ -55,6 +55,10 @@ module DatasetsHelper
     datafiles.group_by(&:start_year).sort.reverse
   end
 
+  def sort_by_created_at(datafiles)
+    datafiles.sort_by(&:created_at).reverse
+  end
+
   def shorten_title(title)
     title.truncate(70, separator: ' ', omission: ' ...')
   end

--- a/app/views/datasets/_datafile_table.html.erb
+++ b/app/views/datasets/_datafile_table.html.erb
@@ -6,7 +6,7 @@
     <th><%= t('.data_preview') %></th>
   </tr>
   <tbody>
-    <% datafiles.each do |datafile| %>
+    <% sort_by_created_at(datafiles).each do |datafile| %>
       <tr class="<%= show_more?(datafiles, datafile) %> dgu-datafile">
         <td class="title small">
           <%= link_to datafile.url,

--- a/spec/helpers/datasets_helper_spec.rb
+++ b/spec/helpers/datasets_helper_spec.rb
@@ -2,34 +2,29 @@ require 'rails_helper'
 
 RSpec.describe DatasetsHelper do
   describe '#edit_dataset_url' do
-    subject { helper.edit_dataset_url(dataset) }
-
-    before { index attributes }
-
-    let(:dataset) { Dataset.get_by_uuid(uuid: attributes[:uuid]) }
-    let(:legacy_name) { 'abc123' }
-
-    context 'when released' do
-      let(:attributes) do
-        DatasetBuilder
-          .new
-          .with_legacy_name(legacy_name)
-          .with_datafiles([Datafile.new(CSV_DATAFILE)])
-          .build
-      end
-
-      it { is_expected.to eq('https://data.gov.uk/dataset/edit/abc123') }
+    let(:attributes) do
+      DatasetBuilder.new.with_datafiles(['datafile'])
+        .with_legacy_name('foo')
     end
 
-    context 'when not released' do
-      let(:attributes) do
-        DatasetBuilder
-          .new
-          .with_legacy_name(legacy_name)
-          .build
-      end
+    it 'uses the normal view if there are datafiles' do
+      url = helper.edit_dataset_url(Dataset.new(attributes.build))
+      expect(url).to eq 'https://data.gov.uk/dataset/edit/foo'
+    end
 
-      it { is_expected.to eq('https://data.gov.uk/unpublished/edit-item/abc123') }
+    it 'uses the unpublished view if there are datafiles' do
+      unpublished_attributes = attributes.with_datafiles([])
+      url = helper.edit_dataset_url(Dataset.new(unpublished_attributes.build))
+      expect(url).to eq 'https://data.gov.uk/unpublished/edit-item/foo'
+    end
+  end
+
+  describe '#sort_by_created_at' do
+    it 'orders datafiles lexicographically by created_at' do
+      datafile_1 = Datafile.new(created_at: 1.hours.ago.iso8601)
+      datafile_2 = Datafile.new(created_at: 2.hours.ago.iso8601)
+      results = helper.sort_by_created_at([datafile_2, datafile_1])
+      expect(results).to eq [datafile_1, datafile_2]
     end
   end
 


### PR DESCRIPTION
Datafiles for a dataset are stored in an inline array, but may be
displayed in groups (timeseries) or ungrouped (non-timeseries). Both
views use the datatable partial, to which I've added a sorting method on
the input datafiles array, using the lexicographic property of ISO8601
timestamps like created_at to sort and then reverse (most recent first).

https://trello.com/c/zhhymOmv/15-datafiles-are-displayed-oldest-first-rather-than-most-recent-at-the-top-s