### PR TITLE
Scope search filter values to those available in the query results

### DIFF
--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -4,15 +4,18 @@ module SearchHelper
   end
 
   def datafile_formats_for_select
-    Dataset.datafile_formats.sort.map(&:upcase).uniq.reject(&:empty?)
+    buckets = search.aggregations['datafiles']['datafile_formats']['buckets']
+    map_keys(buckets).map(&:upcase)
   end
 
   def dataset_topics_for_select
-    Dataset.topics.sort.uniq.reject(&:empty?)
+    buckets = search.aggregations['topics']['topic_titles']['buckets']
+    map_keys(buckets)
   end
 
   def dataset_publishers_for_select
-    Dataset.publishers.sort.uniq.reject(&:empty?)
+    buckets = search.aggregations['organisations']['org_titles']['buckets']
+    map_keys(buckets)
   end
 
   def selected_publisher
@@ -40,5 +43,14 @@ private
 
   def no_filters_selected?
     params[:filters].nil? || params[:filters].values.reject(&:blank?).empty?
+  end
+
+  def map_keys(buckets)
+    buckets.map { |bucket| bucket['key'] }.sort.uniq.reject(&:empty?)
+  end
+
+  def search
+    query = Search::Query.search(params)
+    Dataset.search(query)
   end
 end

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -42,32 +42,14 @@ class Dataset
     get_by_query(query: Search::Query.related(id))
   end
 
-  def self.locations
-    query = Search::Query.locations_aggregation
-    buckets = Dataset.search(query).aggregations['locations']['buckets']
-    map_keys(buckets)
-  end
-
   def self.publishers
-    query = Search::Query.publishers_aggregation
+    query = { aggs: Search::Query.publishers_aggregation }
     buckets = Dataset.search(query).aggregations['organisations']['org_titles']['buckets']
-    map_keys(buckets)
-  end
-
-  def self.topics
-    query = Search::Query.dataset_topics_aggregation
-    buckets = Dataset.search(query).aggregations['topics']['topic_titles']['buckets']
-    map_keys(buckets)
-  end
-
-  def self.datafile_formats
-    query = Search::Query.datafile_formats_aggregation
-    buckets = Dataset.search(query).aggregations['datafiles']['datafile_formats']['buckets']
-    map_keys(buckets)
+    buckets.map { |bucket| bucket['key'] }.sort.uniq.reject(&:empty?)
   end
 
   def self.datafiles
-    query = Search::Query.datafiles_aggregation
+    query = { aggs: Search::Query.datafiles_aggregation }
     Dataset.search(query).aggregations['datafiles']
   end
 
@@ -174,10 +156,6 @@ class Dataset
     datafiles.select(&:non_timeseries?)
   end
 
-  def self.map_keys(buckets)
-    buckets.map { |bucket| bucket['key'] }
-  end
-
   def organisation=(organisation)
     @organisation = Organisation.new(organisation)
   end
@@ -185,6 +163,4 @@ class Dataset
   def editable?
     harvested == false
   end
-
-  private_class_method :map_keys
 end

--- a/app/services/search/query.rb
+++ b/app/services/search/query.rb
@@ -22,21 +22,26 @@ module Search
       query
     end
 
