### PR TITLE
Delete cookies if present

### DIFF
--- a/app/assets/javascripts/govuk.js
+++ b/app/assets/javascripts/govuk.js
@@ -8,6 +8,11 @@ $(document).ready(function () {
 
   // Clear cookie set by govuk_template.
   GOVUK.cookie('seen_cookie_message', null);
+  document.cookie = '_ga=;expires=' + new Date() + ';domain=' + window.location.hostname + ';path=/'
+  document.cookie = '_gat=;expires=' + new Date() + ';domain=' + window.location.hostname + ';path=/'
+  document.cookie = '_gid=;expires=' + new Date() + ';domain=' + window.location.hostname + ';path=/'
+  document.cookie = '_session_id=;expires=' + new Date() + ';domain=' + window.location.hostname + ';path=/'
+  document.cookie = 'dgu_beta_banner_dismissed=;expires=' + new Date() + ';domain=' + window.location.hostname + ';path=/'
   $('#global-cookie-message').remove();
 
   // Show and hide toggled content


### PR DESCRIPTION
Since we don't ask for consent to set cookies in data.gov.uk and we have
done work to avoid setting them, we also want to delete those that were
previously set.

Trello card: https://trello.com/c/gyV5StET/1747-stop-datagovuk-setting-cookies