### PR TITLE
Set dataset contact links to use text instead of their URLs

### DIFF
--- a/app/helpers/datasets_helper.rb
+++ b/app/helpers/datasets_helper.rb
@@ -125,6 +125,10 @@ module DatasetsHelper
     dataset.foi_name.presence || dataset.organisation.foi_name
   end
 
+  def foi_email_is_email?(dataset)
+    foi_email_for(dataset) =~ /@/
+  end
+
   def foi_email_for(dataset)
     dataset.foi_email.presence || dataset.organisation.foi_email
   end

--- a/app/views/datasets/_additional_info.html.erb
+++ b/app/views/datasets/_additional_info.html.erb
@@ -72,9 +72,9 @@
             <% if i['harvest_object_id'] %>
               <dt><%= t('.inspire_gemini_record') %></dt>
               <dd>
-                <%= link_to t('.xml'), "/api/2/rest/harvestobject/#{ i['harvest_object_id'] }/xml", class: 'govuk_link' %>
+                <%= link_to t('.xml'), "/api/2/rest/harvestobject/#{ i['harvest_object_id'] }/xml", class: 'govuk-link' %>
                 <br />
-                <%= link_to t('.html'), "/api/2/rest/harvestobject/#{ i['harvest_object_id'] }/html", class: 'govuk_link' %>
+                <%= link_to t('.html'), "/api/2/rest/harvestobject/#{ i['harvest_object_id'] }/html", class: 'govuk-link' %>
               </dd>
             <% end %>
           </dl>

--- a/app/views/datasets/_additional_info.html.erb
+++ b/app/views/datasets/_additional_info.html.erb
@@ -71,11 +71,8 @@
             <% end %>
             <% if i['harvest_object_id'] %>
               <dt><%= t('.inspire_gemini_record') %></dt>
-              <dd>
-                <%= link_to t('.xml'), "/api/2/rest/harvestobject/#{ i['harvest_object_id'] }/xml", class: 'govuk-link' %>
-                <br />
-                <%= link_to t('.html'), "/api/2/rest/harvestobject/#{ i['harvest_object_id'] }/html", class: 'govuk-link' %>
-              </dd>
+              <dd><%= link_to t('.xml'), "/api/2/rest/harvestobject/#{ i['harvest_object_id'] }/xml", class: 'govuk-link' %></dd>
+              <dd><%= link_to t('.html'), "/api/2/rest/harvestobject/#{ i['harvest_object_id'] }/html", class: 'govuk-link' %></dd>
             <% end %>
           </dl>
         </div>

--- a/app/views/datasets/_contact.html.erb
+++ b/app/views/datasets/_contact.html.erb
@@ -52,7 +52,7 @@
         <%= content_tag(:span, foi_mail) if foi_mail.present? %>
         <% if foi_web_address_for(dataset).present? %>
           <%= content_tag(:span) do %>
-            <%= link_to("Freedom of information requests for #{@dataset.organisation.title}", foi_web_address_for(dataset), ga_data) %>
+            <%= link_to("Freedom of information requests for this dataset", foi_web_address_for(dataset), ga_data) %>
           <% end %>
         <% end %>
 

--- a/app/views/datasets/_contact.html.erb
+++ b/app/views/datasets/_contact.html.erb
@@ -1,6 +1,6 @@
 <%
   default_name = "Contanct #{@dataset.organisation.title} regarding this dataset"
-  ga_data = {'data-ga-event': 'contact', 'data-ga-publisher': @dataset.organisation.name}
+  link_attrs = {'data-ga-event': 'contact', 'data-ga-publisher': @dataset.organisation.name, 'class': 'govuk_link'}
 
   if contact_name_for(dataset).present?
     email_name = contact_name_for(dataset)
@@ -15,15 +15,15 @@
   end
 
   if contact_email_is_email?(dataset)
-    mail = mail_to(contact_email_for(dataset), email_name, ga_data, class: 'govuk_link')
+    mail = mail_to(contact_email_for(dataset), email_name, link_attrs)
   else
-    mail = link_to(email_name, contact_email_for(dataset), ga_data, class: 'govuk_link')
+    mail = link_to(email_name, contact_email_for(dataset), link_attrs)
   end
 
   if foi_email_is_email?(dataset)
-    foi_mail = mail_to(foi_email_for(dataset), foi_name, ga_data, class: 'govuk_link')
+    foi_mail = mail_to(foi_email_for(dataset), foi_name, link_attrs)
   else
