### PR TITLE
Retrieve S3 bucket data for correct environment

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root to: 'pages#home'
 
-  get "/sites/default/files/*organogram_path", to: redirect("https://s3-eu-west-1.amazonaws.com/datagovuk-production-ckan-organogram/legacy/%{organogram_path}"), format: false
+  get "/sites/default/files/*organogram_path", to: redirect("https://s3-eu-west-1.amazonaws.com/datagovuk-#{Rails.env}-ckan-organogram/legacy/%{organogram_path}"), format: false
 
   if ENV["CKAN_REDIRECTION_URL"].present?
     get 'dataset/edit/:legacy_name', to: redirect(domain: ENV['CKAN_REDIRECTION_URL'], subdomain: '', path: "/dataset/edit/%{legacy_name}")

--- a/spec/requests/legacy/redirect_spec.rb
+++ b/spec/requests/legacy/redirect_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe 'legacy', type: :request do
   describe "legacy organograms" do
     it "redirects to S3" do
       get "/sites/default/files/organogram/appointments-commission/31/03/2011/appointments_commission-2011-03-31-organogram-junior.csv"
-      expect(response).to redirect_to("https://s3-eu-west-1.amazonaws.com/datagovuk-production-ckan-organogram/legacy/organogram/appointments-commission/31/03/2011/appointments_commission-2011-03-31-organogram-junior.csv")
+      expect(response).to redirect_to("https://s3-eu-west-1.amazonaws.com/datagovuk-#{Rails.env}-ckan-organogram/legacy/organogram/appointments-commission/31/03/2011/appointments_commission-2011-03-31-organogram-junior.csv")
     end
   end
 end


### PR DESCRIPTION
Currently, we always fetch organograms data from the production S3
bucket regardless of the environment that we make the request from. This
causes staging to try to fetch production data and the request fails due
to CORS rules that don't allow this.

This commit fixes this issue by dynamically constructing the S3 bucket
name for the correct environment.

Trello card: https://trello.com/c/Vx11ucIl/1043-fix-display-of-organogram-visualisations-on-stagingdatagovuk

Co-Authored-By: Murilo Dal Ri <murilo.dalri@digital.cabinet-office.gov.uk>