### PR TITLE
Released strikes again

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -8,7 +8,7 @@ class Dataset
               :organisation, :id, :uuid, :datafiles, :licence, :licence_other,
               :location1, :location2, :location3, :public_updated_at, :topic,
               :licence_custom, :docs, :contact_email, :foi_email, :foi_web,
-              :notes, :inspire_dataset, :harvested, :contact_name
+              :notes, :inspire_dataset, :harvested, :contact_name, :released
 
   index_name ENV['ES_INDEX'] || "datasets-#{Rails.env}"
 
@@ -23,6 +23,7 @@ class Dataset
     @location1 = hash["location1"]
     @location2 = hash["location2"]
     @location3 = hash["location3"]
+    @released = hash["released"]
     @licence = hash["licence"]
     @licence_other = hash["licence_other"]
     @licence_custom = hash["licence_custom"]
@@ -76,10 +77,6 @@ class Dataset
   def self.datafiles
     query = { aggs: Search::Query.datafiles_aggregation }
     Dataset.search(query).aggregations['datafiles']
-  end
-
-  def released?
-    (docs.count + datafiles.count).positive?
   end
 
   def licence?

--- a/app/views/datasets/_meta_data.html.erb
+++ b/app/views/datasets/_meta_data.html.erb
@@ -21,7 +21,7 @@
     <div class="column-two-thirds">
       <div class="dgu-metadata__box dgu-metadata__box--in-dataset">
         <dl class="metadata">
-          <% if !@dataset.released? %>
+          <% unless @dataset.released %>
             <dt><%= t('.availability') %>:</dt>
             <dd>
               <span class="dgu-highlight">Not released</span>

--- a/app/views/search/search.html.erb
+++ b/app/views/search/search.html.erb
@@ -50,7 +50,7 @@
                 <%= link_to dataset.title, dataset_path(dataset.uuid, dataset.name) %>
               </h2>
               <dl class="dgu-metadata__box">
-                <% if !dataset.released? %>
+                <% unless dataset.released? %>
                   <dt><%= t('.meta_data_box.availability') %>:</dt>
                   <dd class="availability">
                   <span class="dgu-highlight">Not released</span>

--- a/app/views/search/search.html.erb
+++ b/app/views/search/search.html.erb
@@ -50,6 +50,12 @@
                 <%= link_to dataset.title, dataset_path(dataset.uuid, dataset.name) %>
               </h2>
               <dl class="dgu-metadata__box">
+                <% if !dataset.released? %>
+                  <dt><%= t('.meta_data_box.availability') %>:</dt>
+                  <dd class="availability">
+                  <span class="dgu-highlight">Not released</span>
+                  </dd>
+                <% end %>
                 <dt><%= t('.meta_data_box.published_by') %>:</dt>
                 <dd class="published_by"><%= dataset.organisation['title'] %></dd>
                 <dt><%= t('.meta_data_box.last_updated') %>:</dt>

--- a/spec/features/dataset_show_page_spec.rb
+++ b/spec/features/dataset_show_page_spec.rb
@@ -518,38 +518,16 @@ RSpec.feature 'Dataset page', type: :feature, elasticsearch: true do
   end
 
   feature 'not released label' do
-    scenario 'Not released label is not shown where there are files' do
-      dataset = DatasetBuilder
-                  .new
-                  .with_legacy_name('abc123')
-                  .with_datafiles(DATA_FILES_WITH_START_AND_ENDDATE)
-                  .build
-
+    scenario 'released is set to false' do
+      dataset = DatasetBuilder.new.with_released(false).build
       index_and_visit(dataset)
-
-      expect(page).to have_no_content('Not released')
+      expect(page).to have_content 'Not released'
     end
 
-    scenario 'Not released is not shown where there are docs' do
-      dataset = DatasetBuilder
-                  .new
-                  .with_legacy_name('abc123')
-                  .with_docs([HTML_DATAFILE])
-                  .build
-
+    scenario 'released is set to true' do
+      dataset = DatasetBuilder.new.with_released(true).build
       index_and_visit(dataset)
-
-      expect(page).to have_no_content('Not released')
-    end
-
-    scenario 'Not released is shown when there are no docs and no files' do
-      dataset = DatasetBuilder
-                  .new
-                  .with_legacy_name('abc123')
-                  .build
-
-      index_and_visit(dataset)
-      expect(page).to have_content('Not released')
+      expect(page).to have_no_content 'Not released'
     end
   end
 

--- a/spec/features/search_page_spec.rb
+++ b/spec/features/search_page_spec.rb
@@ -27,6 +27,16 @@ RSpec.feature 'Search page', type: :feature, elasticsearch: true do
     expect(page).to have_css('a', text: dataset_title)
   end
 
+  scenario 'Search results indicate dataset availability' do
+    index(DatasetBuilder.new.with_released(true).build)
+    search_for('')
+    expect(page).to have_no_content 'Not released'
+
+    index(DatasetBuilder.new.with_released(false).build)
+    search_for('')
+    expect(page).to have_content 'Not released'
+  end
+
   scenario 'Search results are correctly sorted' do
     old_dataset = DatasetBuilder.new
                     .with_title('Old Interesting Dataset')

--- a/spec/support/dataset_spec_builder.rb
+++ b/spec/support/dataset_spec_builder.rb
@@ -17,6 +17,7 @@ class DatasetBuilder
         created_at: '2013-08-31T00:56:15.435Z',
         last_updated_at: '2017-07-24T14:47:25.975Z',
         contact_email: '',
+        released: true,
         uuid: SecureRandom.uuid,
         organisation: {
             id: 582,
@@ -56,6 +57,11 @@ class DatasetBuilder
 
   def with_uuid(uuid)
     @dataset[:uuid] = uuid
+    self
+  end
+
+  def with_released(released)
+    @dataset[:released] = released
     self
   end
 


### PR DESCRIPTION
https://trello.com/c/BkjMdru2/143-remove-not-available-label-from-search-results

The previous PR was against the manual-model-attributes branch in order to make the diff clear.