### PR TITLE
Upgrade to 1.8.0 buildpack

### DIFF
--- a/production-manifest.yml
+++ b/production-manifest.yml
@@ -3,7 +3,7 @@ applications:
 - name: find-data-beta
   instances: 4
   memory: 512M
-  buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.7.40
+  buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.0
   stack: cflinuxfs3
   routes:
   - route: find-data-beta.cloudapps.digital

--- a/staging-manifest.yml
+++ b/staging-manifest.yml
@@ -3,7 +3,7 @@ applications:
 - name: find-data-beta-staging
   instances: 1
   memory: 512M
-  buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.7.40
+  buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.0
   stack: cflinuxfs3
   routes:
     - route: find-data-beta-staging.cloudapps.digital


### PR DESCRIPTION
It hasn't been possible to deploy Find since https://github.com/alphagov/datagovuk_find/pull/703 because Ruby 2.6.5 isn't available in the 1.7.40 buildpack.

Example failure: https://travis-ci.org/alphagov/datagovuk_find/builds/647285154

[Trello Card](https://trello.com/c/gyV5StET/1747-stop-datagovuk-setting-cookies)