-    foi_mail = link_to(foi_name, foi_email_for(dataset), ga_data, class: 'govuk_link')
+    foi_mail = link_to(foi_name, foi_email_for(dataset), link_attrs)
   end
 %>
 <section class="contact">
@@ -52,7 +52,7 @@
         <%= content_tag(:span, foi_mail) if foi_mail.present? %>
         <% if foi_web_address_for(dataset).present? %>
           <%= content_tag(:span) do %>
-            <%= link_to("Freedom of information requests for this dataset", foi_web_address_for(dataset), ga_data) %>
+            <%= link_to("Freedom of information requests for this dataset", foi_web_address_for(dataset), link_attrs) %>
           <% end %>
         <% end %>
 

--- a/app/views/datasets/_contact.html.erb
+++ b/app/views/datasets/_contact.html.erb
@@ -1,5 +1,5 @@
 <%
-  default_name = "Contanct #{@dataset.organisation.title} regarding this dataset"
+  default_name = "Contact #{@dataset.organisation.title} regarding this dataset"
   link_attrs = {'data-ga-event': 'contact', 'data-ga-publisher': @dataset.organisation.name, 'class': 'govuk_link'}
 
   if contact_name_for(dataset).present?

--- a/app/views/datasets/_contact.html.erb
+++ b/app/views/datasets/_contact.html.erb
@@ -1,6 +1,6 @@
 <%
   default_name = "Contact #{@dataset.organisation.title} regarding this dataset"
-  link_attrs = {'data-ga-event': 'contact', 'data-ga-publisher': @dataset.organisation.name, 'class': 'govuk_link'}
+  link_attrs = {'data-ga-event': 'contact', 'data-ga-publisher': @dataset.organisation.name, 'class': 'govuk-link'}
 
   email_name = contact_name_for(dataset).presence || default_name
   foi_name = foi_name_for(dataset).presence || default_name

--- a/app/views/datasets/_contact.html.erb
+++ b/app/views/datasets/_contact.html.erb
@@ -2,8 +2,8 @@
   default_name = "Contact #{@dataset.organisation.title} regarding this dataset"
   link_attrs = {'data-ga-event': 'contact', 'data-ga-publisher': @dataset.organisation.name, 'class': 'govuk_link'}
 
-  email_name = contact_name_for(dataset).present? ? contact_name_for(dataset) : default_name
-  foi_name = foi_name_for(dataset).present? ? foi_name_for(dataset) : default_name
+  email_name = contact_name_for(dataset).presence || default_name
+  foi_name = foi_name_for(dataset).presence || default_name
   mail = contact_email_is_email?(dataset) ? mail_to(contact_email_for(dataset), email_name, link_attrs) : link_to(email_name, contact_email_for(dataset), link_attrs)
   foi_mail = foi_email_is_email?(dataset) ? mail_to(foi_email_for(dataset), foi_name, link_attrs) : link_to(foi_name, foi_email_for(dataset), link_attrs)
 %>

--- a/app/views/datasets/_contact.html.erb
+++ b/app/views/datasets/_contact.html.erb
@@ -1,8 +1,29 @@
 <%
-  if contact_email_is_email?(dataset)
-    mail = mail_to(contact_email_for(dataset), nil, {'data-ga-event': 'contact', 'data-ga-publisher': @dataset.organisation.name, class: 'govuk_link'})
+  default_name = "Contanct #{@dataset.organisation.title} regarding this dataset"
+  ga_data = {'data-ga-event': 'contact', 'data-ga-publisher': @dataset.organisation.name}
+
+  if contact_name_for(dataset).present?
+    email_name = contact_name_for(dataset)
   else
-    mail = link_to(contact_email_for(dataset), contact_email_for(dataset), {'data-ga-event': 'contact', 'data-ga-publisher': @dataset.organisation.name, class: 'govuk_link'})
+    email_name = default_name
+  end
+
+  if foi_name_for(dataset).present?
+    foi_name = foi_name_for(dataset)
+  else
+    foi_name = default_name
+  end
+
+  if contact_email_is_email?(dataset)
+    mail = mail_to(contact_email_for(dataset), email_name, ga_data, class: 'govuk_link')
+  else
+    mail = link_to(email_name, contact_email_for(dataset), ga_data, class: 'govuk_link')
+  end
+
+  if foi_email_is_email?(dataset)
+    foi_mail = mail_to(foi_email_for(dataset), foi_name, ga_data, class: 'govuk_link')
+  else
+    foi_mail = link_to(foi_name, foi_email_for(dataset), ga_data, class: 'govuk_link')
   end
 %>
 <section class="contact">
