### PR TITLE
Use cflinuxfs3 stack

### DIFF
--- a/production-manifest.yml
+++ b/production-manifest.yml
@@ -4,6 +4,7 @@ applications:
   instances: 4
   memory: 512M
   buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.7.34
+  stack: cflinuxfs3
   routes:
   - route: find-data-beta.cloudapps.digital
   - route: data.gov.uk

--- a/staging-manifest.yml
+++ b/staging-manifest.yml
@@ -4,6 +4,7 @@ applications:
   instances: 1
   memory: 512M
   buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.7.34
+  stack: cflinuxfs3
   routes:
   - route: find-data-beta-staging.cloudapps.digital
   - route: test.data.gov.uk


### PR DESCRIPTION
cflinuxfs2 is being deprecated so we should upgrade to the latest stack version.

[Trello Card](https://trello.com/c/LnfsfS1q/875-upgrade-datagovuk-to-cflinuxfs3)