### PR TITLE
Replace licence/licence_code with explicit fields

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -8,7 +8,7 @@ class SearchController < ApplicationController
     @location = params.dig(:filters, :location)
     @format = params.dig(:filters, :format)
     @topic = params.dig(:filters, :topic)
-    @licence = params.dig(:filters, :licence)
+    @licence_code = params.dig(:filters, :licence_code)
     @datasets = @search.page(page_number)
   end
 

--- a/app/helpers/datasets_helper.rb
+++ b/app/helpers/datasets_helper.rb
@@ -58,14 +58,14 @@ module DatasetsHelper
         name: dataset.organisation.title
       },
       description: dataset.summary,
-      license: dataset.licence == 'uk-ogl' ? '' : dataset.licence_other,
+      license: {
+        "@type": "CreativeWork",
+        name: dataset.licence_title,
+        text: dataset.licence_custom,
+        url: dataset.licence_url
+      },
       dateModified: dataset.public_updated_at
     }
-    if dataset.licence == 'uk-ogl'
-      dataset_metadata[:license] = "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
-    elsif dataset.licence_other
-      dataset_metadata[:license] = dataset.licence_other
-    end
     if dataset.topic
       dataset_metadata[:keywords] = dataset.topic['title']
     end

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -5,10 +5,11 @@ class Dataset
   DatasetNotFound = Class.new(StandardError)
 
   attr_reader :name, :legacy_name, :title, :summary, :description, :foi_name,
-              :organisation, :id, :uuid, :datafiles, :licence, :licence_other,
-              :location1, :location2, :location3, :public_updated_at, :topic,
-              :licence_custom, :docs, :contact_email, :foi_email, :foi_web,
-              :notes, :inspire_dataset, :harvested, :contact_name, :released
+              :organisation, :id, :uuid, :datafiles, :location1, :location2,
+              :location3, :public_updated_at, :topic, :licence_custom, :docs,
+              :contact_email, :foi_email, :foi_web, :notes, :inspire_dataset,
+              :harvested, :contact_name, :released, :licence_title, :licence_url,
+              :licence_code
 
   index_name ENV['ES_INDEX'] || "datasets-#{Rails.env}"
 
@@ -77,77 +78,6 @@ class Dataset
   def self.datafiles
     query = { aggs: Search::Query.datafiles_aggregation }
     Dataset.search(query).aggregations['datafiles']
-  end
-
-  def licence?
-    licence_code.present?
-  end
-
-  def licence_code
-    @licence_code || case licence
-                     when 'other'
-                       licence_other
-                     when 'no-licence'
-                       if licence_custom.present?
-                         'other'
-                       end
-                     else
-                       licence
-                     end
-  end
-
-  def licence_title
-    @licence_title || case licence_code
-                      when 'cc-by'
-                        'Creative Commons Attribution'
-                      when 'cc-by-sa'
-                        'Creative Commons Attribution Share-Alike'
-                      when 'cc-nc'
-                        'Creative Commons Non-Commercial (Any)'
-                      when 'cc-zero'
-                        'Creative Commons CCZero'
-                      when 'notspecified'
-                        'License Not Specified'
-                      when 'odc-by'
-                        'Open Data Commons Attribution License'
-                      when 'odc-odbl'
-                        'Open Data Commons Open Database License (ODbL)'
-                      when 'odc-pddl'
-                        'Open Data Commons Public Domain Dedication and License (PDDL)'
-                      when 'other'
-                        'Other'
-                      when 'other-closed'
-                        'Other (Not Open)'
-                      when 'other-nc'
-                        'Other (Non-Commercial)'
-                      when 'other-open'
-                        'Other (Open)'
-                      when 'other-pd'
-                        'Other (Public Domain)'
-                      when 'uk-ogl'
-                        'Open Government Licence'
-                      end
-  end
-
-  def licence_url
-    @licence_url || case licence_code
-                    when 'cc-by'
-                      'http://www.opendefinition.org/licenses/cc-by'
-                    when 'cc-by-sa'
-                      'http://www.opendefinition.org/licenses/cc-by-sa'
-                    when 'cc-nc'
-                      'http://creativecommons.org/licenses/by-nc/2.0/'
-                    when 'cc-zero'
-                      'http://www.opendefinition.org/licenses/cc-zero'
-                    when 'odc-by'
-                      'http://www.opendefinition.org/licenses/odc-by'
-                    when 'odc-odbl'
-                      'http://www.opendefinition.org/licenses/odc-odbl'
-                    when 'odc-pddl'
-                      'http://www.opendefinition.org/licenses/odc-pddl'
-                    when 'uk-ogl'
-                      'http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/'
-                    end
   end
 
   def links

--- a/app/services/search/query.rb
+++ b/app/services/search/query.rb
@@ -148,7 +148,7 @@ module Search
       location_param =  params.dig(:filters, :location)
       format_param =    params.dig(:filters, :format)
       topic_param = params.dig(:filters, :topic)