@@ -16,7 +37,6 @@
         <%= t('datasets.contact.enquiries') %>
       </h3>
       <p>
-        <%= content_tag(:span, contact_name_for(dataset)) if contact_name_for(dataset).present? %>
         <%= content_tag(:span, mail) if mail.present? %>
       </p>
     </div>
@@ -29,11 +49,10 @@
       </h3>
 
       <p>
-        <%= content_tag(:span, foi_name_for(dataset)) if foi_name_for(dataset).present? %>
-        <%= content_tag(:span, mail_to(foi_email_for(dataset), nil, {class: 'ga-contact'})) if foi_email_for(dataset).present? %>
+        <%= content_tag(:span, foi_mail) if foi_mail.present? %>
         <% if foi_web_address_for(dataset).present? %>
           <%= content_tag(:span) do %>
-            <%= link_to(foi_web_address_for(dataset), foi_web_address_for(dataset), { class: 'ga-contact'} ) %>
+            <%= link_to("Freedom of information requests for #{@dataset.organisation.title}", foi_web_address_for(dataset), ga_data) %>
           <% end %>
         <% end %>
 

--- a/app/views/datasets/_contact.html.erb
+++ b/app/views/datasets/_contact.html.erb
@@ -2,29 +2,10 @@
   default_name = "Contact #{@dataset.organisation.title} regarding this dataset"
   link_attrs = {'data-ga-event': 'contact', 'data-ga-publisher': @dataset.organisation.name, 'class': 'govuk_link'}
 
-  if contact_name_for(dataset).present?
-    email_name = contact_name_for(dataset)
-  else
-    email_name = default_name
-  end
-
-  if foi_name_for(dataset).present?
-    foi_name = foi_name_for(dataset)
-  else
-    foi_name = default_name
-  end
-
-  if contact_email_is_email?(dataset)
-    mail = mail_to(contact_email_for(dataset), email_name, link_attrs)
-  else
-    mail = link_to(email_name, contact_email_for(dataset), link_attrs)
-  end
-
-  if foi_email_is_email?(dataset)
-    foi_mail = mail_to(foi_email_for(dataset), foi_name, link_attrs)
-  else
-    foi_mail = link_to(foi_name, foi_email_for(dataset), link_attrs)
-  end
+  email_name = contact_name_for(dataset).present? ? contact_name_for(dataset) : default_name
+  foi_name = foi_name_for(dataset).present? ? foi_name_for(dataset) : default_name
+  mail = contact_email_is_email?(dataset) ? mail_to(contact_email_for(dataset), email_name, link_attrs) : link_to(email_name, contact_email_for(dataset), link_attrs)
+  foi_mail = foi_email_is_email?(dataset) ? mail_to(foi_email_for(dataset), foi_name, link_attrs) : link_to(foi_name, foi_email_for(dataset), link_attrs)
 %>
 <section class="contact">
   <h2 class="heading-medium">

--- a/app/views/datasets/_contact.html.erb
+++ b/app/views/datasets/_contact.html.erb
@@ -1,9 +1,9 @@
 <%
-  default_name = "Contact #{@dataset.organisation.title} regarding this dataset"
+  default_message = t('datasets.contact.default_message', title: @dataset.organisation.title)
   link_attrs = {'data-ga-event': 'contact', 'data-ga-publisher': @dataset.organisation.name, 'class': 'govuk-link'}
 
-  email_name = contact_name_for(dataset).presence || default_name
-  foi_name = foi_name_for(dataset).presence || default_name
+  email_name = contact_name_for(dataset).presence || default_message
+  foi_name = foi_name_for(dataset).presence || default_message
   mail = contact_email_is_email?(dataset) ? mail_to(contact_email_for(dataset), email_name, link_attrs) : link_to(email_name, contact_email_for(dataset), link_attrs)
   foi_mail = foi_email_is_email?(dataset) ? mail_to(foi_email_for(dataset), foi_name, link_attrs) : link_to(foi_name, foi_email_for(dataset), link_attrs)
 %>
@@ -33,7 +33,7 @@
         <%= content_tag(:span, foi_mail) if foi_mail.present? %>
         <% if foi_web_address_for(dataset).present? %>
           <%= content_tag(:span) do %>
