### PR TITLE
Fix missing FOI attribute for organisations

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,5 +1,5 @@
 class Organisation
-  attr_reader :title, :name, :contact_email,
+  attr_reader :title, :name, :contact_email, :foi_name,
               :foi_email, :foi_web, :contact_name
 
   def initialize(hash)
@@ -9,5 +9,6 @@ class Organisation
     @contact_name = hash['contact_name']
     @foi_email = hash['foi_email']
     @foi_web = hash['foi_web']
+    @foi_name = hash['foi_name']
   end
 end

--- a/app/views/datasets/_contact.html.erb
+++ b/app/views/datasets/_contact.html.erb
@@ -11,7 +11,7 @@
   </h2>
 
   <% if contact_email_exists?(dataset) %>
-    <div class="column-one-half">
+    <div class="column-one-half enquiries">
       <h3 class="heading-small">
         <%= t('datasets.contact.enquiries') %>
       </h3>

--- a/spec/features/dataset_show_page_spec.rb
+++ b/spec/features/dataset_show_page_spec.rb
@@ -377,28 +377,99 @@ RSpec.feature 'Dataset page', type: :feature, elasticsearch: true do
     end
   end
 
-  feature 'Contact' do
-    scenario 'Is displayed if available' do
-      contact_email = 'contact@somewhere.com'
-      dataset = DatasetBuilder.new
-        .with_contact_email(contact_email)
-        .with_datafiles(DATA_FILES_WITH_START_AND_ENDDATE)
-        .build
-
-      index_and_visit(dataset)
-
-      expect(page).to have_css('h2', text: 'Contact')
-      expect(page).to have_css('a', text: contact_email)
-    end
-
+  feature 'Contact enquiries' do
     scenario 'Is not displayed if not available' do
       dataset = DatasetBuilder.new
         .with_datafiles(DATA_FILES_WITH_START_AND_ENDDATE)
         .build
 
       index_and_visit(dataset)
-
       expect(page).to_not have_css('h2', text: 'Contact')
+    end
+
+    scenario 'Is displayed if available' do
+      dataset = DatasetBuilder.new
+                  .with_contact_name('Mr. Contact')
+                  .with_contact_email('contact@example.com')
+                  .build
+
+      index_and_visit(dataset)
+
+      expect(page).to have_css('h2', text: 'Contact')
+      expect(page).to have_css('h3', text: 'Enquiries')
+
+      within('section.contact .enquiries') do
+        expect(page).to have_link(dataset[:contact_email])
+        expect(page).to have_content(dataset[:contact_name])
+      end
+    end
+
+    scenario 'Is displayed if available on the organisation' do
+      dataset = DatasetBuilder.new
+                  .with_org_contact_name('Mr. Contact')
+                  .with_org_contact_email('contact@example.com')
+                  .build
+
+      index_and_visit(dataset)
+
+      expect(page).to have_css('h2', text: 'Contact')
+      expect(page).to have_css('h3', text: 'Enquiries')
+
+      within('section.contact .enquiries') do
+        expect(page).to have_link(dataset[:organisation][:contact_email])
+        expect(page).to have_content(dataset[:organisation][:contact_name])
+      end
+    end
+  end
+
+  feature 'Contact FOI' do
+    scenario 'Is not displayed if not available' do
+      dataset = DatasetBuilder
+                  .new
+                  .build
+
+      index_and_visit(dataset)
+      expect(page).to_not have_css('h2', text: 'Contact')
+    end
+
+    scenario 'Is displayed if available' do
+      dataset = DatasetBuilder
+                  .new
+                  .with_foi_name('Mr. FOI')
+                  .with_foi_email('mr.foi@example.com')
+                  .with_foi_web('http://foi.com')
+                  .build
+
+      index_and_visit(dataset)
+      expect(page).to have_css('h2', text: 'Contact')
+      expect(page).to have_css('h3', text: 'Freedom of Information (FOI) requests')
+
+      within('section.contact .foi') do
+        expect(page).to have_content(dataset[:foi_name])
+        expect(page).to have_content(dataset[:foi_email])
+        expect(page).to have_link(dataset[:foi_web], href: dataset[:foi_web])
+      end
+    end
+
+    scenario 'Is displayed if available on the organisation' do
+      dataset = DatasetBuilder
+                  .new
+                  .with_org_foi_name('Mr. FOI')
+                  .with_org_foi_email('mr.foi@example.com')
+                  .with_org_foi_web('http://foi.com')
+                  .build
+
+      index_and_visit(dataset)
+      expect(page).to have_css('h2', text: 'Contact')
+      expect(page).to have_css('h3', text: 'Freedom of Information (FOI) requests')
+
+      within('section.contact .foi') do
+        expect(page).to have_content(dataset[:organisation][:foi_name])
+        expect(page).to have_content(dataset[:organisation][:foi_email])
+
+        expect(page).to have_link(dataset[:organisation][:foi_web],
+                                  href: dataset[:organisation][:foi_web])
+      end
     end
   end
 

--- a/spec/support/dataset_spec_builder.rb
+++ b/spec/support/dataset_spec_builder.rb
@@ -54,6 +54,36 @@ class DatasetBuilder
     }
   end
 
+  def with_org_foi_name(name)
+    @dataset[:organisation][:foi_name] = name
+    self
+  end
+
+  def with_org_foi_email(email)
+    @dataset[:organisation][:foi_email] = email
+    self
+  end
+
+  def with_org_foi_web(web)
+    @dataset[:organisation][:foi_web] = web
+    self
+  end
+
+  def with_foi_name(name)
+    @dataset[:foi_name] = name
+    self
+  end
+
+  def with_foi_email(email)
+    @dataset[:foi_email] = email
+    self
+  end
+
+  def with_foi_web(web)
+    @dataset[:foi_web] = web
+    self
+  end
+
   def with_uuid(uuid)
     @dataset[:uuid] = uuid
     self
@@ -71,6 +101,21 @@ class DatasetBuilder
 
   def with_name(slug)
     @dataset[:name] = slug
+    self
+  end
+
+  def with_contact_name(name)
+    @dataset[:contact_name] = name
+    self
+  end
+
+  def with_org_contact_name(name)
+    @dataset[:organisation][:contact_name] = name
+    self
+  end
+
+  def with_org_contact_email(email)
+    @dataset[:organisation][:contact_email] = email
     self
   end
 


### PR DESCRIPTION
https://trello.com/c/SkQ9KxWf/139-show-availability-of-datasets-in-search-results

This bug occurred due to a lack of tests for the Contact section of the
dataset show page. All branches of this behaviour should now be tested.