### PR TITLE
Ignore spec examples file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .env
 .byebug_history
+spec/examples.txt
 
 /coverage/
 /vendor/bundle


### PR DESCRIPTION
The `spec/examples.txt` is a temporary file used by Rspec. The comments say it shouldn't be tracked.