-            <%= link_to("Freedom of information requests for this dataset", foi_web_address_for(dataset), link_attrs) %>
+            <%= link_to(t('datasets.contact.foi_message'), foi_web_address_for(dataset), link_attrs) %>
           <% end %>
         <% end %>
 

--- a/app/views/datasets/_no_datafiles.html.erb
+++ b/app/views/datasets/_no_datafiles.html.erb
@@ -4,7 +4,7 @@
     <%= t('datasets.show.contact_the_publisher') %>
   <% else %>
     <%= t('datasets.show.contact_the_team') %>
-    <%= link_to 'data.gov.uk/support', support_path, class: 'govuk_link' %>
+    <%= link_to 'data.gov.uk/support', support_path, class: 'govuk-link' %>
     <%= t('datasets.show.if_you_have_questions') %>
   <% end %>
 </div>

--- a/config/locales/views/datasets/en.yml
+++ b/config/locales/views/datasets/en.yml
@@ -31,8 +31,10 @@ en:
       search: "Search"
     contact:
       contact: "Contact"
+      default_message: "Contact %{title} regarding this dataset"
       enquiries: "Enquiries"
       foi_requests: "Freedom of Information (FOI) requests"
+      foi_message: "Freedom of information requests for this dataset"
     datafile_table:
       link_to_data: "Link to the data"
       format: "Format"

--- a/spec/features/dataset_show_page_spec.rb
+++ b/spec/features/dataset_show_page_spec.rb
@@ -272,7 +272,7 @@ RSpec.feature "Dataset page", type: :feature, elasticsearch: true do
       expect(page).to have_css("h3", text: "Enquiries")
 
       within("section.contact .enquiries") do
-        expect(page).to have_link(dataset.contact_name, href: dataset.contact_email)
+        expect(page).to have_link(dataset.contact_name, href: "mailto:#{dataset.contact_email}")
       end
     end
 
@@ -287,7 +287,7 @@ RSpec.feature "Dataset page", type: :feature, elasticsearch: true do
       expect(page).to have_css("h3", text: "Enquiries")
 
       within("section.contact .enquiries") do
-        expect(page).to have_link(dataset.organisation.contact_name, href: dataset.organisation.contact_email)
+        expect(page).to have_link(dataset.organisation.contact_name, href: "mailto:#{dataset.organisation.contact_email}")
       end
     end
   end
@@ -309,7 +309,7 @@ RSpec.feature "Dataset page", type: :feature, elasticsearch: true do
       expect(page).to have_css("h3", text: "Freedom of Information (FOI) requests")
 
       within("section.contact .foi") do
-        expect(page).to have_link(dataset.foi_name, href: dataset.foi_email)
+        expect(page).to have_link(dataset.foi_name, href: "mailto:#{dataset.foi_email}")
         expect(page).to have_link("Freedom of information requests for this dataset", href: dataset.foi_web)
       end
     end
@@ -326,7 +326,7 @@ RSpec.feature "Dataset page", type: :feature, elasticsearch: true do
       expect(page).to have_css("h3", text: "Freedom of Information (FOI) requests")
 
       within("section.contact .foi") do
-        expect(page).to have_link(dataset.organisation.foi_name, href: dataset.organisation.foi_email)
+        expect(page).to have_link(dataset.organisation.foi_name, href: "mailto:#{dataset.organisation.foi_email}")
         expect(page).to have_link("Freedom of information requests for this dataset", href: dataset.organisation.foi_web)
       end
     end

--- a/spec/features/dataset_show_page_spec.rb
+++ b/spec/features/dataset_show_page_spec.rb
@@ -272,8 +272,7 @@ RSpec.feature "Dataset page", type: :feature, elasticsearch: true do
       expect(page).to have_css("h3", text: "Enquiries")
 
       within("section.contact .enquiries") do
-        expect(page).to have_link(dataset.contact_email)
-        expect(page).to have_content(dataset.contact_name)
+        expect(page).to have_link(dataset.contact_name, href: dataset.contact_email)
       end
     end
 
@@ -288,8 +287,7 @@ RSpec.feature "Dataset page", type: :feature, elasticsearch: true do
       expect(page).to have_css("h3", text: "Enquiries")
 
       within("section.contact .enquiries") do
