### PR TITLE
Use js to determine whether to show beta banner, rather than server s…

### DIFF
--- a/app/assets/javascripts/beta_banner.js
+++ b/app/assets/javascripts/beta_banner.js
@@ -1,0 +1,26 @@
+$(document).ready(function () {
+  var banner = document.getElementById('dgu-beta__banner');
+  var beta_cancel = document.getElementById('dgu-survey-cancel')
+  var phase = document.getElementById('dgu-phase-banner');
+
+  // if the beta banner is served by the back end, reveal it with CSS (default state is hidden)
+  // UNLESS user has dismissed it and has a cookie
+  if(banner && GOVUK.cookie('dgu_beta_banner_dismissed') != 'true') {
+    banner.classList.remove("dgu-beta__banner--hidden");
+    var dgu_beta_banner = "visible";
+  }
+
+  // if the banner is revealed, hide the "beta" label
+  if(phase && dgu_beta_banner == "visible") {
+    phase.classList.add("phase-banner--hidden");
+  }
+
+  // when user dismisses banner, set cookie for 1 year, hide banner, and display label
+  beta_cancel.addEventListener("click", function onclick(event) {
+    GOVUK.cookie('dgu_beta_banner_dismissed', 'true', { days: 365 });
+    banner.classList.add("dgu-beta__banner--hidden");
+    phase.classList.remove("phase-banner--hidden");
+    event.preventDefault();
+  });
+
+})

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -70,6 +70,15 @@
 }
 
 // dgu beta message ============================================================
+#dgu-beta__banner {
+    background: #0C5FA3;
+    max-width: 100%
+}
+
+.dgu-beta__banner--hidden{
+  display:none;
+}
+
 .dgu-beta {
   &__banner {
     background: #0C5FA3;
@@ -103,6 +112,9 @@
       }
     }
   }
+}
+.phase-banner--hidden{
+  display:none;
 }
 
 // split-background layout  ====================================================

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,6 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception, prepend: true
   before_action :set_raven_context
-  before_action :toggle_beta_message
 
 private
 
@@ -10,14 +9,5 @@ private
                         url: request.url,
                         environment: Rails.env,
                         app: ENV['VCAP_APPLICATION'])
-  end
-
-  def toggle_beta_message
-    flash[:beta_message] =
-      beta_message_unseen? ? 'show' : 'hide'
-  end
-
-  def beta_message_unseen?
-    !session.key?('beta_message') || session[:beta_message] == false
   end
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,6 +1,0 @@
-class MessagesController < ApplicationController
-  def acknowledge
-    session[:beta_message] = true
-    redirect_back(fallback_location: root_path)
-  end
-end

--- a/app/views/layouts/_beta_message.html.erb
+++ b/app/views/layouts/_beta_message.html.erb
@@ -1,4 +1,4 @@
-<div class="dgu-beta__banner">
+<div id="dgu-beta__banner" class="dgu-beta__banner--hidden">
   <div class="dgu-beta__message">
     <p>
       We’ve been improving data.gov.uk to help you find and use open government data.<br />
@@ -6,8 +6,10 @@
     </p>
 
     <p>
-      <%= link_to "Don't show this message again", acknowledge_path %>
+      <a class="survey-close-button" href="#user-survey-cancel" id="dgu-survey-cancel" role="button">
+        Don't show this message again
+      </a>
     </p>
-    
+
   </div>
 </div>

--- a/app/views/layouts/_feedback_survey_banner.html.erb
+++ b/app/views/layouts/_feedback_survey_banner.html.erb
@@ -1,4 +1,4 @@
-<div class="phase-banner">
+<div id="dgu-phase-banner" class="phase-banner">
   <p>
     <strong class="phase-tag">BETA</strong>
     <span><%= t(".beta_survey_message_html", :href => link_to(t('.href'), t('.survey_url')))%>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,14 +35,14 @@
 <% end %>
 
 <% content_for :after_header do %>
