### PR TITLE
Add additional information

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -8,6 +8,7 @@ class Dataset
                 :location1, :location2, :location3,
                 :foi_name, :foi_email, :foi_phone, :foi_web,
                 :contact_name, :contact_email, :contact_phone,
+                :licence_code, :licence_title, :licence_url, :licence_custom,
                 :licence, :licence_other, :frequency,
                 :published_date, :last_updated_at, :created_at,
                 :harvested, :uuid, :short_id, :topic,
@@ -84,6 +85,77 @@ class Dataset
 
   def datafiles=(datafiles)
     @datafiles = datafiles.map { |file| Datafile.new(file)}
+  end
+
+  def licence?
+    licence_code.present?
+  end
+
+  def licence_code
+    @licence_code || case licence
+                     when 'other'
+                       licence_other
+                     when 'no-licence'
+                       if licence_custom.present?
+                         'other'
+                       end
+                     else
+                       licence
+                     end
+  end
+
+  def licence_title
+    @licence_title || case licence_code
+                      when 'cc-by'
+                        'Creative Commons Attribution'
+                      when 'cc-by-sa'
+                        'Creative Commons Attribution Share-Alike'
+                      when 'cc-nc'
+                        'Creative Commons Non-Commercial (Any)'
+                      when 'cc-zero'
+                        'Creative Commons CCZero'
+                      when 'notspecified'
+                        'License Not Specified'
+                      when 'odc-by'
+                        'Open Data Commons Attribution License'
+                      when 'odc-odbl'
+                        'Open Data Commons Open Database License (ODbL)'
+                      when 'odc-pddl'
+                        'Open Data Commons Public Domain Dedication and License (PDDL)'
+                      when 'other'
+                        'Other'
+                      when 'other-closed'
+                        'Other (Not Open)'
+                      when 'other-nc'
+                        'Other (Non-Commercial)'
+                      when 'other-open'
+                        'Other (Open)'
+                      when 'other-pd'
+                        'Other (Public Domain)'
+                      when 'uk-ogl'
+                        'Open Government Licence'
+                      end
+  end
+
+  def licence_url
+    @licence_url || case licence_code
+                    when 'cc-by'
+                      'http://www.opendefinition.org/licenses/cc-by'
+                    when 'cc-by-sa'
+                      'http://www.opendefinition.org/licenses/cc-by-sa'
+                    when 'cc-nc'
+                      'http://creativecommons.org/licenses/by-nc/2.0/'
+                    when 'cc-zero'
+                      'http://www.opendefinition.org/licenses/cc-zero'
+                    when 'odc-by'
+                      'http://www.opendefinition.org/licenses/odc-by'
+                    when 'odc-odbl'
+                      'http://www.opendefinition.org/licenses/odc-odbl'
+                    when 'odc-pddl'
+                      'http://www.opendefinition.org/licenses/odc-pddl'
+                    when 'uk-ogl'
+                      'http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/'
+                    end
   end
 
   def links

--- a/app/views/datasets/_meta_data.html.erb
+++ b/app/views/datasets/_meta_data.html.erb
@@ -2,7 +2,10 @@
   <%= tag.meta name: 'dc:title',   content: unescape(@dataset.title) %>
   <%= tag.meta name: 'dc:creator', content: @dataset.organisation.title %>
   <%= tag.meta name: 'dc:date',    content: Date.parse(displayed_date(@dataset)).to_formatted_s %>
-  <%= tag.meta name: 'dc:rights',  content: t('.uk_ogl') %>
+
+  <% if @dataset.licence_title.present? %>
+    <%= tag.meta name: 'dc:rights', content: @dataset.licence_title %>
+  <% end %>
 <% end %>
 
 <section class="meta-data">
@@ -43,15 +46,18 @@
           <% end %>
 
           <dt><%= t('.licence') %>:</dt>
-          <% if @dataset.licence == 'uk-ogl' %>
+          <% if @dataset.licence? %>
             <dd property="dc:rights">
