### PR TITLE
Remove 'rdoc' from travis install step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ addons:
   chrome: stable
 before_install:
   - gem update --system
-  - gem install bundler --no-document rdoc
+  - gem install bundler --no-document
 install:
   - bundle install --path vendor/bundle
   - yarn


### PR DESCRIPTION
The no-documentation flag by default will disable all documentation generation. Including `rdoc` results in the gem being installed unnecessarily. 