### PR TITLE
Fix description field from Publish not being shown

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -7,9 +7,8 @@ class Dataset
   attr_reader :name, :legacy_name, :title, :summary, :description, :foi_name,
               :organisation, :id, :uuid, :datafiles, :location1, :location2,
               :location3, :public_updated_at, :topic, :licence_custom, :docs,
-              :contact_email, :foi_email, :foi_web, :notes, :inspire_dataset,
-              :harvested, :contact_name, :released, :licence_title, :licence_url,
-              :licence_code
+              :contact_email, :foi_email, :foi_web, :inspire_dataset, :harvested,
+              :contact_name, :released, :licence_title, :licence_url, :licence_code
 
   index_name ENV['ES_INDEX'] || "datasets-#{Rails.env}"
 
@@ -38,7 +37,6 @@ class Dataset
     @foi_name = hash["foi_name"]
     @foi_email = hash["foi_email"]
     @foi_web = hash["foi_web"]
-    @notes = hash["notes"]
     @inspire_dataset = hash["inspire_dataset"]
     @harvested = hash["harvested"]
     @organisation = Organisation.new(hash["organisation"])

--- a/app/views/datasets/_additional_info.html.erb
+++ b/app/views/datasets/_additional_info.html.erb
@@ -3,9 +3,9 @@
     <h2 class="heading-medium">
       <%= t('.additional_info') %>
     </h2>
-    <% if dataset.notes.present? %>
+    <% if dataset.description.present? %>
       <p class="dgu-additional-info__notes">
-        <%= dataset.notes %>
+        <%= dataset.description %>
       </p>
     <% end %>
 

--- a/app/views/datasets/show.html.erb
+++ b/app/views/datasets/show.html.erb
@@ -40,7 +40,7 @@
       </div>
     </div>
 
-    <% if @dataset.notes.present? || @dataset.inspire_dataset.present? %>
+    <% if @dataset.description.present? || @dataset.inspire_dataset.present? %>
       <%= render partial: "additional_info", locals: { dataset: @dataset } %>
     <% end %>
 

--- a/spec/features/dataset_show_page_spec.rb
+++ b/spec/features/dataset_show_page_spec.rb
@@ -194,10 +194,10 @@ RSpec.feature 'Dataset page', type: :feature, elasticsearch: true do
 
   feature 'Additional info' do
     scenario 'Is displayed if available' do
-      dataset = build :dataset, notes: 'Some very interesting notes'
+      dataset = build :dataset
       index_and_visit(dataset)
       expect(page).to have_css('h2', text: 'Additional information')
-      expect(page).to have_content(dataset.notes)
+      expect(page).to have_content(dataset.description)
     end
 
     scenario 'Contains a link to original INSPIRE XML' do
@@ -213,7 +213,7 @@ RSpec.feature 'Dataset page', type: :feature, elasticsearch: true do
     end
 
     scenario 'Is not displayed if not available' do
-      dataset = build :dataset
+      dataset = build :dataset, description: nil
       index_and_visit(dataset)
       expect(page).to_not have_css('h2', text: 'Additional information')
     end


### PR DESCRIPTION
https://trello.com/c/htS3Hsh4/193-additional-info-not-showing

This was incorrectly coded as coming from a 'notes' field, which doesn't
exist in the datasets index schema. There are underlying usability
issues with this field, but we should leave it in a working state before
handing over.