### PR TITLE
Do not bind GDS prometheus to the PaaS app

### DIFF
--- a/production-manifest.yml
+++ b/production-manifest.yml
@@ -14,4 +14,3 @@ applications:
   - find-production-secrets
   - logit-ssl-drain
   - beta-production-elasticsearch
-  - dgu-prometheus

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -37,7 +37,7 @@ end
 
 Capybara.register_driver :headless_chrome do |app|
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-    chromeOptions: { args: %w(headless disable-gpu) }
+    chromeOptions: { args: %w(headless disable-gpu --no-sandbox --disable-dev-shm-usage) }
   )
 
   Capybara::Selenium::Driver.new app, browser: :chrome, desired_capabilities: capabilities

--- a/staging-manifest.yml
+++ b/staging-manifest.yml
@@ -14,4 +14,3 @@ applications:
   - find-staging-secrets
   - beta-staging-elasticsearch
   - logit-ssl-drain
-  - dgu-prometheus


### PR DESCRIPTION
This application no longer requires metric collection by the
GDS prometheus, as implemented by
https://github.com/alphagov/datagovuk_find/pull/633

This commit removes the PaaS service bind so that Prometheus
will not try and collect metrics as intended.