### PR TITLE
Change dataset 'Last updated' value

### DIFF
--- a/app/helpers/datasets_helper.rb
+++ b/app/helpers/datasets_helper.rb
@@ -23,7 +23,7 @@ module DatasetsHelper
     if dataset.datafiles.none?
       dataset.last_updated_at
     else
-      most_recent_datafile(dataset).created_at
+      most_recent_datafile(dataset).updated_at
     end
   end
 

--- a/spec/features/dataset_show_page_spec.rb
+++ b/spec/features/dataset_show_page_spec.rb
@@ -208,14 +208,14 @@ feature 'Dataset page', elasticsearch: true do
     end
 
     context 'When a dataset has datafiles' do
-      it 'Last Updated field is the most recent datafiles creation date' do
+      it 'Last Updated field is the most recent datafiles updated_at date' do
         dataset = DatasetBuilder.new
           .with_datafiles(DATA_FILES_WITH_START_AND_ENDDATE)
           .build
         index_and_visit(dataset)
         datafiles = dataset[:datafiles]
-        last = datafiles.sort_by { |datafile| datafile[:created_at] }.last
-        date = Time.parse(last["created_at"]).strftime("%d %B %Y")
+        last = datafiles.sort_by { |datafile| datafile[:updated_at] }.last
+        date = Time.parse(last["updated_at"]).strftime("%d %B %Y")
         expect(page).to have_content("Last updated: #{date}")
       end
     end


### PR DESCRIPTION
For https://trello.com/c/wQjbYbbv/50-last-updated-different-in-search-results-vs-dataset-page

On the search results page each dataset displays a 'Last updated' date based on
its `last_updated_at` value. However after clicking through to a dataset page,
in cases where the dataset has datafiles, the metadata shows a 'Last updated'
date using the most recent datafile's `created_at` value, causing a mismatch.
This changes `Last updated` on dataset pages to display the most recent
datafile's `updated_at` value instead.

**Results page**

<img width="653" alt="search_results_before" src="https://user-images.githubusercontent.com/13434452/39252338-5abf113c-489d-11e8-9e79-c0ba15e9d9be.png">

**Dataset page before**

<img width="664" alt="dataset_page_before" src="https://user-images.githubusercontent.com/13434452/39252361-66dadbd6-489d-11e8-85bf-5579171ede9f.png">

**Dataset page after**

<img width="665" alt="dataset_page_after" src="https://user-images.githubusercontent.com/13434452/39252381-6e104d1e-489d-11e8-807e-c412de89488d.png">

