### PR TITLE
Specify Accept-Encoding when calling URI().read

### DIFF
--- a/app/controllers/map_previews_controller.rb
+++ b/app/controllers/map_previews_controller.rb
@@ -25,7 +25,10 @@ class MapPreviewsController < ApplicationController
 
   def proxy
     url = correct_url(url_param)
-    response = URI(url).read.force_encoding("ISO-8859-1").encode("UTF-8")
+    response = URI(url)
+                 .read('Accept-Encoding' => 'gzip, deflate')
+                 .force_encoding("ISO-8859-1")
+                 .encode("UTF-8")
     render xml: Nokogiri::XML(response)
   rescue StandardError => e
     Raven.capture_exception(e)


### PR DESCRIPTION
Without this, something seems to go wrong. I'm not sure what value is
being sent for this header (if any) without this method argument, nor
do I know if this is specific to some server configurations, but at
least with one [1] URL, there's a Zlib::BufError raised from inside of
open-uri if the Accept-Encoding parameter isn't specified.

I found a reference to Ruby supporting gzip and deflate, so I went
with accepting those.

1: https://emaps.eastleigh.gov.uk/inspire/wms.exe?_dc=1570638796663&request=GetCapabilities&service=WMS