### PR TITLE
Update regex for licence_custom

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,7 @@ AllCops:
     - config.ru
     - db/schema.rb
     - vendor/**/*
+    - vendor/bundle/**/*
 
 Metrics/BlockLength:
   Exclude:

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -34,7 +34,7 @@ class Dataset
     raw_licence_custom = hash["licence_custom"]
     # left this code in place because extracting it into a method would break tests
     # as the initialize is called twice in the tests
-    @licence_custom = if raw_licence_custom && raw_licence_custom.match?(/\[.+\]/)
+    @licence_custom = if raw_licence_custom && raw_licence_custom.match?(/^\[.+\]$/)
                         YAML.safe_load(raw_licence_custom).join("<br />")
                       else
                         raw_licence_custom

--- a/spec/factories/dataset.rb
+++ b/spec/factories/dataset.rb
@@ -67,6 +67,10 @@ FactoryBot.define do
       licence_custom '["Special case"]'
     end
 
+    trait :with_custom_licence_brackets_middle do
+      licence_custom 'Special case, [2019].'
+    end
+
     initialize_with { Dataset.new(attributes.stringify_keys) }
   end
 end

--- a/spec/features/dataset_show_page_spec.rb
+++ b/spec/features/dataset_show_page_spec.rb
@@ -82,6 +82,24 @@ RSpec.feature 'Dataset page', type: :feature, elasticsearch: true do
       end
     end
 
+    scenario 'Link to custom licence brackets (no title, no URL)' do
+      dataset = build :dataset, :with_custom_licence_brackets_middle
+      index_and_visit(dataset)
+
+      within('section.meta-data') do
+        expect(page)
+          .to have_content('Other Licence')
+
+        expect(page)
+          .to have_link('View licence information',
+                        href: '#licence-info')
+      end
+
+      within('section.dgu-licence-info') do
+        expect(page).to have_content('Special case')
+      end
+    end
+
     scenario 'Simple licence title (no URL)' do
       dataset = build :dataset, licence_title: 'My Licence'
       index_and_visit(dataset)


### PR DESCRIPTION
## What

Datasets with custom licences were not showing because the licence contained square brackets within the licence. 

The regex to handle the `licence_custom` field is updated to only look for square brackets at the ends.