### PR TITLE
Remove IE8 meta tag

### DIFF
--- a/app/views/map_previews/show.html.erb
+++ b/app/views/map_previews/show.html.erb
@@ -1,8 +1,6 @@
 <% content_for :page_title do %>Preview on map<% end %>
 
 <% content_for :head do %>
-  <meta http-equiv="X-UA-Compatible" content="IE=EmulateIE8" />
-
   <meta name="dc.coverage" content="GB" />
   <meta name="dc.creator" content="Ordnance Survey, http://www.ordnancesurvey.co.uk/contactus" />
   <meta name="dc.date" scheme="DCTERMS.W3CDTF" content="2011-04-15" />


### PR DESCRIPTION
It was found that this tag caused the map previews to not be shown on IE 11 browsers, removing the tag allowed the map previews to work and did not prevent it from working on other versions of IE during testing on browser stack.

## Reference 

https://trello.com/c/YaF8gzIp/973-make-dgu-map-preview-work-in-ie11