-  <%= render 'layouts/beta_message' if flash[:beta_message] == 'show'%>
+  <%= render 'layouts/beta_message' %>
   <%= render 'layouts/staging_ribbon' if Rails.env.staging? %>
 <% end %>
 
 <% content_for :content do %>
   <div class="dgu-top-non-content">
     <div class="dgu-top-non-content__inner">
-      <%= render 'layouts/feedback_survey_banner' if flash[:beta_message] == 'hide'%>
+      <%= render 'layouts/feedback_survey_banner' %>
       <%= yield :breadcrumb %>
     </div>
   </div>

--- a/spec/features/beta_message_spec.rb
+++ b/spec/features/beta_message_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 feature "Combined data.gov.uk and beta banner" do
-  scenario "Is displayed on all pages for a first time visitor" do
+  scenario "Is displayed on all pages for a first time visitor", js: true do
     dataset = DatasetBuilder.new.build
 
     index(dataset)
@@ -18,10 +18,11 @@ feature "Combined data.gov.uk and beta banner" do
       within '.dgu-beta__message' do
         expect(page).to have_content('We’ve been improving data.gov.uk')
       end
+      expect(page).to have_selector('#dgu-beta__banner', visible: true)
     end
   end
 
-  scenario "Dismissing banner on search page works and retains query" do
+  scenario "Dismissing banner on search page works and retains query", js: true do
     dataset = DatasetBuilder.new
                 .with_title("Zebra data")
                 .build
@@ -31,35 +32,20 @@ feature "Combined data.gov.uk and beta banner" do
     visit search_path(q: 'zebra')
 
     expect(page).to have_field('Search', with: 'zebra')
+    expect(page).to_not have_selector('.dgu-beta__banner--hidden')
 
     within '.dgu-beta__message' do
       click_link "Don't show this message again"
     end
 
     expect(page).to have_field('Search', with: 'zebra')
-    expect(page).to_not have_selector('.dgu-beta__message')
-  end
-
-  scenario "Dismissing banner on dataset page works" do
-    dataset = DatasetBuilder.new
-                .with_title("Zebra data")
-                .build
-
-    index_and_visit(dataset)
-
-    expect(page).to have_selector('h1', text: 'Zebra')
-
-    within '.dgu-beta__message' do
-      click_link "Don't show this message again"
-    end
-
-    expect(page).to have_selector('h1', text: 'Zebra')
-    expect(page).to_not have_selector('.dgu-beta__message')
+    expect(page).to have_selector('.dgu-beta__banner--hidden', visible: false)
+    expect(page).to have_selector('#dgu-beta__banner', visible: false)
   end
 end
 
 feature "Beta banner" do
-  it "is displayed on all pages after the combined banner is dismissed" do
+  it "is displayed on all pages after the combined banner is dismissed", js: true do
     dataset = DatasetBuilder.new.build
 
     index(dataset)
@@ -81,11 +67,12 @@ feature "Beta banner" do
     paths.each do |path|
       visit path
 
-      within '.phase-banner' do
+      expect(page).to have_selector('#dgu-phase-banner', visible: true)
+      within '#dgu-phase-banner' do
         expect(page).to have_content('This is a new service – your feedback will help us to improve it')
       end
 
-      expect(page).to_not have_selector('.dgu-beta__message')
+      expect(page).to_not have_selector('.phase-banner--hidden')
     end
   end
 end


### PR DESCRIPTION
…ide code

https://trello.com/c/OJtmziK9/107-stop-using-sessions-for-weve-been-improving-blue-message-bar

This PR lets us stop using server side code to display our blue beta banner.

It adds some IDs to make js manipulation easier, and some classes to hide 
content from the user. It also strips out the unnecessary server side messaging
and updates the tests to check the js solution. The cookie setting/checking code 
is called from an inherited gov.uk library so the new js is minimal.

By default, with no js available, the phase banner will display. If js is 
available, and the user does not have a relevant cookie, the beta banner will 
replace the phase banner. When a user interacts with the dismiss link, the 
cookie is set for 365 days, and the large banner is switched back to the phase
banner.