+    def self.aggregations
+      [
+        publishers_aggregation,
+        datafile_formats_aggregation,
+        dataset_topics_aggregation
+      ]
+    end
+
     def self.publishers_aggregation
       {
-        size: 0,
-        aggs: {
-          organisations: {
-            nested: {
-              path: 'organisation'
-            },
-            aggs: {
-              org_titles: {
-                terms: {
-                  field: 'organisation.title.raw',
-                  order: { _term: 'asc' },
-                  size: TERMS_SIZE
-                }
+        organisations: {
+          nested: {
+            path: 'organisation'
+          },
+          aggs: {
+            org_titles: {
+              terms: {
+                field: 'organisation.title.raw',
+                order: { _term: 'asc' },
+                size: TERMS_SIZE
               }
             }
           }
@@ -46,35 +51,18 @@ module Search
 
     def self.datafiles_aggregation
       {
-        size: 0,
-        aggs: {
-          datafiles: {
-            nested: {
-              path: 'datafiles'
+        datafiles: {
+          nested: {
+            path: 'datafiles'
+          },
+          aggs: {
+            datasets_with_datafiles: {
+              reverse_nested: {}
             },
-            aggs: {
-              datasets_with_datafiles: {
-                reverse_nested: {}
-              },
-              formats: {
-                terms: {
-                  field: 'datafiles.format'
-                }
+            formats: {
+              terms: {
+                field: 'datafiles.format'
               }
-            }
-          }
-        }
-      }
-    end
-
-    def self.locations_aggregation
-      {
-        size: 0,
-        aggs: {
-          locations: {
-            terms: {
-              field: 'location1.raw',
-              size: TERMS_SIZE
             }
           }
         }
@@ -83,19 +71,16 @@ module Search
 
     def self.dataset_topics_aggregation
       {
-        size: 0,
-        aggs: {
-          topics: {
-            nested: {
-              path: 'topic'
-            },
-            aggs: {
-              topic_titles: {
-                terms: {
-                  field: 'topic.title.raw',
-                  order: { _term: 'asc' },
-                  size: TERMS_SIZE
-                }
+        topics: {
+          nested: {
+            path: 'topic'
+          },
+          aggs: {
+            topic_titles: {
+              terms: {
+                field: 'topic.title.raw',
+                order: { _term: 'asc' },
+                size: TERMS_SIZE
               }
             }
           }
@@ -105,17 +90,14 @@ module Search
 
     def self.datafile_formats_aggregation
       {
-        size: 0,
-        aggs: {
-          datafiles: {
-            nested: {
-              path: 'datafiles'
-            },
-            aggs: {
-              datafile_formats: {
-                terms: {
-                  field: 'datafiles.format'
-                }
+        datafiles: {
+          nested: {
+            path: 'datafiles'
+          },
+          aggs: {
+            datafile_formats: {
+              terms: {
+                field: 'datafiles.format'
               }
             }
           }
@@ -198,6 +180,8 @@ module Search
       end
 
       query[:sort] = { "last_updated_at": { "order": "desc" } } if sort_param == "recent"
+
+      query[:aggs] = aggregations.inject(&:merge)
 
       query
     end

--- a/spec/features/search_page_spec.rb
+++ b/spec/features/search_page_spec.rb
@@ -308,4 +308,30 @@ feature 'Search page', elasticsearch: true do
   def assert_search_results_headings(*headings)
     expect(all('h2 a').map(&:text)).to contain_exactly(*headings)
   end
+
+  scenario 'search filters are scoped to search query results' do
+    foo_dataset = DatasetBuilder
+                    .new
+                    .with_title('Foo')
+                    .with_publisher('Org 1')
+                    .with_topic({ name: 'fun', title: 'Fun' })
+                    .with_datafiles([{ format: 'CSV' }])
+                    .build
+
+    bar_dataset = DatasetBuilder
+                    .new
+                    .with_title('Bar')
+                    .with_publisher('Org 2')
+                    .with_topic({ name: 'trivia', title: 'Trivia' })
+                    .with_datafiles([{ format: 'PDF' }])
+                    .build
+
+    index(foo_dataset, bar_dataset)
+
+    search_for('foo')
+
+    expect(page).to have_select('Publisher', options: ['', 'Org 1'])
+    expect(page).to have_select('Topic', options: ['', 'Fun'])
+    expect(page).to have_select('Format', options: ['', 'CSV'])
+  end
 end


### PR DESCRIPTION
This PR makes sure the search filters are scoped to the search query results.

https://trello.com/c/pZt678Ds/75-filters-should-show-only-include-applicable-options

https://www.elastic.co/guide/en/elasticsearch/guide/master/_scoping_aggregations.html