### PR TITLE
Use API key for submitting Zendesk tickets

### DIFF
--- a/config/initializers/zendesk.rb
+++ b/config/initializers/zendesk.rb
@@ -6,7 +6,6 @@ module Zendesk
     ZendeskAPI::Client.new do |config|
       config.username = ENV['ZENDESK_USERNAME']
       config.token = ENV['ZENDESK_API_KEY']
-      config.password = ENV['ZENDESK_PASSWORD']
       config.url = ENV['ZENDESK_END_POINT']
     end
   end


### PR DESCRIPTION
The current ZenDesk config was using both a password and an API key.
When both are submitted, it appears it default to using the password.

This password can expire, needing manual intervention to update.

By removing the password from the config, the API key will be used
for authentication instead.

We tested this locally with the correct credentials and ZenDesk tickets
were created as expected.

Co-authored-by: Rosa Fox <rosa.fox@digital.cabinet-office.gov.uk>