### PR TITLE
Remove the word additional from licences and don't show Other

### DIFF
--- a/app/views/datasets/_meta_data.html.erb
+++ b/app/views/datasets/_meta_data.html.erb
@@ -55,14 +55,19 @@
 
               <% if @dataset.licence_custom.present? %>
                 <br />
-                <%= link_to t('.view_additional_licence_information'),
-                            '#additional-licence-info' %>
+                <%= link_to t('.view_licence_information'),
+                            '#licence-info' %>
               <% end %>
             </dd>
           <% else %>
-            <dd class="dgu-unavailable">
-              <%= t('.no_licence') %>
-            </dd>
+            <% if @dataset.licence_custom.present? %>
+              <%= link_to t('.view_licence_information'),
+                          '#licence-info' %>
+            <% else %>
+              <dd class="dgu-unavailable">
+                <%= t('.no_licence') %>
+              </dd>
+            <% end %>
           <% end %>
         </dl>
 

--- a/app/views/datasets/show.html.erb
+++ b/app/views/datasets/show.html.erb
@@ -53,13 +53,13 @@
     <% end %>
 
     <% if @dataset.licence_custom.present? %>
-      <section class="dgu-additional-licence-info">
+      <section class="dgu-licence-info">
         <div class="grid-row">
           <div class="column-full">
-            <h2 class="heading-medium" id="additional-licence-info">
-              <%= t('.additional_licence_information') %>
+            <h2 class="heading-medium" id="licence-info">
+              <%= t('.licence_information') %>
             </h2>
-            <p class="dgu-additional-licence-info__notes">
+            <p class="dgu-licence-info__notes">
               <%= to_markdown(@dataset.licence_custom) %>
             </p>
           </div>

--- a/config/locales/views/datasets/en.yml
+++ b/config/locales/views/datasets/en.yml
@@ -56,7 +56,7 @@ en:
       related_datasets: "Related datasets"
       search_gov_data: "Search"
       data_links: "Data links"
-      view_additional_licence_information: "View additional licence information"
+      view_licence_information: "View licence information"
       no_licence: "None"
       uk_ogl: "Open Government Licence"
       accessibility:
@@ -68,7 +68,7 @@ en:
       date_added: "Date added"
       format: "Format"
     show:
-      additional_licence_information: "Additional licence information"
+      licence_information: "Licence information"
       open_all: "Open all"
       data_links: "Data links"
       not_released: "This data hasn’t been released by the publisher."

--- a/spec/features/dataset_show_page_spec.rb
+++ b/spec/features/dataset_show_page_spec.rb
@@ -47,11 +47,11 @@ feature 'Dataset page', elasticsearch: true do
                         href: 'http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/')
 
         expect(page)
-          .to have_link('View additional licence information',
-                        href: '#additional-licence-info')
+          .to have_link('View licence information',
+                        href: '#licence-info')
       end
 
-      within('section.dgu-additional-licence-info') do
+      within('section.dgu-licence-info') do
         expect(page).to have_content('Special case')
       end
     end
@@ -76,7 +76,7 @@ feature 'Dataset page', elasticsearch: true do
       end
     end
 
-    scenario 'Additional licence information' do
+    scenario 'Licence information' do
       dataset = DatasetBuilder
                   .new
                   .with_licence('no-licence')
@@ -91,11 +91,11 @@ feature 'Dataset page', elasticsearch: true do
 
       within('section.meta-data') do
         expect(page)
-          .to have_link('View additional licence information',
-                        href: '#additional-licence-info')
+          .to have_link('View licence information',
+                        href: '#licence-info')
       end
 
-      within('section.dgu-additional-licence-info') do
+      within('section.dgu-licence-info') do
         expect(page).to have_content('Special licence')
       end
     end
@@ -142,11 +142,11 @@ feature 'Dataset page', elasticsearch: true do
                         href: 'https://opensource.org/licenses/Feature-Spec-2.1')
 
         expect(page)
-          .to have_link('View additional licence information',
-                        href: '#additional-licence-info')
+          .to have_link('View licence information',
+                        href: '#licence-info')
       end
 
-      within('section.dgu-additional-licence-info') do
+      within('section.dgu-licence-info') do
         expect(page).to have_content('For feature specs only.')
       end
     end


### PR DESCRIPTION
When there is no main licence and a custom licence, we no longer show
the word other.  We instead show a link to the licence information
below.

We have removed the word additional from any mention of licences.

https://trello.com/c/XpSB7F2k/121-improve-labelling-of-licence-information-on-dataset-page-s