-              <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="dc:rights">
-                <%= t('.uk_ogl') %>
-              </a>
-            </dd>
-          <% elsif @dataset.licence_other %>
-            <dd>
-              <%= @dataset.licence_other %>
+              <%= link_to_if @dataset.licence_url.present?,
+                             @dataset.licence_title,
+                             @dataset.licence_url,
+                             rel: 'dc:rights' %>
+
+              <% if @dataset.licence_custom.present? %>
+                <br />
+                <%= link_to t('.view_additional_licence_information'),
+                            '#additional-licence-info' %>
+              <% end %>
             </dd>
           <% else %>
             <dd class="dgu-unavailable">

--- a/app/views/datasets/show.html.erb
+++ b/app/views/datasets/show.html.erb
@@ -54,6 +54,21 @@
       <%= render partial: "contact", locals: { dataset: @dataset } %>
     <% end %>
 
+    <% if @dataset.licence_custom.present? %>
+      <section class="dgu-additional-licence-info">
+        <div class="grid-row">
+          <div class="column-full">
+            <h2 class="heading-medium" id="additional-licence-info">
+              <%= t('.additional_licence_information') %>
+            </h2>
+            <p class="dgu-additional-licence-info__notes">
+              <%= to_markdown(@dataset.licence_custom) %>
+            </p>
+          </div>
+        </div>
+      </section>
+    <% end %>
+
     <% if @dataset.editable? %>
       <section>
         <div class="grid-row">

--- a/config/locales/views/datasets/en.yml
+++ b/config/locales/views/datasets/en.yml
@@ -56,6 +56,7 @@ en:
       related_datasets: "Related datasets"
       search_gov_data: "Search"
       data_links: "Data links"
+      view_additional_licence_information: "View additional licence information"
       no_licence: "None"
       uk_ogl: "Open Government Licence"
       accessibility:
@@ -67,6 +68,7 @@ en:
       date_added: "Date added"
       format: "Format"
     show:
+      additional_licence_information: "Additional licence information"
       open_all: "Open all"
       data_links: "Data links"
       not_released: "This data hasn’t been released by the publisher."

--- a/spec/features/dataset_show_page_spec.rb
+++ b/spec/features/dataset_show_page_spec.rb
@@ -8,6 +8,150 @@ feature 'Dataset page', elasticsearch: true do
     expect(page).to have_content('Page not found')
   end
 
