### PR TITLE
Remove preview fetch initialiser

### DIFF
--- a/config/initializers/preview_fetch_initializer.rb
+++ b/config/initializers/preview_fetch_initializer.rb
@@ -1,8 +1,0 @@
-require 'rest-client'
-require 'uri'
-
-PUBLISH_URL = ENV['PUBLISH_URL'] || "https://publish-data-beta.herokuapp.com"
-
-def preview_url(file_id)
-  URI.join(PUBLISH_URL, "/api/previews/#{file_id}").to_s
-end


### PR DESCRIPTION
This is no longer used. Preview is implemented in `app/models/preview.rb`.

Found looking for references to the Publish URL for https://trello.com/c/mBViuo1y