### PR TITLE
Increase the RAM available to the application

### DIFF
--- a/production-manifest.yml
+++ b/production-manifest.yml
@@ -2,7 +2,7 @@
 applications:
 - name: find-data-beta
   instances: 8
-  memory: 256M
+  memory: 512M
   buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.7.16
   routes:
   - route: find-data-beta.cloudapps.digital

--- a/staging-manifest.yml
+++ b/staging-manifest.yml
@@ -2,7 +2,7 @@
 applications:
 - name: find-data-beta-staging
   instances: 4
-  memory: 256M
+  memory: 512M
   buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.7.16
   routes:
   - route: find-data-beta-staging.cloudapps.digital


### PR DESCRIPTION
Running `cf events find-data-beta | grep find-data-beta | wc -l` shows
that the find application has crashed 26 times in the last 2 hours. Each
crash is logged as `Exited with status 137 (out of memory)`. Unfortunately
this is a SIGKILL (9) so there's no opportunity to try and force the freeing of 
memory.

This PR increases the amount of memory available to each instance to
reduce the number of crashes. Unfortunately if an application crashes
during a request, the inflight request will fail, rather than it
being re-routed to a live instance.  So this means users (or systems)
are seeing errors of some form or other.