### PR TITLE
Display public updated at in search results

### DIFF
--- a/app/helpers/datasets_helper.rb
+++ b/app/helpers/datasets_helper.rb
@@ -12,16 +12,6 @@ module DatasetsHelper
     URI::HTTPS.build(host: 'data.gov.uk', path: "/dataset/edit/#{dataset.legacy_name}").to_s
   end
 
-  def displayed_date(dataset)
-    if dataset.public_updated_at.present?
-      dataset.public_updated_at
-    elsif dataset.datafiles.none?
-      dataset.last_updated_at
-    else
-      most_recent_datafile(dataset).updated_at
-    end
-  end
-
   def to_markdown(content)
     markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML, autolink: true, tables: false)
     markdown.render(content).html_safe
@@ -69,7 +59,7 @@ module DatasetsHelper
       },
       description: dataset.summary,
       license: dataset.licence == 'uk-ogl' ? '' : dataset.licence_other,
-      dateModified: displayed_date(dataset)
+      dateModified: dataset.public_updated_at
     }
     if dataset.licence == 'uk-ogl'
       dataset_metadata[:license] = "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"

--- a/app/services/search/query.rb
+++ b/app/services/search/query.rb
@@ -179,7 +179,7 @@ module Search
         query[:query][:bool][:should] << organisation_category_filter('local-council', boost: 1)
       end
 
-      query[:sort] = { "last_updated_at": { "order": "desc" } } if sort_param == "recent"
+      query[:sort] = { "public_updated_at": { "order": "desc" } } if sort_param == "recent"
 
       query[:aggs] = aggregations.inject(&:merge)
 

--- a/app/views/datasets/_meta_data.html.erb
+++ b/app/views/datasets/_meta_data.html.erb
@@ -1,7 +1,7 @@
 <% content_for :head do %>
   <%= tag.meta name: 'dc:title',   content: unescape(@dataset.title) %>
   <%= tag.meta name: 'dc:creator', content: @dataset.organisation.title %>
-  <%= tag.meta name: 'dc:date',    content: Date.parse(displayed_date(@dataset)).to_formatted_s %>
+  <%= tag.meta name: 'dc:date',    content: Date.parse(@dataset.public_updated_at).to_formatted_s %>
 
   <% if @dataset.licence_title.present? %>
     <%= tag.meta name: 'dc:rights', content: @dataset.licence_title %>
@@ -34,8 +34,8 @@
           </dd>
 
           <dt><%= t('.last_updated') %>:</dt>
-          <dd property="dc:date" content="<%= format_timestamp(displayed_date(@dataset)) %>">
-            <%= format_timestamp(displayed_date(@dataset)) %>
+          <dd property="dc:date" content="<%= format_timestamp(@dataset.public_updated_at) %>">
+            <%= format_timestamp(@dataset.public_updated_at) %>
           </dd>
 
           <dt><%= t('.topic') %>:</dt>

--- a/app/views/search/search.html.erb
+++ b/app/views/search/search.html.erb
@@ -53,8 +53,8 @@
                 <dt><%= t('.meta_data_box.published_by') %>:</dt>
                 <dd class="published_by"><%= dataset.organisation['title'] %></dd>
                 <dt><%= t('.meta_data_box.last_updated') %>:</dt>
-                <% if dataset.last_updated_at.present? %>
-                  <dd class="last_updated"><%= format_timestamp(dataset.last_updated_at) %></dd>
+                <% if dataset.public_updated_at.present? %>
+                  <dd class="last_updated"><%= format_timestamp(dataset.public_updated_at) %></dd>
                 <% else %>
                   <dd class="last_updated dgu-secondary-text"> <%= t('.meta_data_box.not_applicable') %></dd>
                 <% end %>

--- a/spec/features/dataset_show_page_spec.rb
+++ b/spec/features/dataset_show_page_spec.rb
@@ -199,36 +199,10 @@ feature 'Dataset page', elasticsearch: true do
       expect(page).to have_content('Topic: Not added')
     end
 
-    context 'When public_updated_at is present on a dataset' do
-      scenario 'Last Updated field displays public_updated_at' do
-        dataset = DatasetBuilder.new.build
-        index_and_visit(dataset)
-        expect(page).to have_content("Last updated: #{dataset['last_updated_at']}")
-      end
-    end
-
-    context 'When public_updated_at is not present on a dataset with no datafiles' do
-      scenario 'Last Updated field displays dataset last_updated_at' do
-        dataset = DatasetBuilder.new.build
-        dataset.delete(:public_updated_at)
-        index_and_visit(dataset)
-        expect(page).to have_content("Last updated: #{dataset['last_updated_at']}")
-      end
-    end
-
-    context 'When public_updated_at is not present on a dataset with datafiles' do
-      scenario 'Last Updated field displays most recent datafile updated_at' do
-        last_datafile = DATA_FILES_WITH_START_AND_ENDDATE.last
-        datafile_updated_at = Time.parse(last_datafile['updated_at']).strftime('%d %B %Y')
-
-        dataset = DatasetBuilder.new
-          .with_datafiles([last_datafile])
-          .build
-        dataset.delete(:public_updated_at)
-
-        index_and_visit(dataset)
-        expect(page).to have_content("Last updated: #{datafile_updated_at}")
-      end
+    scenario 'Last Updated field displays public_updated_at' do
+      dataset = DatasetBuilder.new.build
+      index_and_visit(dataset)
+      expect(page).to have_content("Last updated: #{dataset['public_updated_at']}")
     end
   end
 

--- a/spec/features/search_page_spec.rb
+++ b/spec/features/search_page_spec.rb
@@ -32,13 +32,12 @@ feature 'Search page', elasticsearch: true do
     old_dataset = DatasetBuilder.new
                     .with_title('Old Interesting Dataset')
                     .with_name('old-dataset')
-                    .last_updated_at('2014-07-24T14:47:25.975Z')
+                    .public_updated_at(Time.now - 1)
                     .build
 
     new_dataset = DatasetBuilder.new
                     .with_title('Recent Interesting Dataset')
                     .with_name('new-dataset')
-                    .last_updated_at('2017-07-24T14:47:25.975Z')
                     .build
 
     index(old_dataset, new_dataset)

--- a/spec/support/dataset_spec_builder.rb
+++ b/spec/support/dataset_spec_builder.rb
@@ -129,6 +129,11 @@ class DatasetBuilder
     self
   end
 
+  def public_updated_at(date_string)
+    @dataset[:public_updated_at] = date_string
+    self
+  end
+
   def with_publisher(publisher)
     @dataset[:organisation][:name] = publisher
     @dataset[:organisation][:title] = publisher


### PR DESCRIPTION
For https://trello.com/c/wQjbYbbv/50-last-updated-different-in-search-results-vs-dataset-page

This updates the "recent" sort functionality to sort by `public_updated_at` instead of `last_updated_at`.  In cases where a dataset has datafiles, `public_updated_at` is the date a datafile was last updated, and in cases where a dataset has no datafiles, `public_updated_at` is the date the metadata was last updated.

Now that we have `public_updated_at` we no longer need the `displayed_date` helper to determine the correct date to display, so we remove it and updated references to it to use `public_updated_at` instead.