### PR TITLE
Handle broken gzip encoding in the map previews controller

### DIFF
--- a/app/controllers/map_previews_controller.rb
+++ b/app/controllers/map_previews_controller.rb
@@ -26,7 +26,13 @@ class MapPreviewsController < ApplicationController
   def proxy
     url = correct_url(url_param)
     response = URI(url)
-                 .read('Accept-Encoding' => 'gzip, deflate')
+                 .read
+                 .force_encoding("ISO-8859-1")
+                 .encode("UTF-8")
+    render xml: Nokogiri::XML(response)
+  rescue Zlib::BufError
+    response = URI(url)
+                 .read('Accept-Encoding' => '')
                  .force_encoding("ISO-8859-1")
                  .encode("UTF-8")
     render xml: Nokogiri::XML(response)


### PR DESCRIPTION
This improves on the changes in [1] that avoided Zlib::BufError
errors, but the response returned wasn't valid XML.

To cope with the possibility that the response might not be properly
encoded, detect Zlib::BufError errors, then repeat the request forcing
no content encoding. This means that for servers that support
correctly encoding the response, gzip will be used, and for servers
that don't, the proxy will still work by making a request without
content encoding.

This [2] is the example URL that I've been testing with.

1: bdc8c75215df5f09c5cdf0a19774b7e0d43479a4
2: https://emaps.eastleigh.gov.uk/inspire/wms.exe?_dc=1570638796663&request=GetCapabilities&service=WMS