### PR TITLE
Remove the end_date and its unused method usage

### DIFF
--- a/app/models/datafile.rb
+++ b/app/models/datafile.rb
@@ -1,14 +1,13 @@
 class Datafile
   DatafileNotFound = Class.new(StandardError)
 
-  attr_reader :name, :url, :start_date, :end_date,
+  attr_reader :name, :url, :start_date,
               :created_at, :updated_at, :format, :size, :uuid
 
   def initialize(hash)
     @name = hash["name"]
     @url = hash["url"]
     @start_date = hash["start_date"]
-    @end_date = hash["end_date"]
     @created_at = hash["created_at"]
     @updated_at = hash["updated_at"]
     @format = hash["format"]
@@ -19,11 +18,6 @@ class Datafile
   def start_year
     return if start_date.blank?
     Time.parse(start_date).year
-  end
-
-  def most_recent_date
-    return updated_at if end_date.blank?
-    end_date > updated_at ? end_date : updated_at
   end
 
   def timeseries?

--- a/spec/models/datafile_spec.rb
+++ b/spec/models/datafile_spec.rb
@@ -7,21 +7,6 @@ RSpec.describe Datafile do
       expect(datafile.start_year).to eql 2001
     end
 
-    describe "#most_recent_date" do
-      it 'returns updated_at if end date is blank' do
-        datafile = build :datafile
-        expect(datafile.most_recent_date).to eq datafile.updated_at
-      end
-
-      it 'returns the most recent date out of the end date and the updated_at date' do
-        datafile = build :datafile, start_date: '2001/1/15',
-                                    end_date: '2017/1/15',
-                                    updated_at: '2016-08-31T14:40:57.528Z'
-
-        expect(datafile.most_recent_date).to eq datafile.end_date
-      end
-    end
-
     describe "#html?" do
       it 'returns true if datafile is a webpage' do
         datafile = build :datafile, format: 'html'


### PR DESCRIPTION
https://trello.com/c/73zsOucF/262-sync-a-single-dataset-using-the-ckan-api-26

The end_date field is only in a single method, which in turn is not used
anywhere in the code. It should be removed to avoid confusion.