### PR TITLE
Raise as 404 error if legacy datafile cannot be found

### DIFF
--- a/app/controllers/legacy/datafiles_controller.rb
+++ b/app/controllers/legacy/datafiles_controller.rb
@@ -3,6 +3,8 @@ class Legacy::DatafilesController < ApplicationController
     dataset = Dataset.get_by_legacy_name(legacy_name: params[:legacy_dataset_name])
     datafile = dataset.datafiles.find { |f| f.uuid == params[:datafile_uuid] }
 
+    raise Datafile::DatafileNotFound if datafile.nil?
+
     redirect_path = datafile_preview_path(dataset.uuid, dataset.name, datafile.uuid)
 
     redirect_to redirect_path, status: :moved_permanently

--- a/spec/requests/error_handling_spec.rb
+++ b/spec/requests/error_handling_spec.rb
@@ -21,4 +21,12 @@ RSpec.describe "Error handling", type: :request do
     get "/dataset/#{dataset.uuid}/#{dataset.name}/datafile/#{SecureRandom.uuid}/preview"
     expect(response).to have_http_status(:not_found)
   end
+
+  it "handles a legacy Datafile that can't be found by UUID" do
+    dataset = build :dataset
+    index(dataset)
+
+    get "/dataset/#{dataset.name}/resource/#{SecureRandom.uuid}"
+    expect(response).to have_http_status(:not_found)
+  end
 end


### PR DESCRIPTION
We are currently not catching this error, which throws a 500
internal server error when a datafile can't be found for a legacy
dataset. This is misleading to users and should be treated as a 404
error.

We have a number of datasets with this issue, which might affect
how Google ranks data.gov.uk.

Trello card: https://trello.com/c/QamBRS2t/1792-2-missing-datasets-on-datagovuk-should-give-a-404-error-not-a-500