### PR TITLE
Hide global cookie message

### DIFF
--- a/app/assets/javascripts/govuk.js
+++ b/app/assets/javascripts/govuk.js
@@ -8,6 +8,7 @@ $(document).ready(function () {
 
   // Clear cookie set by govuk_template.
   GOVUK.cookie('seen_cookie_message', null);
+  $('#global-cookie-message').remove();
 
   // Show and hide toggled content
   // Where .multiple-choice uses the data-target attribute


### PR DESCRIPTION
This is part of govuk_template which can't be edited. This follows on from https://github.com/alphagov/datagovuk_find/pull/714.