### PR TITLE
Switch to using Rubocop directly

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+inherit_gem:
+  govuk-lint: "configs/rubocop/all.yml"
+
 AllCops:
   TargetRubyVersion: 2.5
   Exclude:

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,4 +1,4 @@
 desc "Run govuk-lint on all files"
 task "lint" do
-  sh "govuk-lint-ruby --format clang"
+  sh "bundle exec rubocop --parallel app config lib spec --format clang"
 end


### PR DESCRIPTION
As this avoids the need for the govuk-lint-ruby wrapper script.