### PR TITLE
Add check to Dataset `organogram?` to return false for items without a schema id

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -108,6 +108,8 @@ class Dataset
   end
 
   def organogram?
+    return false unless @schema_id
+
     schema_id = @schema_id.gsub(/\["|"\]/, '')
     ORGANOGRAM_SCHEMA_IDS.include?(schema_id)
   end

--- a/spec/models/dataset_spec.rb
+++ b/spec/models/dataset_spec.rb
@@ -16,5 +16,10 @@ RSpec.describe Dataset do
       dataset = build :dataset, schema_id: 'non-organogram'
       expect(dataset.organogram?).to be false
     end
+
+    it 'does not recognise nil ids as an organogram' do
+      dataset = build :dataset, schema_id: nil
+      expect(dataset.organogram?).to be false
+    end
   end
 end


### PR DESCRIPTION
It is possible for datasets to exist  without a schema id. When previewing the
CSV for these datasets, the check to see if they are an Organogram causes an error.

This PR allows the Organogram check to automatically return `false` and the previews
to continue rendering.

Co-authored-by: Ed Kerry <edward.kerry@digital.cabinet-office.gov.uk>
Co-authored-by: Ken Tsang <ken.tsang@digital.cabinet-office.gov.uk>