### PR TITLE
Update travis before_install bundler flags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ addons:
   chrome: stable
 before_install:
   - gem update --system
-  - gem install bundler --no-ri --no-rdoc
+  - gem install bundler --no-document rdoc
 install:
   - bundle install --path vendor/bundle
   - yarn


### PR DESCRIPTION
RubyGems 3.0.0 deprecated the flags `--[no-]ri` and `--[no-]rdoc` flags.
http://blog.rubygems.org/2018/12/19/3.0.0-released.html

These have been replaced with `--[no-]document [TYPES]`
https://guides.rubygems.org/command-reference/#gem-install