### PR TITLE
Reorder gems alphabetically

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,45 +2,44 @@ source 'https://rubygems.org'
 
 ruby IO.read('.ruby-version').strip
 
-gem 'rails', '~> 5.2'
-gem 'pg', '~> 0.18'
-gem 'puma', '~> 3.7'
-gem 'sass-rails', '~> 5.0'
-gem 'uglifier', '>= 1.3.0'
-gem 'jbuilder', '~> 2.5'
-gem 'govuk_elements_rails'
-gem 'govuk_template'
-gem 'kaminari', '~> 1.0.1'
-gem 'rest-client', '~> 2.0.2'
-gem 'mime-types', '~> 3.1'
-gem "elasticsearch", "~> 5.0.4"
-gem "elasticsearch-model", "~> 5.0.1"
-gem "elasticsearch-rails", "~> 5.0.1"
-gem "elasticsearch-persistence", "~> 5", require: "elasticsearch/persistence/model"
-gem 'elasticsearch-dsl', "~> 0.1.5"
-gem 'htmlentities', '~> 4.3'
+gem 'browser', '~> 2.5.3'
+gem 'elasticsearch', '~> 5.0.4'
+gem 'elasticsearch-model', '~> 5.0.1'
+gem 'elasticsearch-rails', '~> 5.0.1'
 gem 'faraday'
 gem 'faraday_middleware'
-gem 'sentry-raven'
+gem 'gds_metrics', '~> 0.0.2'
+gem 'govuk_elements_rails'
+gem 'govuk_template'
+gem 'htmlentities', '~> 4.3'
+gem 'jbuilder', '~> 2.5'
+gem 'jquery-rails'
+gem 'kaminari', '~> 1.0.1'
 gem 'lograge', '~> 0.10'
 gem 'logstash-event', '~> 1.2'
-gem 'zendesk_api'
+gem 'mime-types', '~> 3.1'
 gem 'parslet'
-gem 'gds_metrics', '~> 0.0.2'
+gem 'pg', '~> 0.18'
+gem 'puma', '~> 3.7'
+gem 'rails', '~> 5.2'
 gem 'redcarpet', '~> 3.4'
-gem 'jquery-rails'
-gem 'browser', '~> 2.5.3'
+gem 'rest-client', '~> 2.0.2'
+gem 'sass-rails', '~> 5.0'
+gem 'sentry-raven'
+gem 'uglifier', '>= 1.3.0'
+gem 'zendesk_api'
+
 
 group :development, :test do
+  gem 'brakeman', '~> 4.2'
   gem 'byebug', '~> 9'
+  gem 'dotenv-rails', '~> 2.2'
   gem 'pry', '~> 0.10'
   gem 'pry-byebug', '~> 3.4'
   gem 'pry-stack_explorer', '~> 0.4.9'
-  gem 'rspec-rails', '~> 3.6'
   gem 'rspec', '~> 3.6'
+  gem 'rspec-rails', '~> 3.6'
   gem 'webmock'
-  gem 'dotenv-rails', '~> 2.2'
-  gem 'brakeman', '~> 4.2'
 end
 
 group :development do
@@ -50,11 +49,9 @@ group :development do
 end
 
 group :test do
-  gem 'simplecov', '~> 0.13'
-  gem 'codeclimate-test-reporter', '~> 1.0.0'
   gem 'capybara', '~> 2.15.1'
   gem 'capybara-selenium', '0.0.6'
   gem 'chromedriver-helper', '~> 1.1'
+  gem 'codeclimate-test-reporter', '~> 1.0.0'
+  gem 'simplecov', '~> 0.13'
 end
-
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,10 +47,6 @@ GEM
     archive-zip (0.7.0)
       io-like (~> 0.3.0)
     arel (9.0.0)
-    axiom-types (0.1.1)
-      descendants_tracker (~> 0.0.4)
-      ice_nine (~> 0.11.0)
-      thread_safe (~> 0.3, >= 0.3.1)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     brakeman (4.2.1)
@@ -75,15 +71,11 @@ GEM
     codeclimate-test-reporter (1.0.8)
       simplecov (<= 0.13)
     coderay (1.1.2)
-    coercible (1.0.0)
-      descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.0.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.4)
     debug_inspector (0.0.3)
-    descendants_tracker (0.0.4)
-      thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.3)
     docile (1.1.5)
     domain_name (0.5.20170404)
@@ -97,23 +89,14 @@ GEM
       elasticsearch-transport (= 5.0.4)
     elasticsearch-api (5.0.4)
       multi_json
-    elasticsearch-dsl (0.1.5)
     elasticsearch-model (5.0.1)
       activesupport (> 3)
       elasticsearch (~> 5)
       hashie
-    elasticsearch-persistence (5.0.1)
-      activemodel (> 4)
-      activesupport (> 4)
-      elasticsearch (~> 5)
-      elasticsearch-model (~> 5)
-      hashie
-      virtus
     elasticsearch-rails (5.0.1)
     elasticsearch-transport (5.0.4)
       faraday
       multi_json
-    equalizer (0.0.11)
     erubi (1.7.1)
     execjs (2.7.0)
     faraday (0.13.1)
@@ -141,7 +124,6 @@ GEM
       domain_name (~> 0.5)
     i18n (1.0.0)
       concurrent-ruby (~> 1.0)
-    ice_nine (0.11.2)
     inflection (1.0.0)
     io-like (0.3.0)
     jbuilder (2.7.0)
@@ -318,11 +300,6 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.4)
-    virtus (1.0.5)
-      axiom-types (~> 0.1)
-      coercible (~> 1.0)
-      descendants_tracker (~> 0.0, >= 0.0.3)
-      equalizer (~> 0.0, >= 0.0.9)
     webmock (3.0.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -352,9 +329,7 @@ DEPENDENCIES
   codeclimate-test-reporter (~> 1.0.0)
   dotenv-rails (~> 2.2)
   elasticsearch (~> 5.0.4)
-  elasticsearch-dsl (~> 0.1.5)
   elasticsearch-model (~> 5.0.1)
-  elasticsearch-persistence (~> 5)
   elasticsearch-rails (~> 5.0.1)
   faraday
   faraday_middleware
@@ -385,7 +360,6 @@ DEPENDENCIES
   spring (~> 2.0)
   spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)
-  tzinfo-data
   uglifier (>= 1.3.0)
   webmock
   zendesk_api

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,4 +1,6 @@
-# frozen_string_literal: true
 Kaminari.configure do |config|
   config.default_per_page = 20
 end
+
+Kaminari::Hooks.init if defined?(Kaminari::Hooks)
+Elasticsearch::Model::Response::Response.__send__ :include, Elasticsearch::Model::Response::Pagination::Kaminari


### PR DESCRIPTION
Turns out that elasticsearch-model either has to be after kaminari in
the Gemfile, or its hooks have to be setup manually. I've gone with the
manual setup approach to avoid breaking an established convention.

https://github.com/elastic/elasticsearch-rails/tree/master/elasticsearch-model