### PR TITLE
2ND Line: highlighting problem with CSRF authentication in support form

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -25,8 +25,7 @@ Rails.application.configure do
   # Render exceptions instead of raising them
   config.action_dispatch.show_exceptions = true
 
-  # Disable request forgery protection in test environment.
-  config.action_controller.allow_forgery_protection = false
+  # Disable caching in test environment.
   config.action_mailer.perform_caching = false
 
   # Tell Action Mailer not to deliver emails to the real world.
@@ -39,4 +38,7 @@ Rails.application.configure do
 
   # Raises error for missing translations
   config.action_view.raise_on_missing_translations = true
+
+  # The support forms require CSRF authentication, this should be checked in the tests
+  config.action_controller.allow_forgery_protection = true  
 end

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,1 +1,2 @@
-Rails.application.config.session_store :disabled
+Rails.application.config.session_store :cookie_store, expire_after: 14.days, secure: !(Rails.env.development? || Rails.env.test?), httponly: true
+


### PR DESCRIPTION
The recent move to disable session cookies (https://github.com/alphagov/datagovuk_find/commit/44156183dbdc7ec0e461241edc557601b1b9e235) seems to have broken the support forms.

Currently, clicking submit takes the user to the following error...

<img width="561" alt="Screenshot 2020-02-27 at 12 22 51" src="https://user-images.githubusercontent.com/41922771/75444778-fb3a0100-595b-11ea-9304-1d133d564672.png">
<img width="806" alt="Screenshot 2020-02-27 at 12 23 08" src="https://user-images.githubusercontent.com/41922771/75444781-fbd29780-595b-11ea-9777-f28b06a6c21b.png">

This is because the server compares the submitted authenticity_token to the value associated with the user’s session. So, without cookies enabled this will not work, since there is no associated session.

No one picked up on this happening as the tests still passed, this is because forgery protection is set to false by default in test and development environments. Toggling this setting to true results in all of the tests in _support_spec.rb_ failing. I have left it on true in order to alert us should this happen again. I don't think it will affect performance with regards to running the tests all that much. 

To restore functionality in the forms I have restored the old settings for session cookies. 