### PR TITLE
Initialize all model attributes manually

### DIFF
--- a/app/controllers/datasets_controller.rb
+++ b/app/controllers/datasets_controller.rb
@@ -6,7 +6,7 @@ class DatasetsController < ApplicationController
     @timeseries_datafiles = @dataset.timeseries_datafiles
     @non_timeseries_datafiles = @dataset.non_timeseries_datafiles
     @referer_query = referer_query
-    @related_datasets = Dataset.related(@dataset._id)
+    @related_datasets = Dataset.related(@dataset.id)
 
     if request_to_outdated_url?
       return redirect_to newest_dataset_path, status: :moved_permanently

--- a/app/models/datafile.rb
+++ b/app/models/datafile.rb
@@ -4,16 +4,16 @@ class Datafile
   attr_reader :name, :url, :start_date, :end_date,
               :created_at, :updated_at, :format, :size, :uuid
 
-  def initialize(attrs)
-    @name = attrs["name"]
-    @url = attrs["url"]
-    @start_date = attrs["start_date"]
-    @end_date = attrs["end_date"]
-    @created_at = attrs["created_at"]
-    @updated_at = attrs["updated_at"]
-    @format = attrs["format"]
-    @size = attrs["size"]
-    @uuid = attrs["uuid"]
+  def initialize(hash)
+    @name = hash["name"]
+    @url = hash["url"]
+    @start_date = hash["start_date"]
+    @end_date = hash["end_date"]
+    @created_at = hash["created_at"]
+    @updated_at = hash["updated_at"]
+    @format = hash["format"]
+    @size = hash["size"]
+    @uuid = hash["uuid"]
   end
 
   def start_year

--- a/app/models/doc.rb
+++ b/app/models/doc.rb
@@ -1,15 +1,11 @@
 class Doc
-  attr_reader :name, :url, :created_at,
-              :updated_at, :format, :size,
-              :uuid
+  attr_reader :name, :url, :format, :uuid, :created_at
 
-  def initialize(attrs)
-    @name = attrs["name"]
-    @url = attrs["url"]
-    @created_at = attrs["created_at"]
-    @updated_at = attrs["updated_at"]
-    @format = attrs["format"]
-    @size = attrs["size"]
-    @uuid = attrs["uuid"]
+  def initialize(hash)
+    @name = hash["name"]
+    @url = hash["url"]
+    @format = hash["format"]
+    @created_at = hash["created_at"]
+    @uuid = hash["uuid"]
   end
 end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,9 +1,13 @@
 class Organisation
-  include ActiveModel::Model
+  attr_reader :title, :name, :contact_email,
+              :foi_email, :foi_web, :contact_name
 
-  attr_accessor :id, :name, :title, :description, :abbreviation,
-                :replace_by, :contact_email, :contact_phone, :contact_name,
-                :foi_email, :foi_phone, :foi_name, :foi_web, :category,
-                :organisation_user_id, :created_at, :updated_at, :uuid,
-                :active, :org_type, :ancestry, :govuk_content_id
+  def initialize(hash)
+    @title = hash['title']
+    @name = hash['name']
+    @contact_email = hash['contact_email']
+    @contact_name = hash['contact_name']
+    @foi_email = hash['foi_email']
+    @foi_web = hash['foi_web']
+  end
 end

--- a/spec/helpers/datasets_helper_spec.rb
+++ b/spec/helpers/datasets_helper_spec.rb
@@ -8,13 +8,13 @@ RSpec.describe DatasetsHelper do
     end
 
     it 'uses the normal view if there are datafiles' do
-      url = helper.edit_dataset_url(Dataset.new(attributes.build))
+      url = helper.edit_dataset_url(Dataset.new(attributes.build.stringify_keys))
       expect(url).to eq 'https://data.gov.uk/dataset/edit/foo'
     end
 
     it 'uses the dataset editor even when there are no datafiles' do
       unpublished_attributes = attributes.with_datafiles([])
-      url = helper.edit_dataset_url(Dataset.new(unpublished_attributes.build))
+      url = helper.edit_dataset_url(Dataset.new(unpublished_attributes.build.stringify_keys))
       expect(url).to eq 'https://data.gov.uk/dataset/edit/foo'
     end
   end
@@ -30,12 +30,12 @@ RSpec.describe DatasetsHelper do
 
   describe '#contact_email_is_email?' do
     it 'returns true when the email is valid' do
-      dataset = Dataset.new(DatasetBuilder.new.with_contact_email('foo@bar.com').build)
+      dataset = Dataset.new(DatasetBuilder.new.with_contact_email('foo@bar.com').build.stringify_keys)
       expect(helper.contact_email_is_email?(dataset)).to be_truthy
     end
 
     it 'returns false when the email is invalid' do
-      dataset = Dataset.new(DatasetBuilder.new.with_contact_email('http://foo.com').build)
+      dataset = Dataset.new(DatasetBuilder.new.with_contact_email('http://foo.com').build.stringify_keys)
       expect(helper.contact_email_is_email?(dataset)).to be_falsey
     end
   end


### PR DESCRIPTION
https://trello.com/c/SkQ9KxWf/139-show-availability-of-datasets-in-search-results

Using ActiveModel to initialize model attributes would create issues
when a new attribute appeared in ES but was not defined in the model.
There are two approaches to avoid this: allow all attributes using
something like OpenStruct, or unpack the attributes manually in the
initializer (or whatever calls the initializer).

The approach taken here is to manually populate the model attributes,
which has the advantage of visibility and allows for extra mapping to be
done when the model is loaded.