### PR TITLE
Add option to support for to become a publisher

### DIFF
--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -1,7 +1,6 @@
 class TicketsController < ApplicationController
   def new
-    @support_queue = params['support']
-    @ticket = Ticket.new
+    @ticket = Ticket.new(support: params['support'])
   end
 
   def create

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -16,7 +16,7 @@ class Ticket
 
   def to_json
     { "requester": { "name": name, "email": email },
-      "subject": support_queue + " Find open data - support request",
+      "subject": support_queue + " Find open data - #{support} request",
       "comment": { "body": content } }
   end
 

--- a/app/views/pages/support.html.erb
+++ b/app/views/pages/support.html.erb
@@ -17,10 +17,6 @@
       </p>
 
       <p>
-        If you want to ask for a dataset, choose the data request option below.
-      </p>
-
-      <p>
         For questions about a dataset, you can contact the publisher directly if they’ve provided contact details on the
         dataset page.
       </p>
@@ -50,6 +46,11 @@
             <div class="multiple-choice">
               <input id="support-2" type="radio" name="support" value="data">
               <label for="support-2">I have a data request</label>
+            </div>
+
+            <div class="multiple-choice">
+              <input id="support-3" type="radio" name="support" value="publish">
+              <label for="support-3">I want to publish for an organisation</label>
             </div>
 
           </fieldset>

--- a/app/views/tickets/new.html.erb
+++ b/app/views/tickets/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title do %>Send a data request<% end %>
+<% content_for :page_title do %><%= t(".#{@ticket.support}_request") %><% end %>
 
 <%= content_for :breadcrumb do %>
   <%= render 'shared/breadcrumb' %>
@@ -21,11 +21,7 @@
       <% end %>
 
       <h1 class='heading-medium'>
-        <% if @support_queue == 'data'%>
-          <%= t('.send_data_request') %>
-        <% else %>
-          <%= t('.report_a_problem') %>
-        <% end %>
+        <%= t(".#{@ticket.support}_request") %>
       </h1>
 
       <%= form_for @ticket, url: { action: "create", controller: "tickets" } do |f| %>
@@ -64,7 +60,7 @@
                           class: input_box_class_for(@ticket, :email),
                           id: "example-email") %>
         </div>
-        <%= f.hidden_field(:support, :value => @support_queue) %>
+        <%= f.hidden_field(:support, :value => @ticket.support) %>
           <%= f.submit t('.submit'), class: "button dgu-support__button" %>
       <% end %>
     </div>

--- a/config/locales/views/tickets/en.yml
+++ b/config/locales/views/tickets/en.yml
@@ -2,8 +2,9 @@ en:
   tickets:
     new:
       problem: "There was a problem"
-      send_data_request: "Send a data request"
-      report_a_problem: "Report a problem"
+      data_request: "Send a data request"
+      feedback_request: "Report a problem"
+      publish_request: "Publish for an organisation"
       your_message: "Your message"
       enter_a_message: "Enter a message"
       name: "Name"

--- a/spec/features/support_spec.rb
+++ b/spec/features/support_spec.rb
@@ -47,6 +47,27 @@ RSpec.feature 'Support tickets', type: :feature do
     end
   end
 
+  feature 'Becoming a publisher' do
+    let(:ticket) { build :ticket, support: 'publish' }
+
+    scenario 'Send a support ticket to Zendesk' do
+      choose 'I want to publish for an organisation'
+      click_on 'Continue'
+      expect(page).to have_content 'Publish for an organisation'
+
+      fill_in 'example-content', with: ticket.content
+      fill_in 'example-name', with: ticket.name
+      fill_in 'example-email', with: ticket.email
+
+      expect(Zendesk.client)
+        .to receive_message_chain('tickets.create!')
+        .with(ticket.to_json)
+
+      click_on 'Submit'
+      expect(page).to have_content 'Thanks for contacting data.gov.uk'
+    end
+  end
+
   feature 'Recover from invalid data' do
     let(:ticket) { build :ticket, email: 'foo' }
 


### PR DESCRIPTION
https://trello.com/c/bGmVDyz0/409-replace-registration-process

The breadcrumb now correctly shows the type of support being requested,
which incurred a refactoring to get this data from the ticket model,
rather than from an instance variable.