### PR TITLE
Never used the unpublished dataset editor

### DIFF
--- a/app/helpers/datasets_helper.rb
+++ b/app/helpers/datasets_helper.rb
@@ -9,14 +9,7 @@ module DatasetsHelper
   }.freeze
 
   def edit_dataset_url(dataset)
-    url = URI::HTTPS.build(host: 'data.gov.uk')
-    url += if dataset.released?
-             '/dataset/edit/'
-           else
-             '/unpublished/edit-item/'
-           end
-    url += dataset.legacy_name
-    url.to_s
+    URI::HTTPS.build(host: 'data.gov.uk', path: "/dataset/edit/#{dataset.legacy_name}").to_s
   end
 
   def displayed_date(dataset)

--- a/spec/features/dataset_show_page_spec.rb
+++ b/spec/features/dataset_show_page_spec.rb
@@ -627,7 +627,7 @@ feature 'Dataset page', elasticsearch: true do
                   .build
 
       index_and_visit(dataset)
-      expect(page).to have_link('Sign in', href: 'https://data.gov.uk/unpublished/edit-item/abc123')
+      expect(page).to have_link('Sign in', href: 'https://data.gov.uk/dataset/edit/abc123')
     end
   end
 end

--- a/spec/helpers/datasets_helper_spec.rb
+++ b/spec/helpers/datasets_helper_spec.rb
@@ -12,10 +12,10 @@ RSpec.describe DatasetsHelper do
       expect(url).to eq 'https://data.gov.uk/dataset/edit/foo'
     end
 
-    it 'uses the unpublished view if there are datafiles' do
+    it 'uses the dataset editor even when there are no datafiles' do
       unpublished_attributes = attributes.with_datafiles([])
       url = helper.edit_dataset_url(Dataset.new(unpublished_attributes.build))
-      expect(url).to eq 'https://data.gov.uk/unpublished/edit-item/foo'
+      expect(url).to eq 'https://data.gov.uk/dataset/edit/foo'
     end
   end
 


### PR DESCRIPTION
Regardless of whether we consider a dataset as 'unpublished' (in legacy
terms) always send the user to the normal dataset editor.  Some
workflows involve saving a dataset without any files intending to come
back to it, but they then can't because they get sent to the wrong
editor.