### PR TITLE
Display full salary ranges for junior posts in organograms

### DIFF
--- a/app/assets/javascripts/organograms/org-data-loader.js
+++ b/app/assets/javascripts/organograms/org-data-loader.js
@@ -131,7 +131,7 @@ var OrgDataLoader = {
             var floor = post["Payscale Minimum (£)"] * 100 / 100;
             var ceil = post['Payscale Maximum (£)'] * 100 / 100;
 
-            return formatMoney(floor) + " - " + formatMoney(floor);
+            return formatMoney(floor) + " - " + formatMoney(ceil);
         }
 
         function createJuniorPostNode(post, index){


### PR DESCRIPTION
Junior posts on organograms are currently displaying salary ranges as `£{min_salary} - £{min_salary}`.

This will correct to display the full range `£{min_salary} - £{max_salary}`.

[Trello](https://trello.com/c/nmB2L0l0/1111-junior-post-organogram-showing-only-minimum-pay)