### PR TITLE
Add GOVUK_APP_DOMAIN env var

### DIFF
--- a/production-manifest.yml
+++ b/production-manifest.yml
@@ -12,6 +12,7 @@ applications:
     RAILS_ENV: production
     RACK_ENV: production
     CKAN_REDIRECTION_URL: ckan.publishing.service.gov.uk
+    GOVUK_APP_DOMAIN: www.gov.uk
   services:
   - find-production-secrets
   - elasticsearch-6-beta-production

--- a/staging-manifest.yml
+++ b/staging-manifest.yml
@@ -12,6 +12,7 @@ applications:
     RAILS_ENV: staging
     RACK_ENV: staging
     CKAN_REDIRECTION_URL: ckan.staging.publishing.service.gov.uk
+    GOVUK_APP_DOMAIN: www.gov.uk
   services:
   - find-staging-secrets
   - elasticsearch-6-beta-staging


### PR DESCRIPTION
The builds are failing because it's expecting `GOVUK_APP_DOMAIN` to be set, but it currently isn't. Adding it here to see if that helps.