### PR TITLE
Explicitly set reverse axis order for all projections

### DIFF
--- a/app/assets/javascripts/map-preview/wms-eval-map.js
+++ b/app/assets/javascripts/map-preview/wms-eval-map.js
@@ -41,6 +41,11 @@ Proj4js.defs["EPSG:4326"] = "+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs";
 /* Tell OpenLayers which projections need reverseAxisOrder in WMS 1.3 */
 OpenLayers.Layer.WMS.prototype.yx["EPSG:4258"] = true;
 
+OpenLayers.Projection.defaults["EPSG:27700"]  = { yx: false };
+OpenLayers.Projection.defaults["EPSG:29903"]  = { yx: false };
+OpenLayers.Projection.defaults["EPSG:2157"]   = { yx: false };
+OpenLayers.Projection.defaults["EPSG:4326"]   = { yx: false };
+
 /* Provide a more informative default image for failed legendUrl requests */
 //GeoExt.LegendImage.prototype.defaultImgSrc = "http://46.137.180.108/images/no_legend.png";
 


### PR DESCRIPTION
https://trello.com/c/OLbsdrHQ/616-fix-dgu-map-preview-feature-info-functionality

Side effect of https://github.com/alphagov/datagovuk_find/pull/654

We now use WMS 1.3.0 for all WMS interactions, OpenLayers needs to know the
axis order for every possible coordinate system, so set the false values
explicitly.

Here's the OpenLayers function which errors without these additional projection code properties:

```javascript
reverseAxisOrder: function() {
  var a = this.projection.getCode();
  return 1.3 <= parseFloat(this.params.VERSION) && !(!this.yx[a] && !OpenLayers.Projection.defaults[a].yx)
},
```

The error thrown is
```
OpenLayers.js:886 Uncaught TypeError: Cannot read property 'yx' of undefined
    at initialize.reverseAxisOrder (OpenLayers.js:886)
    at initialize.getURL (OpenLayers.js:886)
    at initialize.renderTile (OpenLayers.js:539)
    at initialize.draw (OpenLayers.js:539)
    at initialize.drawTileFromQueue (OpenLayers.js:552)
    at OpenLayers.js:62
    at e.(:3000/data/anonymous function) (...OpenLayers.js:406:57)
```
