### PR TITLE
Fix redirection to CKAN

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -8,10 +8,6 @@ class PagesController < ApplicationController
     @datafiles_count_by_format = Dataset.datafiles['formats']['buckets']
   end
 
-  def redirect
-    redirect_to("#{ENV['CKAN_REDIRECTION_URL']}/#{params[:path]}")
-  end
-
 private
 
   def get_datasets_count

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   get "/sites/default/files/*organogram_path", to: redirect("https://s3-eu-west-1.amazonaws.com/datagovuk-production-ckan-organogram/legacy/%{organogram_path}"), format: false
 
   if ENV["CKAN_REDIRECTION_URL"].present?
-    get 'dataset/edit/:legacy_name', to: redirect("#{ENV['CKAN_REDIRECTION_URL']}/dataset/edit/%{legacy_name}")
+    get 'dataset/edit/:legacy_name', to: redirect(domain: ENV['CKAN_REDIRECTION_URL'], subdomain: '', path: "/dataset/edit/%{legacy_name}")
   end
 
   get 'dataset/:uuid', to: 'datasets#show', uuid: /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/
@@ -55,6 +55,6 @@ Rails.application.routes.draw do
 
   # Route everything else to CKAN
   if ENV["CKAN_REDIRECTION_URL"].present?
-    match "*path", to: "pages#redirect", via: :all
+    match '*path', to: redirect(domain: ENV['CKAN_REDIRECTION_URL'], subdomain: '', path: "/%{path}"), via: :all
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,10 @@ Rails.application.routes.draw do
 
   get "/sites/default/files/*organogram_path", to: redirect("https://s3-eu-west-1.amazonaws.com/datagovuk-production-ckan-organogram/legacy/%{organogram_path}"), format: false
 
+  if ENV["CKAN_REDIRECTION_URL"].present?
+    get 'dataset/edit/:legacy_name', to: redirect("#{ENV['CKAN_REDIRECTION_URL']}/dataset/edit/%{legacy_name}")
+  end
+
   get 'dataset/:uuid', to: 'datasets#show', uuid: /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/
 
   scope module: 'legacy' do

--- a/production-manifest.yml
+++ b/production-manifest.yml
@@ -10,7 +10,7 @@ applications:
   env:
     RAILS_ENV: production
     RACK_ENV: production
-    CKAN_REDIRECTION_URL: https://ckan.publishing.service.gov.uk
+    CKAN_REDIRECTION_URL: ckan.publishing.service.gov.uk
   services:
   - find-production-secrets
   - logit-ssl-drain

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,7 +4,7 @@ SimpleCov.start
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
-ENV['CKAN_REDIRECTION_URL'] ||= 'http://testdomain'
+ENV['CKAN_REDIRECTION_URL'] ||= 'testdomain'
 require File.expand_path('../../config/environment', __FILE__)
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?

--- a/spec/requests/legacy/redirect_spec.rb
+++ b/spec/requests/legacy/redirect_spec.rb
@@ -82,5 +82,12 @@ RSpec.describe 'CKANRouter' do
 
       expect(response).to redirect_to(location)
     end
+
+    it 'routes GET /dataset/edit/:legacy_name to CKAN domain' do
+      get "/dataset/edit/some_dataset"
+      location = "http://testdomain/dataset/edit/some_dataset"
+
+      expect(response).to redirect_to(location)
+    end
   end
 end

--- a/spec/requests/legacy/redirect_spec.rb
+++ b/spec/requests/legacy/redirect_spec.rb
@@ -83,6 +83,13 @@ RSpec.describe 'CKANRouter' do
       expect(response).to redirect_to(location)
     end
 
+    it 'routes GET /publish?id=123 to CKAN domain and retains query string' do
+      get "/publish?id=123"
+      location = "http://testdomain/publish?id=123"
+
+      expect(response).to redirect_to(location)
+    end
+
     it 'routes GET /dataset/edit/:legacy_name to CKAN domain' do
       get "/dataset/edit/some_dataset"
       location = "http://testdomain/dataset/edit/some_dataset"

--- a/staging-manifest.yml
+++ b/staging-manifest.yml
@@ -10,7 +10,7 @@ applications:
   env:
     RAILS_ENV: staging
     RACK_ENV: staging
-    CKAN_REDIRECTION_URL: https://ckan.staging.publishing.service.gov.uk
+    CKAN_REDIRECTION_URL: ckan.staging.publishing.service.gov.uk
   services:
   - find-staging-secrets
   - elasticsearch-beta-staging


### PR DESCRIPTION
Two issues fixed:
- Query string is now retained when redirecting to CKAN
- `/dataset/edit/:legacy_name` is now redirected to CKAN (this was previously considered by the `/dataset` route)