+  feature 'Licence information' do
+    scenario 'Link to Open Government Licence information' do
+      dataset = DatasetBuilder
+                  .new
+                  .with_licence('uk-ogl')
+                  .build
+
+      index_and_visit(dataset)
+
+      expect(page)
+        .to have_css('meta[name="dc:rights"][content="Open Government Licence"]',
+                     visible: false)
+
+      within('section.meta-data') do
+        expect(page)
+          .to have_link('Open Government Licence',
+                        href: 'http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/')
+      end
+    end
+
+    scenario 'Link to Open Government Licence with additional information' do
+      dataset = DatasetBuilder
+                  .new
+                  .with_licence('uk-ogl')
+                  .with_licence_custom('Special case')
+                  .build
+
+      index_and_visit(dataset)
+
+      expect(page)
+        .to have_css('meta[name="dc:rights"][content="Open Government Licence"]',
+                     visible: false)
+
+      within('section.meta-data') do
+        expect(page)
+          .to have_link('Open Government Licence',
+                        href: 'http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/')
+
+        expect(page)
+          .to have_link('View additional licence information',
+                        href: '#additional-licence-info')
+      end
+
+      within('section.dgu-additional-licence-info') do
+        expect(page).to have_content('Special case')
+      end
+    end
+
+    scenario 'Link to Creative Commons CCZero information' do
+      dataset = DatasetBuilder
+                  .new
+                  .with_licence('other')
+                  .with_licence_other('cc-zero')
+                  .build
+
+      index_and_visit(dataset)
+
+      expect(page)
+        .to have_css('meta[name="dc:rights"][content="Creative Commons CCZero"]',
+                     visible: false)
+
+      within('section.meta-data') do
+        expect(page)
+          .to have_link('Creative Commons CCZero',
+                        href: 'http://www.opendefinition.org/licenses/cc-zero')
+      end
+    end
+
+    scenario 'Additional licence information' do
+      dataset = DatasetBuilder
+                  .new
+                  .with_licence('no-licence')
+                  .with_licence_custom('Special licence')
+                  .build
+
+      index_and_visit(dataset)
+
+      expect(page)
+        .to have_css('meta[name="dc:rights"][content="Other"]',
+                     visible: false)
+
+      within('section.meta-data') do
+        expect(page)
+          .to have_link('View additional licence information',
+                        href: '#additional-licence-info')
+      end
+
+      within('section.dgu-additional-licence-info') do
+        expect(page).to have_content('Special licence')
+      end
+    end
+
+    scenario 'Explicit licence information' do
+      dataset = DatasetBuilder
+                  .new
+                  .with_licence_code('example-1.1')
+                  .with_licence_title('Example Open License 1.1')
+                  .with_licence_url('https://opensource.org/licenses/Example-1.1')
+                  .build
+
+      index_and_visit(dataset)
+
+      expect(page)
+        .to have_css('meta[name="dc:rights"][content="Example Open License 1.1"]',
+                     visible: false)
+
+      within('section.meta-data') do
+        expect(page)
+          .to have_link('Example Open License 1.1',
+                        href: 'https://opensource.org/licenses/Example-1.1')
+      end
+    end
+
+    scenario 'Explicit licence information with additional license information' do
+      dataset = DatasetBuilder
+                  .new
+                  .with_licence_code('feature-spec-2.1')
+                  .with_licence_title('Feature Spec Open License 2.1')
+                  .with_licence_url('https://opensource.org/licenses/Feature-Spec-2.1')
+                  .with_licence_custom('For feature specs only.')
+                  .build
+
+      index_and_visit(dataset)
+
+      expect(page)
+        .to have_css('meta[name="dc:rights"][content="Feature Spec Open License 2.1"]',
+                     visible: false)
+
+      within('section.meta-data') do
+        expect(page)
+          .to have_link('Feature Spec Open License 2.1',
+                        href: 'https://opensource.org/licenses/Feature-Spec-2.1')
+
+        expect(page)
+          .to have_link('View additional licence information',
+                        href: '#additional-licence-info')
+      end
+
+      within('section.dgu-additional-licence-info') do
+        expect(page).to have_content('For feature specs only.')
+      end
+    end
+  end
+
   feature 'Map preview links' do
     scenario 'WMS Resources have a link to map preview if we have inspire metadata' do
       dataset = DatasetBuilder

--- a/spec/support/dataset_spec_builder.rb
+++ b/spec/support/dataset_spec_builder.rb
@@ -161,6 +161,31 @@ class DatasetBuilder
     self
   end
 
+  def with_licence_other(licence_other)
+    @dataset[:licence_other] = licence_other
+    self
+  end
+
+  def with_licence_custom(licence_custom)
+    @dataset[:licence_custom] = licence_custom
+    self
+  end
+
+  def with_licence_code(licence_code)
+    @dataset[:licence_code] = licence_code
+    self
+  end
+
+  def with_licence_title(licence_title)
+    @dataset[:licence_title] = licence_title
+    self
+  end
+
+  def with_licence_url(licence_url)
+    @dataset[:licence_url] = licence_url
+    self
+  end
+
   def build
     @dataset
   end


### PR DESCRIPTION
Ensures correct licence information is displayed.

Works with the licence information we currently have in the index, and also the information that will be added to the index as a result of https://github.com/alphagov/datagovuk_publish/pull/558.

Once the index has been rebuilt we can remove most of this logic and use the information directly from the index.

https://trello.com/c/EwW9h6EU