### PR TITLE
Strip whitespace from format for checks on CSV

### DIFF
--- a/app/models/datafile.rb
+++ b/app/models/datafile.rb
@@ -10,7 +10,7 @@ class Datafile
     @start_date = hash["start_date"]
     @created_at = hash["created_at"]
     @updated_at = hash["updated_at"]
-    @format = hash["format"]
+    @format = hash["format"]&.strip&.upcase
     @size = hash["size"]
     @uuid = hash["uuid"]
   end
@@ -30,19 +30,19 @@ class Datafile
   end
 
   def html?
-    format&.upcase == 'HTML'
+    format == 'HTML'
   end
 
   def csv?
-    format&.upcase == 'CSV'
+    format == 'CSV'
   end
 
   def wms?
-    format&.upcase == 'WMS'
+    format == 'WMS'
   end
 
   def wfs?
-    format&.upcase == 'WFS'
+    format == 'WFS'
   end
 
   def preview

--- a/spec/models/datafile_spec.rb
+++ b/spec/models/datafile_spec.rb
@@ -20,5 +20,12 @@ RSpec.describe Datafile do
         expect(datafile.csv?).to be true
       end
     end
+
+    describe "#csv?" do
+      it 'returns true if datafile is "csv "' do
+        datafile = build :datafile, format: 'CSV '
+        expect(datafile.csv?).to be true
+      end
+    end
   end
 end


### PR DESCRIPTION
## What

In some cases the format is stored as `CSV ` (additional space) which causes the CSV check to fail so the CSV previews do not show. 

The additional space is usually found in older datasets, the problem is probably due to the `format` field being allowed to be freeform text. In the most recent versions of `ckan` the format is set by the system if the user doesn't enter a `format` value, but it's still possible to enter `CSV `.

Another solution may have been to clean the data but this would also require an update to the ckan publisher to ensure that there are no trailing spaces.

## Reference 

https://trello.com/c/TZj2r5FI/1258-csv-preview-not-available-for-some-historical-transparency-data