### PR TITLE
Don't redirect assets paths to CKAN

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,9 @@ Rails.application.routes.draw do
 
   # Route everything else to CKAN
   if ENV["CKAN_REDIRECTION_URL"].present?
-    match '*path', to: redirect(domain: ENV['CKAN_REDIRECTION_URL'], subdomain: '', path: "/%{path}"), via: :all
+    match '*path',
+      to: redirect(domain: ENV['CKAN_REDIRECTION_URL'], subdomain: '', path: "/%{path}"),
+      via: :all,
+      constraints: { path: /(?!#{Regexp.quote(Rails.application.config.assets.prefix[1..-1])}).+/ }
   end
 end

--- a/spec/requests/ckan_redirection_spec.rb
+++ b/spec/requests/ckan_redirection_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+require 'securerandom'
+
+RSpec.describe 'CKAN redirection', type: :request do
+  let(:path) { nil }
+
+  shared_examples "does redirect to CKAN" do
+    it "does redirect to CKAN" do
+      get path
+
+      expect(response).to have_http_status(:moved_permanently)
+      expect(response).to redirect_to("http://testdomain#{path}")
+    end
+  end
+
+  shared_examples "doesn't redirect to CKAN" do
+    it "doesn't redirect to CKAN" do
+      get path
+
+      expect(response).to_not have_http_status(:moved_permanently)
+    end
+  end
+
+  context "with a known path" do
+    let(:path) { "/dataset/#{SecureRandom.uuid}" }
+    include_examples "doesn't redirect to CKAN"
+  end
+
+  context "with an assets path" do
+    let(:path) { "/find-assets/application-#{SecureRandom.uuid}.js" }
+    include_examples "doesn't redirect to CKAN"
+  end
+
+  context "with an unknown path" do
+    let(:path) { "/an/unknown/path" }
+    include_examples "does redirect to CKAN"
+  end
+
+  context "with an unknown path that includes 'find-assets'" do
+    let(:path) { "/an/unknown/path/find-assets/application" }
+    include_examples "does redirect to CKAN"
+  end
+end


### PR DESCRIPTION
We're seeing a problem in staging where assets are being redirected to CKAN even when they exist.

I'm not sure why this wasn't a problem in production.

[Trello Card](https://trello.com/c/Vx11ucIl/1043-fix-display-of-organogram-visualisations-on-stagingdatagovuk)