### PR TITLE
Redirect legacy organograms to S3

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,3 +11,7 @@ Metrics/BlockLength:
     - 'config/routes.rb'
     - 'lib/tasks/**/*.rake'
     - 'spec/**/*.rb'
+
+Style/FormatStringToken:
+  Exclude:
+    - "config/routes.rb"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,8 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root to: 'pages#home'
 
+  get "/sites/default/files/*organogram_path", to: redirect("https://s3-eu-west-1.amazonaws.com/datagovuk-production-ckan-organogram/legacy/%{organogram_path}"), format: false
+
   get 'dataset/:uuid', to: 'datasets#show', uuid: /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/
 
   scope module: 'legacy' do

--- a/spec/requests/legacy/redirect_spec.rb
+++ b/spec/requests/legacy/redirect_spec.rb
@@ -65,6 +65,13 @@ RSpec.describe 'legacy', type: :request do
       end
     end
   end
+
+  describe "legacy organograms" do
+    it "redirects to S3" do
+      get "/sites/default/files/organogram/appointments-commission/31/03/2011/appointments_commission-2011-03-31-organogram-junior.csv"
+      expect(response).to redirect_to("https://s3-eu-west-1.amazonaws.com/datagovuk-production-ckan-organogram/legacy/organogram/appointments-commission/31/03/2011/appointments_commission-2011-03-31-organogram-junior.csv")
+    end
+  end
 end
 
 RSpec.describe 'CKANRouter' do


### PR DESCRIPTION
These have been updated in the database, but are still being served
as the old URLs in the new CKAN's solr index.  It will take 3 days
to reindex solr, so for now we're redirecting the legacy URLs for
organogram CSVs to S3.