### PR TITLE
Remove `lint` Rake task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ before_script:
   - "./cc-test-reporter before-build"
 script:
   - bundle exec rake
+  - bundle exec rubocop app spec lib
 after_script:
   - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then ./cc-test-reporter after-build --exit-code
     $TRAVIS_TEST_RESULT; fi

--- a/Rakefile
+++ b/Rakefile
@@ -5,4 +5,4 @@ require_relative 'config/application'
 
 Rails.application.load_tasks
 
-task default: %i(brakeman lint spec)
+task default: %i(brakeman spec)

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,4 +1,0 @@
-desc "Run rubocop on all files"
-task "lint" do
-  sh "bundle exec rubocop --parallel app lib spec test --format clang"
-end


### PR DESCRIPTION
- Now we don't use `govuk-lint` to wrap RuboCop, we _could_ switch this
  to run `bundle exec rubocop`, but that's not very useful as it hides
  the directories that it operates on, and we're trying to move away
  from wrappers.
- Instead, I think we can leave people to run `bundle exec rubocop` on
  their own - it's less typing than `bundle exec rake lint` and
  `rubocop --help` works for options.

https://trello.com/c/IEUuFOVa/129-remove-the-lint-rake-task-from-apps-that-have-it