### PR TITLE
Fix licence url in dataset metadata

### DIFF
--- a/app/helpers/datasets_helper.rb
+++ b/app/helpers/datasets_helper.rb
@@ -58,7 +58,7 @@ module DatasetsHelper
         "@type": "CreativeWork",
         name: dataset.licence_title,
         text: dataset.licence_custom,
-        url: dataset.licence_url,
+        url: licence_url(dataset),
       },
       dateModified: dataset.public_updated_at,
     }
@@ -83,6 +83,10 @@ module DatasetsHelper
       )
     end
     files
+  end
+
+  def licence_url(dataset)
+    dataset.licence_url.presence || "#{request.protocol}#{request.host_with_port}#{request.fullpath}#license-info"
   end
 
   def contact_information_exists?(dataset)


### PR DESCRIPTION
If the dataset `licence_url` and `licence_name` are both `null`,
this invalidates the schema and returns the error
`One of name or url must be provided.` This means the datasets
might not appear as rich results in Google's Dataset Search tool
(https://datasetsearch.research.google.com/)

If the `licence_url` isn't specified  we can set it to the licence
section of the dataset page.

Before:
<img width="548" alt="Screenshot 2020-02-26 at 15 02 07" src="https://user-images.githubusercontent.com/19667619/75357424-4515df00-58a9-11ea-8885-3bb0ba5faffa.png">

After:
<img width="578" alt="Screenshot 2020-02-26 at 15 02 53" src="https://user-images.githubusercontent.com/19667619/75357438-4941fc80-58a9-11ea-9f42-87b2e9d06e52.png">

Trello card: https://trello.com/c/fPAehpfT/1764-5-fix-datagovuk-dataset-markup-errors-as-reported-by-google-search-console