### PR TITLE
Add connect_src CSP for organograms in s3

### DIFF
--- a/app/controllers/previews_controller.rb
+++ b/app/controllers/previews_controller.rb
@@ -1,5 +1,9 @@
 class PreviewsController < ApplicationController
   def show
+    append_content_security_policy_directives(
+      connect_src: %w(s3-eu-west-1.amazonaws.com),
+    )
+
     @dataset = Dataset.get_by_uuid(uuid: params[:dataset_uuid])
     @datafile = @dataset.datafiles.find { |f| f.uuid == params[:datafile_uuid] }
 


### PR DESCRIPTION
## What

Without the connect-src CSP directive a JS error is thrown and no organograms can be visualised, so adding this fills in the blank box.

## Tests

Test on smokey to ensure that we don't get CSP errors - https://github.com/alphagov/smokey/pull/528

## Reference

https://trello.com/c/wh8pUMOm/982-fix-display-of-organogram-visualisations-on-datagovuk