### PR TITLE
Fix url anchor in metadata

### DIFF
--- a/app/helpers/datasets_helper.rb
+++ b/app/helpers/datasets_helper.rb
@@ -86,7 +86,7 @@ module DatasetsHelper
   end
 
   def licence_url(dataset)
-    dataset.licence_url.presence || "#{request.protocol}#{request.host_with_port}#{request.fullpath}#license-info"
+    dataset.licence_url.presence || "#{request.protocol}#{request.host_with_port}#{request.fullpath}#licence-info"
   end
 
   def contact_information_exists?(dataset)


### PR DESCRIPTION
This was originally missed in https://github.com/alphagov/datagovuk_find/pull/721/commits/1ebf569e882956013c303b4c62ced4d2cb10cafc 

Part of PR https://github.com/alphagov/datagovuk_find/pull/721

Trello card: https://trello.com/c/fPAehpfT/1764-5-fix-datagovuk-dataset-markup-errors-as-reported-by-google-search-console