-      licence_param = params.dig(:filters, :licence)
+      licence_param = params.dig(:filters, :licence_code)
 
       query = begin
         QueryTransformer.new.apply(QueryParser.new.parse(query_param))
@@ -275,10 +275,10 @@ module Search
       }
     end
 
-    def self.licence_filter(licence)
+    def self.licence_filter(licence_code)
       {
         match: {
-          "licence": licence
+          "licence_code": licence_code
         }
       }
     end

--- a/app/views/datasets/_meta_data.html.erb
+++ b/app/views/datasets/_meta_data.html.erb
@@ -46,29 +46,25 @@
           <% end %>
 
           <dt><%= t('.licence') %>:</dt>
-          <% if @dataset.licence? %>
-            <dd property="dc:rights">
-              <%= link_to_if @dataset.licence_url.present?,
-                             @dataset.licence_title,
-                             @dataset.licence_url,
-                             rel: 'dc:rights' %>
-
-              <% if @dataset.licence_custom.present? %>
-                <br />
-                <%= link_to t('.view_licence_information'),
-                            '#licence-info' %>
-              <% end %>
-            </dd>
-          <% else %>
-            <% if @dataset.licence_custom.present? %>
-              <%= link_to t('.view_licence_information'),
-                          '#licence-info' %>
+          <dd property="dc:rights">
+            <% if @dataset.licence_url.present? %>
+              <%= link_to @dataset.licence_title,
+                          @dataset.licence_url,
+                          rel: 'dc:rights' %>
+            <% elsif @dataset.licence_title.present? %>
+              <%= @dataset.licence_title %>
+            <% elsif @dataset.licence_custom.present? %>
+              <%= t('.other_licence') %>
             <% else %>
-              <dd class="dgu-unavailable">
-                <%= t('.no_licence') %>
-              </dd>
+              <%= t('.no_licence') %>
             <% end %>
-          <% end %>
+
+            <% if @dataset.licence_custom.present? %>
+              <br>
+              <%= link_to t('.view_licence_information'),
+                            '#licence-info' %>
+            <% end %>
+          </dd>
         </dl>
 
         <h3 class="heading-small">

--- a/app/views/search/_filters.html.erb
+++ b/app/views/search/_filters.html.erb
@@ -17,8 +17,8 @@
 
 <div class="form-group">
   <div class="multiple-choice">
-    <%= check_box_tag 'filters[licence]', 'uk-ogl', @licence == 'uk-ogl' %>
-    <%= label_tag 'filters[licence]', t('.filter_by_ogl') %>
+    <%= check_box_tag 'filters[licence_code]', 'uk-ogl', @licence_code == 'uk-ogl' %>
+    <%= label_tag 'filters[licence_code]', t('.filter_by_ogl') %>
   </div>
 </div>
 

--- a/config/locales/views/datasets/en.yml
+++ b/config/locales/views/datasets/en.yml
@@ -60,6 +60,7 @@ en:
       view_licence_information: "View licence information"
       licence: "Licence"
       no_licence: "None"
+      other_licence: "Other Licence"
       uk_ogl: "Open Government Licence"
       accessibility:
         search_box_label: "Search"

--- a/spec/factories/dataset.rb
+++ b/spec/factories/dataset.rb
@@ -5,9 +5,6 @@ FactoryBot.define do
     title 'Default dataset title'
     summary 'Ethnicity data'
     description 'Ethnicity data'
-    licence 'no-licence'
-    licence_other ''
-    licence_custom ''
     location1 'London'
     location2 'Southwark'
     location3 ''
@@ -55,28 +52,14 @@ FactoryBot.define do
       topic { build :topic }
     end
 
-    trait :with_no_licence do
-      licence 'no-licence'
-      licence_custom 'Special licence'
-    end
-
     trait :with_ogl_licence do
-      licence 'uk-ogl'
+      licence_code 'uk-ogl'
       licence_url 'http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/'
       licence_title 'Open Government Licence'
     end
 
-    trait :with_cczero_licence do
-      licence 'other'
-      licence_other 'cc-zero'
-      licence_url 'http://www.opendefinition.org/licenses/cc-zero'
-      licence_title 'Creative Commons CCZero'
-    end
-
     trait :with_custom_licence do
-      licence 'example-1.1'
-      licence_title 'Example Open License 1.1'
-      licence_url 'https://opensource.org/licenses/Example-1.1'
+      licence_custom 'Special case'
     end
 
     initialize_with { Dataset.new(attributes.stringify_keys) }

--- a/spec/features/dataset_show_page_spec.rb
+++ b/spec/features/dataset_show_page_spec.rb
@@ -9,13 +9,18 @@ RSpec.feature 'Dataset page', type: :feature, elasticsearch: true do
   end
 
   feature 'Licence information' do
