### PR TITLE
Revert "Disable sessions in favour of manual cookies"

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,1 +1,1 @@
-Rails.application.config.session_store :disabled
+Rails.application.config.session_store :cookie_store, expire_after: 14.days, secure: !(Rails.env.development? || Rails.env.test?), httponly: true


### PR DESCRIPTION
https://trello.com/c/i5iX0OiN/224-zendesk-integration-is-broken

This reverts commit ef59e515f4bf85842054e82997460714344a54ff.

The Zendesk form uses an authenticity token, which requires rails sessions.