### PR TITLE
Fix the display of licences

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -31,7 +31,14 @@ class Dataset
     @released = hash["released"]
     @licence = hash["licence"]
     @licence_other = hash["licence_other"]
-    @licence_custom = hash["licence_custom"]
+    raw_licence_custom = hash["licence_custom"]
+    # left this code in place because extracting it into a method would break tests
+    # as the initialize is called twice in the tests
+    @licence_custom = if raw_licence_custom && raw_licence_custom.match?(/\[.+\]/)
+                        YAML.safe_load(raw_licence_custom).join("<br />")
+                      else
+                        raw_licence_custom
+                      end
     @licence_title = hash["licence_title"]
     @licence_url = hash["licence_url"]
     @licence_code = hash["licence_code"]

--- a/spec/factories/dataset.rb
+++ b/spec/factories/dataset.rb
@@ -63,6 +63,10 @@ FactoryBot.define do
       licence_custom 'Special case'
     end
 
+    trait :with_custom_licence_brackets do
+      licence_custom '["Special case"]'
+    end
+
     initialize_with { Dataset.new(attributes.stringify_keys) }
   end
 end

--- a/spec/features/dataset_show_page_spec.rb
+++ b/spec/features/dataset_show_page_spec.rb
@@ -64,6 +64,24 @@ RSpec.feature 'Dataset page', type: :feature, elasticsearch: true do
       end
     end
 
+    scenario 'Link to custom licence brackets (no title, no URL)' do
+      dataset = build :dataset, :with_custom_licence_brackets
+      index_and_visit(dataset)
+
+      within('section.meta-data') do
+        expect(page)
+          .to have_content('Other Licence')
+
+        expect(page)
+          .to have_link('View licence information',
+                        href: '#licence-info')
+      end
+
+      within('section.dgu-licence-info') do
+        expect(page).to have_content('Special case')
+      end
+    end
+
     scenario 'Simple licence title (no URL)' do
       dataset = build :dataset, licence_title: 'My Licence'
       index_and_visit(dataset)


### PR DESCRIPTION
## What

Fix licences that were not displaying correctly if they have ["..."] in the field.

During an investigation in the data it was discovered that the `licence_custom` field can contain data with or without brackets, pre and post migration data was looked at so both need to be handled.

## Reference

https://trello.com/c/mF4hegw6/1247-dgu-licence-information-including-quotations-in-urls