### PR TITLE
Allow map preview to load content images from any URL

### DIFF
--- a/app/controllers/map_previews_controller.rb
+++ b/app/controllers/map_previews_controller.rb
@@ -4,16 +4,14 @@ require 'open-uri'
 
 class MapPreviewsController < ApplicationController
   def show
-    wms_uri = URI(url_param)
-    wms_img_src = "#{wms_uri.scheme}://#{wms_uri.host}"
-
     # rubocop:disable Lint/PercentStringArray
     append_content_security_policy_directives(
-      img_src: %W(osinspiremappingprod.ordnancesurvey.co.uk #{wms_img_src} data:),
       script_src: %w(osinspiremappingprod.ordnancesurvey.co.uk 'unsafe-eval'),
       style_src: %w(osinspiremappingprod.ordnancesurvey.co.uk),
     )
     # rubocop:enable Lint/PercentStringArray
+
+    override_content_security_policy_directives(img_src: %w(* data:))
   end
 
   def getinfo


### PR DESCRIPTION
Previously we tried to set a strong CSP so that map preview images could only be loaded from OS and the WMS host. This is proving to be too strict as we have WMS sources that link to other URIs for their map data. For example https://data.gov.uk/data/map-preview?e=1.8&n=55.8&s=50.0&url=http%3A%2F%2Fenvironment.data.gov.uk%2Fds%2Fwms%3FSERVICE%3DWMS%26INTERFACE%3DENVIRONMENT--6f59c1ce-cc11-43aa-b11d-e1c3ab43a192%26request%3DGetCapabilities&w=-5.7

This allows images to be loaded from any URI so that we can support map previews.