### PR TITLE
Tidy dataset sidebar on narrow views

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -271,11 +271,12 @@
     &__publisher_datasets {
       h3 {
         margin: 0;
-        padding-top: 30px;
-        border-top: 10px solid $highlight-colour;
       }
 
     }
+  }
+  @include media(mobile) {
+    padding-left: 15px;
   }
 }
 


### PR DESCRIPTION
https://trello.com/c/uWqrMoLx/110-dataset-sidebar-display-incorrectly-on-mobile

This PR removes the spurious top grey border on the right nav at all screen widths, and improves the padding on narrow views. 

The linked trello ticket also suggested doing a re-ordering on mobile but a bigger reworking is really needed - to be documented on the ticket.