### PR TITLE
Updating content to reflect change in cookie use

### DIFF
--- a/app/views/pages/cookies.html.erb
+++ b/app/views/pages/cookies.html.erb
@@ -5,58 +5,7 @@
     <h1 class="heading-large">
       Cookies
     </h1>
-
-    <p>We put small files (known as ‘cookies’) onto your computer to collect information about how you browse the site. We collect this information to help us improve the service.</p>
-    
-    <h2 class="heading-medium">How cookies are used on Find open data</h2>
-
-    <p>We use cookies to:</p>
-
-    <ul class="list list-bullet">
-      <li>measure how you use the service so it can be updated and improved based on your needs</li>
-      <li>remember the notifications you’ve seen so that we don’t show them to you again</li>
-      <li>remember that you’ve already seen this page</li>
-      <li>collect information on the search terms you use so the service can be improved</li>
-    </ul>
-
-    <p>We won’t use cookies for any other reasons.</p>
-
-    <p>You’ll see a message on the site before we store a cookie on your computer.</p>
-
-    <p>These are the Google Analytics cookies we’ll use:</p>
-
-    <div class="table-wrapper">
-      <table>
-        <thead>
-        <tr>
-          <th>Name</th>
-          <th>Purpose</th>
-          <th>Expires</th>
-        </tr>
-        </thead>
-
-        <tbody>
-        <tr>
-          <td>_ga, _gid</td>
-          <td>
-            These help us count how many people visit data.gov.uk<br/>
-            by tracking if you’ve visited before
-          </td>
-          <td>_ga 2 years, _gid 24 hours</td>
-        </tr>
-
-        <tr>
-          <td>_gat</td>
-          <td>Used to manage the rate at which page view requests are made</td>
-          <td>10 minutes</td>
-        </tr>
-        </tbody>
-      </table>
-    </div>
-
-    <p>At any time, you can <%= link_to 'opt out of Google Analytics cookies', 'https://tools.google.com/dlpage/gaoptout', target: '_blank' %>.</p>
-    <p>Find out more
-      about <%= link_to 'how to manage cookies', 'https://ico.org.uk/for-the-public/online/cookies', target: '_blank' %>.</p>
-
+    <p>Cookies are files saved on your phone, tablet or computer when you visit a website.</p>
+    <p>Data.gov.uk does not use cookies.</p>
   </div>
 </main>


### PR DESCRIPTION
Changes the content on the cookies page to reflect that we no longer set cookies on data.gov.uk

[Trello](https://trello.com/c/gyV5StET/1747-stop-datagovuk-setting-cookies)