### PR TITLE
Add guidance copy for searches with 0 results.

### DIFF
--- a/app/views/search/search.html.erb
+++ b/app/views/search/search.html.erb
@@ -26,13 +26,10 @@
 
     <div class="column-two-thirds dgu-results">
       <%= render 'sort' if @num_results > 1 %>
-
-      <% if @query.present? %>
-        <span class="dgu-results__summary">
-          <span class="bold-small"><%= number_with_delimiter(@num_results) %></span>
-          <%= t('.result').pluralize(@num_results) %> <%= t('.found') %>
-        </span>
-      <% end %>
+      <span class="dgu-results__summary">
+        <span class="bold-small"><%= number_with_delimiter(@num_results) %></span>
+        <%= t('.result').pluralize(@num_results) %> <%= t('.found') %>
+      </span>
 
       <div>
         <% if @num_results.zero? %>
@@ -40,8 +37,12 @@
             <h2 class="heading-medium"> <%= t('.zero_result_tips.try') %>:</h2>
             <ul class="list list-bullet">
               <li><%= t('.zero_result_tips.different_words') %></li>
-              <li><%= t('.zero_result_tips.clear_filters') %></li>
+              <li><%= t('.zero_result_tips.remove_filters') %></li>
             </ul>
+            <h2 class="heading-medium"> <%= t('.zero_result_tips.older_content') %></h2>
+            <p><%= t('.zero_result_tips.older_contentwe_can_help') %></p>
+            <p><%= t('.zero_result_tips.expand_your_search') %></p>
+
           </div>
         <% else %>
           <% @datasets.each do |dataset| %>

--- a/config/locales/views/search/en.yml
+++ b/config/locales/views/search/en.yml
@@ -13,7 +13,10 @@ en:
       zero_result_tips:
         try: "Please try"
         different_words: "searching again using different words"
-        clear_filters: "clearing your filters"
+        remove_filters: "removing your filters"
+        older_content: "Older content"
+        we_can_help: "If you’ve landed on this page from following a link or from searching on the site, we can help you."
+        expand_your_search: "We recommend you start a new search, add more search terms into the search box, or choose a publisher to filter by."
       meta_data_box:
         availability: "Availability"
         published_by: "Published by"


### PR DESCRIPTION
https://trello.com/c/AoUGf6VE/140-create-content-to-display-for-legacy-searches-on-find

- Add copy when searches have no results
- Always display number of results, even when it is 0

![screen shot 2018-05-23 at 08 10 34](https://user-images.githubusercontent.com/31649453/40408876-f19187a6-5e60-11e8-9c0c-05384eb94057.png)
