### PR TITLE
Update 'Sign in' URL for new CKAN

### DIFF
--- a/app/views/pages/publishers.html.erb
+++ b/app/views/pages/publishers.html.erb
@@ -16,7 +16,7 @@
     </p>
 
     <p>
-      <%= link_to 'Sign in', '/user?destination=page/publisher-tools', role: 'button', class: 'button', rel: %w(nofollow) %>
+      <%= link_to 'Sign in', '/user/login', role: 'button', class: 'button', rel: %w(nofollow) %>
     </p>
 
     <div role="note" aria-label="Publisher information" class="panel panel-border-narrow text">


### PR DESCRIPTION
This was linking to a page that doesn't exist in new CKAN