### PR TITLE
Upgrade elasticsearch to use version 6 service

### DIFF
--- a/production-manifest.yml
+++ b/production-manifest.yml
@@ -14,5 +14,5 @@ applications:
     CKAN_REDIRECTION_URL: ckan.publishing.service.gov.uk
   services:
   - find-production-secrets
+  - elasticsearch-6-beta-production
   - logit-ssl-drain
-  - elasticsearch-beta-production

--- a/staging-manifest.yml
+++ b/staging-manifest.yml
@@ -7,12 +7,11 @@ applications:
   stack: cflinuxfs3
   routes:
   - route: find-data-beta-staging.cloudapps.digital
-  - route: test.data.gov.uk
   env:
     RAILS_ENV: staging
     RACK_ENV: staging
     CKAN_REDIRECTION_URL: ckan.staging.publishing.service.gov.uk
   services:
   - find-staging-secrets
-  - elasticsearch-beta-staging
+  - elasticsearch-6-beta-staging
   - logit-ssl-drain


### PR DESCRIPTION
What
As ES 5 will no longer be supported, a new ES 6 service has been deployed to replace it.

- also remove test.data.gov.uk route from staging as it is not working