### PR TITLE
Fix broken link to guidance

### DIFF
--- a/app/views/pages/publishers.html.erb
+++ b/app/views/pages/publishers.html.erb
@@ -32,7 +32,7 @@
     </h2>
 
     <p>
-      To get started, take a look at the <%= link_to 'information about publishing datasets', 'https://guidance.data.gov.uk/publishing_on_data_gov_uk_overview.html', target: '_blank' %>.
+      To get started, take a look at the <%= link_to 'information about publishing datasets', 'https://guidance.data.gov.uk/publish_and_manage_data/', target: '_blank' %>.
       You can also <%= link_to 'ask us for help', support_path %>.
     </p>
   </div>


### PR DESCRIPTION
There was a broken link to the publisher guidance on the 'Publish data' page.

Zendesk ticket: https://govuk.zendesk.com/agent/tickets/3591501