### PR TITLE
Add invisible span for CSV preview links

### DIFF
--- a/app/views/datasets/_datafile_table.html.erb
+++ b/app/views/datasets/_datafile_table.html.erb
@@ -14,10 +14,10 @@
                 'ga-event' => "download",
                 'ga-format' => "CSV",
                 'ga-publisher' => @dataset.organisation.name
-              },
-              'aria-label': "Download datafile #{datafile.name} format: #{format_of(datafile)} dataset: #{@dataset.title}" do %>
-            <%= (datafile.name ? datafile.name : 'Data Link') %>
-            <span class='visually-hidden'>Download datafile '<%= datafile.name %>', Format: <%= format_of(datafile) %>, Dataset: <%= @dataset.title %></span>
+              } do %>
+            <span class="visually-hidden">Download </span>
+            <%= (datafile.name ? datafile.name : 'Data') %>
+            <span class='visually-hidden'>, Format: <%= format_of(datafile) %>, Dataset: <%= @dataset.title %></span>
           <% end %>
         </td>
         <% if datafile.format.blank? %>

--- a/app/views/datasets/_datafile_table.html.erb
+++ b/app/views/datasets/_datafile_table.html.erb
@@ -43,10 +43,9 @@
                   'ga-event' => 'preview',
                   'ga-format' => (datafile.format.presence || 'n/a').upcase,
                   'ga-publisher' => @dataset.organisation.name
-                  },
-                  'aria-label': "Preview CSV #{datafile.name}, dataset: #{@dataset.title}" do %>
+                  } do %>
                   Preview
-                  <span class='visually-hidden'>Preview CSV '<%= datafile.name %>', Dataset: <%= @dataset.title %></span>
+                  <span class='visually-hidden'> CSV '<%= datafile.name %>', Dataset: <%= @dataset.title %></span>
                   <% end %>
           <% elsif datafile.wms? && @dataset.inspire_dataset.present? %>
             <%= link_to t('.map_preview'), map_preview_url(@dataset, datafile) %>

--- a/app/views/datasets/_datafile_table.html.erb
+++ b/app/views/datasets/_datafile_table.html.erb
@@ -37,17 +37,17 @@
           <td class="dgu-secondary-text">Not available</td>
         <% end %>
         <td class="datafiles__preview">
-          <% if datafile.html? %>
-            <%= link_to t('.go_to_site'), datafile.url %>
-          <% elsif datafile.csv? %>
-            <%= link_to t('.preview'),
-                datafile_preview_path(@dataset.uuid, @dataset.name, datafile.uuid),
+          <% if datafile.csv? %>
+            <%= link_to datafile_preview_path(@dataset.uuid, @dataset.name, datafile.uuid),
                 :data => {
-                  :'ga-event' => 'preview',
-                  :'ga-format' => (datafile.format.presence || 'n/a').upcase,
-                  :'ga-publisher' => @dataset.organisation.name
-                  }
-            %>
+                  'ga-event' => 'preview',
+                  'ga-format' => (datafile.format.presence || 'n/a').upcase,
+                  'ga-publisher' => @dataset.organisation.name
+                  },
+                  'aria-label': "Preview CSV #{datafile.name}, dataset: #{@dataset.title}" do %>
+                  Preview
+                  <span class='visually-hidden'>Preview CSV '<%= datafile.name %>', Dataset: <%= @dataset.title %></span>
+                  <% end %>
           <% elsif datafile.wms? && @dataset.inspire_dataset.present? %>
             <%= link_to t('.map_preview'), map_preview_url(@dataset, datafile) %>
           <% else %>


### PR DESCRIPTION
## What
This PR:

1. adds invisible spans to the "preview" links for CSV resources in dataset resource tables.
2. applies the invisible text only approach to a previous similar issue applied to data links <https://github.com/alphagov/datagovuk_find/pull/512>
3. removes the "go to site" link on HTML resources.

## Why
This is to comply with WCAG accessibility needs based on an audit last year. Specifically this makes the preview link now make sense to screen reader users out of context. The 2 links that were triggering this failure where the "go to site" link for HTML resources and "preview" links for CSV resources. The latter required solving, however the former may be redundant as this link is identical to the data link in the first table cell for HTML resources. It therefore makes more sense to simply remove it as the link is a suitable source for the resource itself.

**Card:** https://trello.com/c/WJFeCU9B/184-fix-non-descriptive-or-duplicate-links-from-datasets-high