### PR TITLE
Update dataset.organogram? to handle legacy schema_id

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -101,6 +101,7 @@ class Dataset
   end
 
   def organogram?
-    ORGANOGRAM_SCHEMA_IDS.include?(@schema_id)
+    schema_id = @schema_id.gsub(/\["|"\]/, '')
+    ORGANOGRAM_SCHEMA_IDS.include?(schema_id)
   end
 end

--- a/spec/factories/dataset.rb
+++ b/spec/factories/dataset.rb
@@ -21,6 +21,7 @@ FactoryBot.define do
     organisation { build :organisation, :raw }
     docs []
     datafiles []
+    schema_id '2d5b1042-0799-4ceb-9075-8307f90e877c'
 
     trait :inspire do
       inspire_dataset do

--- a/spec/models/dataset_spec.rb
+++ b/spec/models/dataset_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe Dataset do
+  describe "#schema_id" do
+    it 'recognises legacy schema_id as an organogram' do
+      dataset = build :dataset, schema_id: '["d3c0b23f-6979-45e4-88ed-d2ab59b005d0"]'
+      expect(dataset.organogram?).to be true
+    end
+
+    it 'recognises new schema_id as an organogram' do
+      dataset = build :dataset, schema_id: 'd3c0b23f-6979-45e4-88ed-d2ab59b005d0'
+      expect(dataset.organogram?).to be true
+    end
+
+    it 'does not recognise other ids as an organogram' do
+      dataset = build :dataset, schema_id: 'non-organogram'
+      expect(dataset.organogram?).to be false
+    end
+  end
+end


### PR DESCRIPTION
## What

The elasticsearch data was not being updated correctly by Publish so this is a short term fix to allow it to work with new and legacy schema_id formats otherwise organograms added in pre migration would not be recognised as such so end users would not be able to see the organogram visualisations.

## Reference

https://trello.com/c/wWud8TWI/1014-discover-and-fix-organograms-not-properly-set-up