### PR TITLE
Switch to new elasticsearch

### DIFF
--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -1,50 +1,20 @@
-require 'base64'
-
-def create_es_cert_file(cert)
-  begin
-    es_cert_file = File.new('elasticsearch_cert.pem', 'w')
-    es_cert_file.write(cert)
-    es_cert_file.close
-  rescue StandardError => e
-    Rails.logger.fatal 'Failed to write elasticsearch certificate. Exiting'
-    Rails.logger.fatal e
-    exit
-  end
-  es_cert_file
-end
-
 def es_config_from_vcap
   begin
     vcap = JSON.parse(Rails.configuration.elasticsearch['vcap_services'])
-    es_servers = vcap['elasticsearch'][0]['credentials']['uris'].map do |uri|
-      uri.chomp('/')
-    end
-    es_cert = Base64.decode64(vcap['elasticsearch'][0]['credentials']['ca_certificate_base64'])
+    es_server = vcap['elasticsearch'][0]['credentials']['uri']
   rescue StandardError => e
-    Rails.logger.fatal 'Failed to extract ES creds from VCAP_SERVICES. Exiting'
+    Rails.logger.fatal "Failed to extract ES creds from VCAP_SERVICES. Exiting"
     Rails.logger.fatal Rails.configuration.elasticsearch['vcap_services']
     Rails.logger.fatal e
     exit
   end
 
-  es_cert_file = create_es_cert_file(es_cert)
-
-  {
-    host: es_servers,
-    transport_options: {
-      request: {
-        timeout: Rails.configuration.elasticsearch['elastic_timeout']
-      },
-      ssl: {
-        ca_file: es_cert_file.path
-      }
-    }
-  }
+  es_config_from_host(es_server)
 end
 
-def es_config_from_host
+def es_config_from_host(host)
   {
-    host: Rails.configuration.elasticsearch['host'],
+    host: host,
     transport_options: {
       request: {
         timeout: Rails.configuration.elasticsearch['elastic_timeout']
@@ -52,9 +22,10 @@ def es_config_from_host
     }
   }
 end
+
 
 if Rails.configuration.elasticsearch['host']
-  config = es_config_from_host
+  config = es_config_from_host(Rails.configuration.elasticsearch['host'])
 elsif Rails.configuration.elasticsearch['vcap_services']
   config = es_config_from_vcap
 else

--- a/production-manifest.yml
+++ b/production-manifest.yml
@@ -13,4 +13,4 @@ applications:
   services:
   - find-production-secrets
   - logit-ssl-drain
-  - beta-production-elasticsearch
+  - elasticsearch-beta-production

--- a/staging-manifest.yml
+++ b/staging-manifest.yml
@@ -12,5 +12,5 @@ applications:
     RACK_ENV: staging
   services:
   - find-staging-secrets
-  - beta-staging-elasticsearch
+  - elasticsearch-beta-staging
   - logit-ssl-drain


### PR DESCRIPTION
The PaaS is switching from IBM Compose to Aiven.  There are some changes to the configuration format, so this isn't just a straight change to the manifest.

---

The change has already been applied to the running DGU instances.  In addition to this PR, there was some devopsing around creating the new backing service (hence the new names) and reindexing everything.

---

[Trello card](https://trello.com/c/uQVcQkJ0/364-move-dgu-paas-elasticsearch)