### PR TITLE
Fix map preview proxy encoding

### DIFF
--- a/app/controllers/map_previews_controller.rb
+++ b/app/controllers/map_previews_controller.rb
@@ -25,7 +25,7 @@ class MapPreviewsController < ApplicationController
 
   def proxy
     url = correct_url(url_param)
-    response = URI(url).read
+    response = URI(url).read.force_encoding("ISO-8859-1").encode("UTF-8")
     render xml: Nokogiri::XML(response)
   rescue StandardError => exception
     Raven.capture_exception(exception)


### PR DESCRIPTION
This is still something of a dark art for me, but
I've tested this on 12 random datasets, and the ones
that weren't broken for unrelated reasons loaded fine.