### PR TITLE
Remove accessible autocomplete from search filters

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,7 +14,6 @@
 //= require cookie-settings
 //= require analytics
 //= require govuk_toolkit
-//= require accessible-autocomplete/dist/accessible-autocomplete.min
 //= require govuk_publishing_components/all_components
 //= require_tree ./organograms/lib
 //= require_tree ./organograms

--- a/app/assets/javascripts/govuk.js
+++ b/app/assets/javascripts/govuk.js
@@ -15,30 +15,6 @@ $(document).ready(function () {
   var showHide = new ShowHide()
   showHide.init()
 
-  if (document.getElementById('publisher')) {
-    accessibleAutocomplete.enhanceSelectElement({
-      selectElement: document.querySelector('#publisher'),
-      showAllValues: true,
-      preserveNullOptions: true
-    })
-  }
-
-  if (document.getElementById('format')) {
-    accessibleAutocomplete.enhanceSelectElement({
-      selectElement: document.querySelector('#format'),
-      showAllValues: true,
-      preserveNullOptions: true
-    })
-  }
-
-  if(document.getElementById('topic')) {
-    accessibleAutocomplete.enhanceSelectElement({
-      selectElement: document.querySelector('#topic'),
-      showAllValues: true,
-      preserveNullOptions: true
-    })
-  }
-
   new FoldableText('.js-summary', 200)
     .init()
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -61,5 +61,4 @@ $alpine-fresh: #128400;
 @import 'cookie-settings';
 @import 'govuk-overrides';
 @import 'components';
-@import 'accessible-autocomplete/dist/accessible-autocomplete.min';
 @import 'organograms';

--- a/app/assets/stylesheets/govuk-overrides.scss
+++ b/app/assets/stylesheets/govuk-overrides.scss
@@ -85,19 +85,6 @@ button.button.secondary {
   padding: .8em 0 0 0;
 }
 
-
-.autocomplete__dropdown-arrow-down {
-  z-index: 1 !important;
-}
-
-.autocomplete__input {
-  z-index: 2;
-}
-
-.autocomplete__option {
-  min-height: 1.31579em;
-}
-
 .breadcrumbs li {
   background-image: image-url("separator.png");
 }

--- a/app/views/search/_filters.html.erb
+++ b/app/views/search/_filters.html.erb
@@ -2,17 +2,17 @@
 
 <div class="form-group">
   <%= label_tag 'publisher', t('.filter_by_publisher'), class: 'form-label' %>
-  <%= select_tag('filters[publisher]', options_for_select(dataset_publishers_for_select, selected_publisher), id: 'publisher', class: 'form-control dgu-filters__filter', include_blank: true) %>
+  <%= select_tag('filters[publisher]', options_for_select(dataset_publishers_for_select, selected_publisher), id: 'publisher', class: 'form-control dgu-filters__filter', include_blank: t('.all_publishers')) %>
 </div>
 
 <div class="form-group">
   <%= label_tag 'topic', t('.filter_by_topic'), class: 'form-label' %>
-  <%= select_tag('filters[topic]', options_for_select(dataset_topics_for_select, selected_topic), id: 'topic', class: 'form-control dgu-filters__filter', include_blank: true) %>
+  <%= select_tag('filters[topic]', options_for_select(dataset_topics_for_select, selected_topic), id: 'topic', class: 'form-control dgu-filters__filter', include_blank: t('.all_topics')) %>
 </div>
 
 <div class="form-group">
   <%= label_tag 'format', t('.filter_by_format'), class: 'form-label' %>
-  <%= select_tag('filters[format]', options_for_select(datafile_formats_for_select, selected_format), id: 'format', class: 'form-control dgu-filters__filter', include_blank: true) %>
+  <%= select_tag('filters[format]', options_for_select(datafile_formats_for_select, selected_format), id: 'format', class: 'form-control dgu-filters__filter', include_blank: t('.all_formats')) %>
 </div>
 
 <div class="form-group">

--- a/config/locales/views/search/en.yml
+++ b/config/locales/views/search/en.yml
@@ -29,6 +29,9 @@ en:
       filter_by_format: "Format"
       filter_by_topic: "Topic"
       filter_by_publisher: "Publisher"
+      all_formats: "All formats"
+      all_topics: "All topics"
+      all_publishers: "All publishers"
       filter_by_ogl: "Open Government Licence (OGL) only"
       accessibility:
         submit_button: "Apply filters"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,5 @@
 {
   "name": "datagovuk_find",
   "license": "UNLICENSED",
-  "dependencies": {
-    "accessible-autocomplete": "^2.0.2"
-  }
+  "dependencies": {}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,14 +2,3 @@
 # yarn lockfile v1
 
 
-accessible-autocomplete@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/accessible-autocomplete/-/accessible-autocomplete-2.0.2.tgz#869d6b3b80a31e21614076b0ce47999f6b1802c8"
-  integrity sha512-cdA4O4u1xmefZuAdtL+0VBnDivdapgIZRQjm0E1bcekHnH5h67Vt1QL79NqPtlAn+6lyrR+H+pbnYVvUOJ1ULQ==
-  dependencies:
-    preact "^8.3.1"
-
-preact@^8.3.1:
-  version "8.4.2"
-  resolved "https://registry.yarnpkg.com/preact/-/preact-8.4.2.tgz#1263b974a17d1ea80b66590e41ef786ced5d6a23"
-  integrity sha512-TsINETWiisfB6RTk0wh3/mvxbGRvx+ljeBccZ4Z6MPFKgu/KFGyf2Bmw3Z/jlXhL5JlNKY6QAbA9PVyzIy9//A==


### PR DESCRIPTION
## What
Removes the accessible autocomplete library, resulting in the search filters component now using standard select elements.

## Why
This is an attempt to fix the issues present on pages 14 to 17 of (this DAC audit)[https://drive.google.com/file/d/1r32grtcw7PFNbJnMsXFCM8EPX_GaD753/view]. The accessible autocomplete in its current state seems to be a significant contributor to these issues and removing it appears to make a difference to user experience following some shallow testing. _I strongly recommend re-auditing data.gov.uk following this accessibility work_ to make a more concrete assessment that this problem has been fixed.

**Card:** https://trello.com/c/SAqUen97/183-define-purpose-of-dgu-search-filters-high