### PR TITLE
Allow long contact email addresses to wrap

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -410,6 +410,7 @@ span.showHide-open-all {
     padding-left: 0;
     span {
       display: block;
+      word-wrap: break-word;
     }
     h3 {
       padding-bottom: 8px;


### PR DESCRIPTION
A fix for the behaviour documented here:
https://trello.com/c/MJQ4Mrrc/151-check-error-on-display-of-contact-details

Before:
![screen shot 2018-05-02 at 13 12 19](https://user-images.githubusercontent.com/31649453/39522619-b3506842-4e0a-11e8-8698-689adf1e954d.png)

After:
![screen shot 2018-05-02 at 13 12 54](https://user-images.githubusercontent.com/31649453/39522631-c181bc72-4e0a-11e8-8e41-7e0472fd914b.png)
