### PR TITLE
Add staging.data.gov.uk as a valid route for staging

### DIFF
--- a/staging-manifest.yml
+++ b/staging-manifest.yml
@@ -6,7 +6,8 @@ applications:
   buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.7.34
   stack: cflinuxfs3
   routes:
-  - route: find-data-beta-staging.cloudapps.digital
+    - route: find-data-beta-staging.cloudapps.digital
+    - route: staging.data.gov.uk
   env:
     RAILS_ENV: staging
     RACK_ENV: staging


### PR DESCRIPTION
Currently it's not listed as a route meaning that if you go to it, you get:

```
404 Not Found: Requested route ('staging.data.gov.uk') does not exist.
```

[Trello Card](https://trello.com/c/MomTjKnV/910-ensure-only-whitelisted-ips-can-purge-dgu-cache)