-    scenario 'Link to Open Government Licence information' do
+    scenario 'Meta licence tag' do
       dataset = build :dataset, :with_ogl_licence
       index_and_visit(dataset)
 
       expect(page)
         .to have_css('meta[name="dc:rights"][content="Open Government Licence"]',
                      visible: false)
+    end
+
+    scenario 'Link to licence' do
+      dataset = build :dataset, :with_ogl_licence
+      index_and_visit(dataset)
 
       within('section.meta-data') do
         expect(page)
@@ -24,20 +29,30 @@ RSpec.feature 'Dataset page', type: :feature, elasticsearch: true do
       end
     end
 
-    scenario 'Link to Open Government Licence with additional information' do
+    scenario 'Link to licence with additional info' do
       dataset = build :dataset, :with_ogl_licence,
                                 licence_custom: 'Special case'
 
       index_and_visit(dataset)
 
-      expect(page)
-        .to have_css('meta[name="dc:rights"][content="Open Government Licence"]',
-                     visible: false)
+      within('section.meta-data') do
+        expect(page)
+          .to have_link('View licence information',
+                        href: '#licence-info')
+      end
+
+      within('section.dgu-licence-info') do
+        expect(page).to have_content('Special case')
+      end
+    end
+
+    scenario 'Link to custom licence (no title, no URL)' do
+      dataset = build :dataset, :with_custom_licence
+      index_and_visit(dataset)
 
       within('section.meta-data') do
         expect(page)
-          .to have_link('Open Government Licence',
-                        href: 'http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/')
+          .to have_content('Other Licence')
 
         expect(page)
           .to have_link('View licence information',
@@ -49,77 +64,34 @@ RSpec.feature 'Dataset page', type: :feature, elasticsearch: true do
       end
     end
 
-    scenario 'Link to Creative Commons CCZero information' do
-      dataset = build :dataset, :with_cczero_licence
+    scenario 'Simple licence title (no URL)' do
+      dataset = build :dataset, licence_title: 'My Licence'
       index_and_visit(dataset)
-
-      expect(page)
-        .to have_css('meta[name="dc:rights"][content="Creative Commons CCZero"]',
-                     visible: false)
 
       within('section.meta-data') do
         expect(page)
-          .to have_link('Creative Commons CCZero',
-                        href: 'http://www.opendefinition.org/licenses/cc-zero')
+          .to have_content('My Licence')
       end
     end
 
-    scenario 'Licence information' do
-      dataset = build :dataset, :with_no_licence
+    scenario 'Link to URL licence without a title' do
+      dataset = build :dataset, licence_url: 'http://licence.com'
       index_and_visit(dataset)
-
-      expect(page)
-        .to have_css('meta[name="dc:rights"][content="Other"]',
-                     visible: false)
 
       within('section.meta-data') do
         expect(page)
-          .to have_link('View licence information',
-                        href: '#licence-info')
-      end
-
-      within('section.dgu-licence-info') do
-        expect(page).to have_content('Special licence')
+          .to have_link('http://licence.com',
+                        href: 'http://licence.com')
       end
     end
 
-    scenario 'Explicit licence information' do
-      dataset = build :dataset, :with_custom_licence
+    scenario 'No licence' do
+      dataset = build :dataset
       index_and_visit(dataset)
-
-      expect(page)
-        .to have_css('meta[name="dc:rights"][content="Example Open License 1.1"]',
-                     visible: false)
 
       within('section.meta-data') do
         expect(page)
-          .to have_link('Example Open License 1.1',
-                        href: 'https://opensource.org/licenses/Example-1.1')
-      end
-    end
-
-    scenario 'Explicit licence information with additional license information' do
-      dataset = build :dataset, :with_custom_licence,
-                                licence_custom: 'For feature specs only.'
-
-      index_and_visit(dataset)
-
-      expect(page)
-        .to have_css('meta[name="dc:rights"][content="Example Open License 1.1"]',
-                     visible: false)
-
-      within('section.meta-data') do
-        expect(page)
-          .to have_link('Example Open License 1.1',
-                        href: 'https://opensource.org/licenses/Example-1.1')
-
-        expect(page)
-          .to have_link('View licence information',
-                        href: '#licence-info')
-      end
-
-      within('section.dgu-licence-info') do
-        expect(page).to have_content('For feature specs only.')
+          .to have_content('None')
       end
     end
   end


### PR DESCRIPTION
https://trello.com/c/mP0NcLrY/93-remove-licence-licencecode-and-licenceother-fields

Licence information is now available in 4 explicit fields: licence_code,
licence_title, licence_url and licence_custom. The approach taken on the
show page is to try and show as much licence information as possible,
even if some of the fields were not completed.

The licence information is also now used in a nested CreativeWork
document as part of the linked data for the show page, although this
isn't tested as it's unclear that this feature is in use. Otherwise, the
CCZero test has been replaced in favour of testing different behaviours.