### PR TITLE
Update WMS requests to version 1.3.0

### DIFF
--- a/app/assets/javascripts/map-preview/wms-eval-map.js
+++ b/app/assets/javascripts/map-preview/wms-eval-map.js
@@ -1851,18 +1851,11 @@ function buildUI(urls){
         Ext.MessageBox.alert('WMS Error', errorStr, '');
     }
 
-    var childLayerParams;
-    var browser = navigator.userAgent;
+    var childLayerParams = { format: 'image/png', transparent: 'true', version: '1.3.0' };
 
     // IE browsers handle PNG transparency very badly so gif images are used instead.
     if (/MSIE (\d+\.\d+);/.test(navigator.userAgent)) {
-        childLayerParams = {
-            format: 'image/gif', transparent: 'true'
-        };
-    } else {
-        childLayerParams = {
-            format: 'image/png', transparent: 'true'
-        };
+        childLayerParams['format'] = 'image/gif';
     }
 
     // Build layer tree from valid WMS URLs


### PR DESCRIPTION
https://trello.com/c/OLbsdrHQ/616-fix-dgu-map-preview-feature-info-functionality

See investigation findings here: https://trello.com/c/tPOdVtaI/452-find-out-why-clicking-on-an-area-in-map-preview-on-datagovuk-isnt-working

A number of GetFeatureInfo requests were failing on specific WMS
endpoints. It's thought that version 1.1.1 API calls were no longer
supported though we don't have visibility of these servers and have
requested more information from the environment agency.
Using WMS 1.3.0 via OpenLayers appears to fix this problem, some working
calls have been tested along with the failing ones and both seem to
work.
This commit sets the OpenLayers WMS version to 1.3.0, it also reinstates
setting the exception parameter as this is required by v1.3.0.