### PR TITLE
Do now show signin (edit) button for harvested datasets

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -106,5 +106,9 @@ class Dataset
     @organisation = Organisation.new(organisation)
   end
 
+  def editable?
+    harvested == false
+  end
+
   private_class_method :map_keys
 end

--- a/app/views/datasets/show.html.erb
+++ b/app/views/datasets/show.html.erb
@@ -58,17 +58,19 @@
       <%= render partial: "contact", locals: { dataset: @dataset } %>
     <% end %>
 
-    <section>
-      <div class="grid-row">
-        <div class="column-full">
-          <h2 class="heading-medium"><%= t('datasets.publishers.title') %></h2>
-          <div role="note" aria-label="Publisher information" class="panel panel-border-narrow text">
-            <p><%= t('datasets.publishers.information') %></p>
+    <% if @dataset.editable? %>
+      <section>
+        <div class="grid-row">
+          <div class="column-full">
+            <h2 class="heading-medium"><%= t('datasets.publishers.title') %></h2>
+            <div role="note" aria-label="Publisher information" class="panel panel-border-narrow text">
+              <p><%= t('datasets.publishers.information') %></p>
+            </div>
+            <p><%= link_to t('datasets.publishers.button'), edit_dataset_url(@dataset), role: 'button', class: 'button', rel: %w(nofollow) %></p>
           </div>
-          <p><%= link_to t('datasets.publishers.button'), edit_dataset_url(@dataset), role: 'button', class: 'button', rel: %w(nofollow) %></p>
         </div>
-      </div>
-    </section>
+      </section>
+    <% end %>
 
   </div>
 </main>

--- a/spec/features/dataset_show_page_spec.rb
+++ b/spec/features/dataset_show_page_spec.rb
@@ -404,6 +404,18 @@ feature 'Dataset page', elasticsearch: true do
   end
 
   feature 'publisher edit link' do
+    scenario 'cannot edit harvested dataset' do
+      dataset = DatasetBuilder
+                  .new
+                  .with_legacy_name('abc123')
+                  .with_harvested(true)
+                  .build
+
+      index_and_visit(dataset)
+
+      expect(page).to_not have_link('Sign in', href: 'https://data.gov.uk/dataset/edit/abc123')
+    end
+
     scenario 'edit released dataset link' do
       dataset = DatasetBuilder
                   .new

--- a/spec/support/dataset_spec_builder.rb
+++ b/spec/support/dataset_spec_builder.rb
@@ -92,6 +92,11 @@ class DatasetBuilder
     self
   end
 
+  def with_harvested(val)
+    @dataset[:harvested] = val
+    self
+  end
+
   def with_location(location)
     @dataset[:location1] = location
     self


### PR DESCRIPTION
Users cannot currently edit harvested datasets as they may then get
overwritten the next time the harvester runs.