### PR TITLE
Constrain csv preview tables to the width of the page

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -318,6 +318,8 @@
 // preview page
 
 .dgu-datafile-preview {
+  border: 5px solid #dee0e2;
+  margin: 30px 0 30px;
   margin-top: 40px;
   table {
     border: 2px solid $panel-colour;
@@ -333,6 +335,11 @@
       border-bottom: none;
     }
   }
+}
+.dgu-datafile-preview__inner {
+  border: 1px solid $panel-colour;
+  padding: 4px;
+  overflow: auto;
 }
 
 // =============================================================================

--- a/app/views/previews/show.html.erb
+++ b/app/views/previews/show.html.erb
@@ -23,6 +23,7 @@
     </div>
     <div class = 'column-full'>
       <section class="dgu-datafile-preview">
+        <div class="dgu-datafile-preview__inner">
           <table>
             <thead>
               <tr>
@@ -41,6 +42,7 @@
               <% end %>
             </tbody>
           </table>
+        </div>
         <% else %>
           <p><%= "#{t('.no_preview_avail')} \"#{@datafile.name}\"" %></p>
         <% end %>


### PR DESCRIPTION
https://trello.com/c/QAuITMn3/104-background-of-preview-doesnt-stretch-right-across-page

- Add a wrapper and border to the csv preview tables as seen elsewhere
on gov.uk data tables
- Fix wrapper to width of page body, with overflow set to auto so that
wider tables appear with a horizontal scroll bar

Before/after screenshots:
![screen shot 2018-05-01 at 10 26 06](https://user-images.githubusercontent.com/31649453/39469557-bee2141a-4d30-11e8-9fc6-39644c0aed96.png)
![screen shot 2018-05-01 at 10 26 43](https://user-images.githubusercontent.com/31649453/39469558-bf011b1c-4d30-11e8-8a2b-347c86737187.png)