### PR TITLE
Adds a HTML view of the INSPIRE metadata alongside the XML one

### DIFF
--- a/app/views/datasets/_additional_info.html.erb
+++ b/app/views/datasets/_additional_info.html.erb
@@ -73,6 +73,8 @@
               <dt><%= t('.inspire_gemini_record') %></dt>
               <dd>
                 <%= link_to t('.xml'), "/api/2/rest/harvestobject/#{ i['harvest_object_id'] }/xml" %>
+                <br />
+                <%= link_to t('.html'), "/api/2/rest/harvestobject/#{ i['harvest_object_id'] }/html" %>
               </dd>
             <% end %>
           </dl>

--- a/config/locales/views/datasets/en.yml
+++ b/config/locales/views/datasets/en.yml
@@ -25,6 +25,7 @@ en:
       inspire_access_constraints_unspecified: "Not specified"
       inspire_gemini_record: "Source Metadata"
       xml: "XML"
+      html: "HTML"
     breadcrumb:
       home: "Home"
       search: "Search"

--- a/spec/features/dataset_show_page_spec.rb
+++ b/spec/features/dataset_show_page_spec.rb
@@ -346,6 +346,26 @@ RSpec.feature 'Dataset page', type: :feature, elasticsearch: true do
       expect(page).to have_content(notes)
     end
 
+    scenario 'Contains a link to original INSPIRE XML' do
+      dataset = DatasetBuilder
+        .new
+        .with_inspire_metadata('harvest_object_id' => '1234')
+        .build
+      index_and_visit(dataset)
+
+      expect(page).to have_xpath("//a[@href='/api/2/rest/harvestobject/1234/xml']")
+    end
+
+    scenario 'Contains a link to HTML rendering of INSPIRE XML' do
+      dataset = DatasetBuilder
+        .new
+        .with_inspire_metadata('harvest_object_id' => '1234')
+        .build
+      index_and_visit(dataset)
+
+      expect(page).to have_xpath("//a[@href='/api/2/rest/harvestobject/1234/html']")
+    end
+
     scenario 'Is not displayed if not available' do
       dataset = DatasetBuilder.new
         .with_datafiles(DATA_FILES_WITH_START_AND_ENDDATE)


### PR DESCRIPTION
When datasets are harvested, CKAN stores the metadata it retrieved in
the database.  For inspire datasets, we should show the HTML rendering
of the metadata so that it is legible, and to reduce the need for adding
more metadata to our Additional Information section.