### PR TITLE
Match fonts between data links and supporting docs

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -225,7 +225,7 @@
     white-space: nowrap;
   }
   th, td {
-    font-size: 16px;
+    font-size: 19px;
   }
   margin-bottom: 20px;
 
@@ -251,11 +251,38 @@
     th {
       white-space: normal;
       vertical-align: top;
+      font-size: 16px;
     }
     td {
       vertical-align: top;
+      font-size: 16px;
     }
   }
+}
+
+// Supporting docs ===================================================================
+
+.supporting table {
+  th {
+    white-space: nowrap;
+  }
+  th, td {
+    font-size: 19px;
+  }
+
+  @include media(mobile) {
+    th {
+      white-space: normal;
+      vertical-align: top;
+      font-size: 16px;
+    }
+    td {
+      vertical-align: top;
+      white-space: normal;
+      font-size: 16px;
+    }
+  }
+
 }
 
 


### PR DESCRIPTION
https://trello.com/c/dvMOpknW/194-explore-fonts-displayed

- Bring supporting table font in line with data table
- Match wrapping rules for narrow screens

Before/after:
![screen shot 2018-05-23 at 16 05 22](https://user-images.githubusercontent.com/31649453/40433125-2accfc16-5ea3-11e8-945e-d5b27addd3dc.png)

-------------------


![screen shot 2018-05-23 at 16 04 50](https://user-images.githubusercontent.com/31649453/40433123-2a9a9276-5ea3-11e8-88ed-d804253d4cf1.png)
