### PR TITLE
Fix preview by increasing bytes read from CSV

### DIFF
--- a/app/models/preview.rb
+++ b/app/models/preview.rb
@@ -38,7 +38,7 @@ private
   def fetch_raw
     connection = build_connection
 
-    connection.headers = { 'Range' => 'bytes=0-1024' }
+    connection.headers = { 'Range' => 'bytes=0-4096' }
 
     begin
       response = connection.get do |request|

--- a/spec/controllers/previews_controller_spec.rb
+++ b/spec/controllers/previews_controller_spec.rb
@@ -7,14 +7,16 @@ RSpec.describe PreviewsController, type: :controller do
   let(:datafile) { dataset.datafiles.first }
 
   describe 'Generating the preview of a CSV file' do
-    it 'will show the previewed CSV' do
+    it 'will show the first six rows (including the header) of the CSV' do
       stub_request(:get, datafile.url).
-        to_return(body: "a,Paris,c,d\ne,f,Berlin,h\ni,j,k,l")
+        to_return(body: "Header row,Name,Grade,Job Title,Job/Team Function,Parent Department,Organisation,Unit,Contact Phone,Contact Email,Reports to Senior Post,Salary,FTE,Actual Pay Floor,Actual Pay Ceiling,Professional,Notes,Valid? \n2nd row,Romeo Juliet SCSX,Permanent Director,Lorem ipsum dolor sit amet consectetur adipiscing elit. Mauris tincidunt in odio sed dignissim. Vivamus quis auctor mi. Praesent et pharetra tellus. Donec eget dapibus purus cursus hendrerit massa. Phasellus ac velit lobortis sem volutpat euismod. Duis aliquam urna ac pulvinar cursus. Aliquam iaculis sit amet diam a commodo.,Cabinet Office,Cabinet Office,Cabinet Office,012 3456 7890,email@test.com,317,xx,1,123000,345000,x,profession,non,1,romeo,sierra \n3rd row,Romeo Juliet SCSX,Permanent Director,Lorem ipsum dolor sit amet consectetur adipiscing elit. Mauris tincidunt in odio sed dignissim. Vivamus quis auctor mi. Praesent et pharetra tellus. Donec eget dapibus purus cursus hendrerit massa. Phasellus ac velit lobortis sem volutpat euismod. Duis aliquam urna ac pulvinar cursus. Aliquam iaculis sit amet diam a commodo.,Cabinet Office,Cabinet Office,Cabinet Office,012 3456 7890,email@test.com,317,xx,1,123000,345000,x,profession,non,1,romeo,sierra \n4th row,Romeo Juliet SCSX,Permanent Director,Lorem ipsum dolor sit amet consectetur adipiscing elit. Mauris tincidunt in odio sed dignissim. Vivamus quis auctor mi. Praesent et pharetra tellus. Donec eget dapibus purus cursus hendrerit massa. Phasellus ac velit lobortis sem volutpat euismod. Duis aliquam urna ac pulvinar cursus. Aliquam iaculis sit amet diam a commodo.,Cabinet Office,Cabinet Office,Cabinet Office,012 3456 7890,email@test.com,317,xx,1,123000,345000,x,profession,non,1,romeo,sierra \n5th row,Romeo Juliet SCSX,Permanent Director,Lorem ipsum dolor sit amet consectetur adipiscing elit. Mauris tincidunt in odio sed dignissim. Vivamus quis auctor mi. Praesent et pharetra tellus. Donec eget dapibus purus cursus hendrerit massa. Phasellus ac velit lobortis sem volutpat euismod. Duis aliquam urna ac pulvinar cursus. Aliquam iaculis sit amet diam a commodo.,Cabinet Office,Cabinet Office,Cabinet Office,012 3456 7890,email@test.com,317,xx,1,123000,345000,x,profession,non,1,romeo,sierra \n6th row,Romeo Juliet SCSX,Permanent Director,Lorem ipsum dolor sit amet consectetur adipiscing elit. Mauris tincidunt in odio sed dignissim. Vivamus quis auctor mi. Praesent et pharetra tellus. Donec eget dapibus purus cursus hendrerit massa. Phasellus ac velit lobortis sem volutpat euismod. Duis aliquam urna ac pulvinar cursus. Aliquam iaculis sit amet diam a commodo.,Cabinet Office,Cabinet Office,Cabinet Office,012 3456 7890,email@test.com,317,xx,1,123000,345000,x,profession,non,1,romeo,sierra\n")
 
       index([dataset])
       get :show, params: { dataset_uuid: dataset.uuid, name: dataset.name, datafile_uuid: datafile.uuid }
-      expect(response.body).to have_content('Berlin')
-      expect(response.body).to have_link("Download this file")
+
+      expect(response.body).to have_content('Header row')
+      expect(response.body).to have_content('2nd row')
+      expect(response.body).not_to have_content("6th row")
     end
 
     it 'will recover if the datafile server times out' do


### PR DESCRIPTION
Some of the CSV previews are showing the header, but no data rows:
![Screen Shot 2019-05-20 at 11 16 17](https://user-images.githubusercontent.com/19667619/58090952-4a2e5b00-7bc0-11e9-9bef-e59d7f84f988.png)

The organogram CSV files can be quite large, and so only one row was being passed through as the preview. Increasing the number of bytes read appears to fix this issue.
Upon further investigation into the code the preview should contain four data rows as well as the header. The test has been updated to reflect this now.
 
Trello card: https://trello.com/c/RO7V0SE1/1002-show-the-csv-preview-for-organograms