### PR TITLE
Clear seen_cookie_message cookie

### DIFF
--- a/app/assets/javascripts/govuk.js
+++ b/app/assets/javascripts/govuk.js
@@ -6,6 +6,9 @@ $(document).ready(function () {
   // with role="button" when the space key is pressed.
   GOVUK.shimLinksWithButtonRole.init()
 
+  // Clear cookie set by govuk_template.
+  GOVUK.cookie('seen_cookie_message', null);
+
   // Show and hide toggled content
   // Where .multiple-choice uses the data-target attribute
   // to toggle hidden content


### PR DESCRIPTION
This cookie is set automatically by govuk_template but we don't want to set any cookies as we don't have consent.

Updating govuk_template to not set this cookie is going to difficult as the library is deprecated.

[Trello Card](https://trello.com/c/gyV5StET/1747-stop-datagovuk-setting-cookies)