### PR TITLE
Fix missing translations (and error on them)

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -43,7 +43,7 @@ Rails.application.configure do
   config.assets.quiet = true
 
   # Raises error for missing translations
-  # config.action_view.raise_on_missing_translations = true
+  config.action_view.raise_on_missing_translations = true
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -38,5 +38,5 @@ Rails.application.configure do
   config.active_support.deprecation = :stderr
 
   # Raises error for missing translations
-  # config.action_view.raise_on_missing_translations = true
+  config.action_view.raise_on_missing_translations = true
 end

--- a/config/locales/views/datasets/en.yml
+++ b/config/locales/views/datasets/en.yml
@@ -58,6 +58,7 @@ en:
       search_gov_data: "Search"
       data_links: "Data links"
       view_licence_information: "View licence information"
+      licence: "Licence"
       no_licence: "None"
       uk_ogl: "Open Government Licence"
       accessibility:

--- a/config/locales/views/pages/en.yml
+++ b/config/locales/views/pages/en.yml
@@ -5,7 +5,7 @@ en:
       lede: "Find data published by central government, local authorities and public bodies to help you build products and services"
       accessibility:
         search_box_label: "Search"
-        search_box_button: "Find data"
+        search_button_label: "Find data"
     topics:
       business_and_economy_label: "Business and economy"
       business_and_economy_description: "Small businesses, industry, imports, exports and trade"

--- a/config/locales/views/shared/en.yml
+++ b/config/locales/views/shared/en.yml
@@ -1,0 +1,4 @@
+en:
+  shared:
+    breadcrumb:
+      home: "Home"


### PR DESCRIPTION
https://trello.com/c/mP0NcLrY/93-remove-licence-licencecode-and-licenceother-fields

The dev and test environments should have exceptions enabled for missing
translations, otherwise Rails will try to auto-translate the requested
translation key. Enabling exceptions turned up a few missing
translations, which I've now added and made them consistent with other
pages.