### PR TITLE
Display public updated at on dataset show page

### DIFF
--- a/app/helpers/datasets_helper.rb
+++ b/app/helpers/datasets_helper.rb
@@ -13,7 +13,9 @@ module DatasetsHelper
   end
 
   def displayed_date(dataset)
-    if dataset.datafiles.none?
+    if dataset.public_updated_at.present?
+      dataset.public_updated_at
+    elsif dataset.datafiles.none?
       dataset.last_updated_at
     else
       most_recent_datafile(dataset).updated_at

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -13,7 +13,7 @@ class Dataset
                 :harvested, :uuid, :short_id, :topic,
                 :inspire_dataset, :json, :notes,
                 :_index, :_type, :_id, :_score, :_source,
-                :_version
+                :_version, :public_updated_at
 
   attr_writer :licence_code, :licence_title, :licence_url
   attr_reader :organisation

--- a/spec/support/dataset_spec_builder.rb
+++ b/spec/support/dataset_spec_builder.rb
@@ -49,7 +49,8 @@ class DatasetBuilder
         },
         datafiles: [],
         docs: [],
-        notes: ''
+        notes: '',
+        public_updated_at: Time.now,
     }
   end
 


### PR DESCRIPTION
For https://trello.com/c/wQjbYbbv/50-last-updated-different-in-search-results-vs-dataset-page

This adds `public_updated_at` to the Dataset model so that we can access it in Elasticsearch, and conditionally uses this value as the "Last updated" date on the Dataset show page when it's present.  After deploying https://github.com/alphagov/datagovuk_publish/pull/602 and rebuilding the Elasticsearch index then we'll remove the conditional logic in the `displayed_date` helper so that we only use `public_updated_at`.