### PR TITLE
Allow focus state to appear on sort filter

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -189,15 +189,19 @@
   &__sort-type {
     margin-top: 5px;
     float: right;
-    overflow: hidden;
     width: 128px;
-    background: image-url("triangle-down.png") no-repeat right center;
+    background: image-url("triangle-down.png") no-repeat right 8px;
     background-size: 8%;
     select {
       @include copy-19;
-      width: 200px;
+      width: 128px;
       background: transparent;
       border: none;
+      -webkit-appearance: none;
+      -moz-appearance: none;
+    }
+    select::-ms-expand {
+      display: none;
     }
   }
 }


### PR DESCRIPTION
https://trello.com/c/JtJHIOr3/80-incorrect-form-focus-state-on-sort-order-button

Focus state wasn't showing for this dropdown because in order to use the custom background the dropdown was set to be overly large with a hidden overflow on the container. This approach hides the default browser chrome for dropdowns in a more targeted way and repositions things accordingly so that the yellow focus outline can be seen. 