-        expect(page).to have_link(dataset.organisation.contact_email)
-        expect(page).to have_content(dataset.organisation.contact_name)
+        expect(page).to have_link(dataset.organisation.contact_name, href: dataset.organisation.contact_email)
       end
     end
   end
@@ -311,9 +309,8 @@ RSpec.feature "Dataset page", type: :feature, elasticsearch: true do
       expect(page).to have_css("h3", text: "Freedom of Information (FOI) requests")
 
       within("section.contact .foi") do
-        expect(page).to have_content(dataset.foi_name)
-        expect(page).to have_content(dataset.foi_email)
-        expect(page).to have_link(dataset.foi_web, href: dataset.foi_web)
+        expect(page).to have_link(dataset.foi_name, href: dataset.foi_email)
+        expect(page).to have_link("Freedom of information requests for this dataset", href: dataset.foi_web)
       end
     end
 
@@ -329,11 +326,8 @@ RSpec.feature "Dataset page", type: :feature, elasticsearch: true do
       expect(page).to have_css("h3", text: "Freedom of Information (FOI) requests")
 
       within("section.contact .foi") do
-        expect(page).to have_content(dataset.organisation.foi_name)
-        expect(page).to have_content(dataset.organisation.foi_email)
-
-        expect(page).to have_link(dataset.organisation.foi_web,
-                                  href: dataset.organisation.foi_web)
+        expect(page).to have_link(dataset.organisation.foi_name, href: dataset.organisation.foi_email)
+        expect(page).to have_link("Freedom of information requests for this dataset", href: dataset.organisation.foi_web)
       end
     end
   end

--- a/spec/helpers/datasets_helper_spec.rb
+++ b/spec/helpers/datasets_helper_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe DatasetsHelper do
   end
 
   describe "#contact_email_is_email?" do
-    it "returns true when the email is valid" do
+    it "returns true when email string is 'valid' (contains '@')" do
       dataset = build :dataset, contact_email: "foo@bar.com"
       expect(helper.contact_email_is_email?(dataset)).to be_truthy
     end
@@ -24,7 +24,7 @@ RSpec.describe DatasetsHelper do
   end
 
   describe "#foi_email_is_email?" do
-    it "returns true when the email is valid" do
+    it "returns true when email string is 'valid' (contains '@')" do
       dataset = build :dataset, foi_email: "foo@bar.com"
       expect(helper.foi_email_is_email?(dataset)).to be_truthy
     end

--- a/spec/helpers/datasets_helper_spec.rb
+++ b/spec/helpers/datasets_helper_spec.rb
@@ -22,4 +22,16 @@ RSpec.describe DatasetsHelper do
       expect(helper.contact_email_is_email?(dataset)).to be_falsey
     end
   end
+
+  describe "#foi_email_is_email?" do
+    it "returns true when the email is valid" do
+      dataset = build :dataset, foi_email: "foo@bar.com"
+      expect(helper.foi_email_is_email?(dataset)).to be_truthy
+    end
+
+    it "returns false when the email is invalid" do
+      dataset = build :dataset, foi_email: "http://foo.com"
+      expect(helper.foi_email_is_email?(dataset)).to be_falsey
+    end
+  end
 end


### PR DESCRIPTION
## What
Amends the setup for dataset contact details so that links are no longer rendered in their literal form but use either the specified text for that contact detail or a generic label. Additionally, this adds the `foi_email_is_email` helper and tidies up the contact partial.

## Why
This is to comply with WCAG regulations around descriptive links, specifically in relation to a previous violation following a DAC audit. See page 28 https://drive.google.com/file/d/1r32grtcw7PFNbJnMsXFCM8EPX_GaD753/view

## Testing

On data.gov.uk dataset view ([example](https://data.gov.uk/dataset/115cb6bc-e29e-4a94-95f5-8461db105b20/mortality-target-monitoring)), contacts set for that dataset will now render as a link to the specified email with the link text being the name of the contact

### Before
<img width="970" alt="Screenshot 2020-07-03 at 09 39 06" src="https://user-images.githubusercontent.com/64783893/86450858-0fc74500-bd12-11ea-9e3f-cf8a7fe3db8e.png">

### After
<img width="1038" alt="Screenshot 2020-07-03 at 09 38 24" src="https://user-images.githubusercontent.com/64783893/86451014-3a190280-bd12-11ea-82a3-0df84e26558a.png">


**Card:** https://trello.com/c/fMi12rao/187-no-descriptive-link-text-on-some-links-low