### PR TITLE
Add link class

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -131,6 +131,10 @@
     float:right;
     word-spacing: 6px;
   }
+
+  a:focus {
+    @include govuk-focused-text;
+  }
 }
 
 // sorting controls ============================================================

--- a/app/views/datasets/_additional_info.html.erb
+++ b/app/views/datasets/_additional_info.html.erb
@@ -72,9 +72,9 @@
             <% if i['harvest_object_id'] %>
               <dt><%= t('.inspire_gemini_record') %></dt>
               <dd>
-                <%= link_to t('.xml'), "/api/2/rest/harvestobject/#{ i['harvest_object_id'] }/xml" %>
+                <%= link_to t('.xml'), "/api/2/rest/harvestobject/#{ i['harvest_object_id'] }/xml", class: 'govuk_link' %>
                 <br />
-                <%= link_to t('.html'), "/api/2/rest/harvestobject/#{ i['harvest_object_id'] }/html" %>
+                <%= link_to t('.html'), "/api/2/rest/harvestobject/#{ i['harvest_object_id'] }/html", class: 'govuk_link' %>
               </dd>
             <% end %>
           </dl>

--- a/app/views/datasets/_breadcrumb.html.erb
+++ b/app/views/datasets/_breadcrumb.html.erb
@@ -6,13 +6,13 @@
         <nav aria-label="Breadcrumb">
           <ol>
             <li>
-              <%= link_to t('.home'), root_path %>
+              <%= link_to t('.home'), root_path, class: 'govuk-link' %>
             </li>
             <li>
               <% if @referer_query.nil? %>
                 <%= @dataset.organisation.title %>
               <% else %>
-                <%= link_to t('.search'), "/search?#{@referrer}" %>
+                <%= link_to t('.search'), "/search?#{@referrer}", class: 'govuk-link' %>
               <% end %>
             </li>
             <li aria-current="page">

--- a/app/views/datasets/_contact.html.erb
+++ b/app/views/datasets/_contact.html.erb
@@ -1,8 +1,8 @@
 <%
   if contact_email_is_email?(dataset)
-    mail = mail_to(contact_email_for(dataset), nil, {'data-ga-event': 'contact', 'data-ga-publisher': @dataset.organisation.name})
+    mail = mail_to(contact_email_for(dataset), nil, {'data-ga-event': 'contact', 'data-ga-publisher': @dataset.organisation.name, class: 'govuk_link'})
   else
-    mail = link_to(contact_email_for(dataset), contact_email_for(dataset), {'data-ga-event': 'contact', 'data-ga-publisher': @dataset.organisation.name})
+    mail = link_to(contact_email_for(dataset), contact_email_for(dataset), {'data-ga-event': 'contact', 'data-ga-publisher': @dataset.organisation.name, class: 'govuk_link'})
   end
 %>
 <section class="contact">

--- a/app/views/datasets/_datafile_table.html.erb
+++ b/app/views/datasets/_datafile_table.html.erb
@@ -14,7 +14,8 @@
                 'ga-event' => "download",
                 'ga-format' => "CSV",
                 'ga-publisher' => @dataset.organisation.name
-              } do %>
+              },
+              class: 'govuk-link' do %>
             <span class="visually-hidden">Download </span>
             <%= (datafile.name ? datafile.name : 'Data') %>
             <span class='visually-hidden'>, Format: <%= format_of(datafile) %>, Dataset: <%= @dataset.title %></span>
@@ -43,7 +44,8 @@
                   'ga-event' => 'preview',
                   'ga-format' => (datafile.format.presence || 'n/a').upcase,
                   'ga-publisher' => @dataset.organisation.name
-                  } do %>
+                  },
+                  class: 'govuk-link' do %>
                   Preview
                   <span class='visually-hidden'> CSV '<%= datafile.name %>', Dataset: <%= @dataset.title %></span>
                   <% end %>

--- a/app/views/datasets/_meta_data.html.erb
+++ b/app/views/datasets/_meta_data.html.erb
@@ -50,7 +50,8 @@
             <% if @dataset.licence_url.present? %>
               <%= link_to @dataset.licence_title,
                           @dataset.licence_url,
-                          rel: 'dc:rights' %>
+                          rel: 'dc:rights',
+                          class: 'govuk-link' %>
             <% elsif @dataset.licence_title.present? %>
               <%= @dataset.licence_title %>
             <% elsif @dataset.licence_custom.present? %>
@@ -62,7 +63,8 @@
             <% if @dataset.licence_custom.present? %>
               <br>
               <%= link_to t('.view_licence_information'),
-                            '#licence-info' %>
+                            '#licence-info',
+                            class: 'govuk-link' %>
             <% end %>
           </dd>
         </dl>
@@ -79,7 +81,7 @@
     <div class="column-one-third dgu-dataset-right">
       <div class="dgu-dataset-right__sidebar__publisher_datasets">
         <h3 class="heading-small"><%= t('.publisher_datasets') %></h3>
-        <%= link_to search_path(filters: { publisher: @dataset.organisation.title }) do %>
+        <%= link_to search_path(filters: { publisher: @dataset.organisation.title }), class: 'govuk-link' do %>
           <%= "All datasets from #{@dataset.organisation.title}" %>
         <% end %>
       </div>
@@ -90,7 +92,7 @@
           <ul>
             <% @related_datasets.each do |dataset| %>
               <li>
-                <%= link_to unescape(dataset.title), dataset_path(dataset.uuid, dataset.name) %>
+                <%= link_to unescape(dataset.title), dataset_path(dataset.uuid, dataset.name), class: 'govuk-link' %>
               </li>
             <% end %>
           </ul>

--- a/app/views/datasets/_no_datafiles.html.erb
+++ b/app/views/datasets/_no_datafiles.html.erb
@@ -4,7 +4,7 @@
     <%= t('datasets.show.contact_the_publisher') %>
   <% else %>
     <%= t('datasets.show.contact_the_team') %>
-    <%= link_to 'data.gov.uk/support', support_path %>
+    <%= link_to 'data.gov.uk/support', support_path, class: 'govuk_link' %>
     <%= t('datasets.show.if_you_have_questions') %>
   <% end %>
 </div>

--- a/app/views/datasets/_supporting_docs.html.erb
+++ b/app/views/datasets/_supporting_docs.html.erb
@@ -15,7 +15,7 @@
     <% dataset.docs.each do |doc| %>
       <tr>
         <td class="title">
-          <a href="<%= doc.url%>"><%= doc.name %></a>
+          <a href="<%= doc.url%>" class="govuk-link"><%= doc.name %></a>
         </td>
         <td><%= doc.format or "N/A" %></td>
         <td><%= format_timestamp(doc.created_at) or "N/A" %></td>

--- a/app/views/datasets/show.html.erb
+++ b/app/views/datasets/show.html.erb
@@ -75,7 +75,7 @@
             <div role="note" aria-label="Publisher information" class="panel panel-border-narrow text">
               <p><%= t('datasets.publishers.information') %></p>
             </div>
-            <p><%= link_to t('datasets.publishers.button'), "/dataset/edit/#{@dataset.legacy_name}", role: 'button', class: 'button', rel: %w(nofollow) %></p>
+            <p><%= link_to t('datasets.publishers.button'), "/dataset/edit/#{@dataset.legacy_name}", role: 'button', class: 'govuk-button', rel: %w(nofollow) %></p>
           </div>
         </div>
       </section>

--- a/app/views/errors/not_found.en.html.erb
+++ b/app/views/errors/not_found.en.html.erb
@@ -5,7 +5,7 @@
     <div class="column-two-thirds">
       <h1 class="heading-large">Page not found</h1>
       <p>If you entered a web address please check it was correct.</p>
-      <p>You can <%= link_to 'search or browse from the homepage', root_path %> to find the information you need.</p>
+      <p>You can <%= link_to 'search or browse from the homepage', root_path, class: 'govuk-link' %> to find the information you need.</p>
     </div>
   </div>
 </main>

--- a/app/views/layouts/_feedback_survey_banner.html.erb
+++ b/app/views/layouts/_feedback_survey_banner.html.erb
@@ -1,7 +1,7 @@
 <div id="dgu-phase-banner" class="phase-banner">
   <p>
     <strong class="phase-tag">BETA</strong>
-    <span><%= t(".beta_survey_message_html", :href => link_to(t('.href'), t('.survey_url')))%>
+    <span><%= t(".beta_survey_message_html", :href => link_to(t('.href'), t('.survey_url'), class: 'govuk-link'))%>
     </span>
   </p>
 </div>

--- a/app/views/layouts/_proposition_header.html.erb
+++ b/app/views/layouts/_proposition_header.html.erb
@@ -3,9 +3,9 @@
     <a href="#proposition-links" class="js-header-toggle menu"><%= t('.menu') %></a>
     <nav id="proposition-menu">
       <ul id="proposition-links">
-        <li><%= link_to t('.publishers'), publishers_path %></li>
-        <li><a href='https://guidance.data.gov.uk/publish_and_manage_data/'>Documentation</a></li>
-        <li><%= link_to t('.support'), support_path %></li>
+        <li><%= link_to t('.publishers'), publishers_path, class: 'govuk-link' %></li>
+        <li><a href='https://guidance.data.gov.uk/publish_and_manage_data/' , class="govuk-link">Documentation</a></li>
+        <li><%= link_to t('.support'), support_path, class: 'govuk-link' %></li>
       </ul>
     </nav>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -37,7 +37,7 @@
       <div class="header-wrapper">
         <div class="header-global">
           <div class="header-logo">
-            <a href="<%= root_path %>" id="logo" class="content">
+            <a href="<%= root_path %>" id="logo" class="content govuk-link">
               <%= t('.data_gov_uk')%> | <%= t('.find_open_data') %>
             </a>
           </div>
@@ -63,13 +63,13 @@
           <div class="footer-meta">
             <div class="footer-meta-inner">
               <ul>
-                <li><%= link_to 'About', about_path %></li>
-                <li><%= link_to 'Accessibility', accessibility_path %></li>
-                <li><%= link_to 'Cookies', cookies_path %></li>
-                <li><%= link_to 'Privacy', privacy_path %></li>
-                <li><%= link_to 'Terms and conditions', terms_path %></li>
-                <li><%= link_to 'Support', support_path %></li>
-                <li>Built by the <%= link_to 'Government Digital Service', 'https://www.gov.uk/government/organisations/government-digital-service' %></li>
+                <li><%= link_to 'About', about_path, class: 'govuk-link' %></li>
+                <li><%= link_to 'Accessibility', accessibility_path, class: 'govuk-link' %></li>
+                <li><%= link_to 'Cookies', cookies_path, class: 'govuk-link' %></li>
+                <li><%= link_to 'Privacy', privacy_path, class: 'govuk-link' %></li>
+                <li><%= link_to 'Terms and conditions', terms_path, class: 'govuk-link' %></li>
+                <li><%= link_to 'Support', support_path, class: 'govuk-link' %></li>
+                <li>Built by the <%= link_to 'Government Digital Service', 'https://www.gov.uk/government/organisations/government-digital-service', class: 'govuk-link' %></li>
               </ul>
               <div class="open-government-licence">
                 <p class="logo">

--- a/app/views/map_previews/show.html.erb
+++ b/app/views/map_previews/show.html.erb
@@ -26,7 +26,7 @@
 <% end %>
 
 <%= content_for :breadcrumb do %>
-  <%= link_to 'Back', :back, class: 'dgu-back-link' %>
+  <%= link_to 'Back', :back, class: 'dgu-back-link govuk-link' %>
 <% end %>
 
 <main role="main" id="content">

--- a/app/views/pages/_topics.html.erb
+++ b/app/views/pages/_topics.html.erb
@@ -3,19 +3,19 @@
     <div>
       <ol>
         <li>
-          <h2><%= link_to t('.business_and_economy_label'), search_path(filters: { topic: 'Business and economy' })  %></h2>
+          <h2><%= link_to t('.business_and_economy_label'), search_path(filters: { topic: 'Business and economy' }), class: 'govuk-link' %></h2>
           <p><%= t('.business_and_economy_description') %></p>
         </li>
         <li>
-          <h2><%= link_to t('.crime_and_justice_label'), search_path(filters: { topic: 'Crime and justice' }) %></h2>
+          <h2><%= link_to t('.crime_and_justice_label'), search_path(filters: { topic: 'Crime and justice' }), class: 'govuk-link' %></h2>
           <p><%= t('.crime_and_justice_description') %></p>
         </li>
         <li>
-          <h2><%= link_to t('.defence_label'), search_path(filters: { topic: 'Defence' }) %></h2>
+          <h2><%= link_to t('.defence_label'), search_path(filters: { topic: 'Defence' }), class: 'govuk-link' %></h2>
           <p><%= t('.defence_description') %></p>
         </li>
         <li>
-          <h2><%= link_to t('.education_label'), search_path(filters: { topic: 'Education' }) %></h2>
+          <h2><%= link_to t('.education_label'), search_path(filters: { topic: 'Education' }), class: 'govuk-link' %></h2>
           <p><%= t('.education_description') %></p>
         </li>
       </ol>
@@ -26,19 +26,19 @@
     <div>
       <ol>
         <li>
-          <h2><%= link_to t('.environment_label'), search_path(filters: { topic: 'Environment' }) %></h2>
+          <h2><%= link_to t('.environment_label'), search_path(filters: { topic: 'Environment' }), class: 'govuk-link' %></h2>
           <p><%= t('.environment_description') %></p>
         </li>
         <li>
-          <h2><%= link_to t('.government_label'), search_path(filters: { topic: 'Government' }) %></h2>
+          <h2><%= link_to t('.government_label'), search_path(filters: { topic: 'Government' }), class: 'govuk-link' %></h2>
           <p><%= t('.government_description') %></p>
         </li>
         <li>
-          <h2><%= link_to t('.government_spending_label'), search_path(filters: { topic: 'Government spending' }) %></h2>
+          <h2><%= link_to t('.government_spending_label'), search_path(filters: { topic: 'Government spending' }), class: 'govuk-link' %></h2>
           <p><%= t('.government_spending_description') %></p>
         </li>
         <li>
-          <h2><%= link_to t('.health_label'), search_path(filters: { topic: 'Health' }) %></h2>
+          <h2><%= link_to t('.health_label'), search_path(filters: { topic: 'Health' }), class: 'govuk-link' %></h2>
           <p><%= t('.health_description') %></p>
         </li>
       </ol>
@@ -48,19 +48,19 @@
     <div>
       <ol>
         <li>
-          <h2><%= link_to t('.mapping_label'), search_path(filters: { topic: 'Mapping' }) %></h2>
+          <h2><%= link_to t('.mapping_label'), search_path(filters: { topic: 'Mapping' }), class: 'govuk-link' %></h2>
           <p><%= t('.mapping_description') %></p>
         </li>
         <li>
-          <h2><%= link_to t('.society_label'), search_path(filters: { topic: 'Society' }) %></h2>
+          <h2><%= link_to t('.society_label'), search_path(filters: { topic: 'Society' }), class: 'govuk-link' %></h2>
           <p><%= t('.society_description') %></p>
         </li>
         <li>
-          <h2><%= link_to t('.towns_and_cities_label'), search_path(filters: { topic: 'Towns and cities' }) %></h2>
+          <h2><%= link_to t('.towns_and_cities_label'), search_path(filters: { topic: 'Towns and cities' }), class: 'govuk-link' %></h2>
           <p><%= t('.towns_and_cities_description') %></p>
         </li>
         <li>
-          <h2><%= link_to t('.transport_label'), search_path(filters: { topic: 'Transport' }) %></h2>
+          <h2><%= link_to t('.transport_label'), search_path(filters: { topic: 'Transport' }), class: 'govuk-link' %></h2>
           <p><%= t('.transport_description') %></p>
         </li>
       </ol>

--- a/app/views/pages/accessibility.html.erb
+++ b/app/views/pages/accessibility.html.erb
@@ -17,11 +17,11 @@
 
     <p>
       Find open data links to several third party sites belonging to other government organisations. We can’t guarantee
-      that these sites meet our <%= link_to 'accessibility requirements', 'https://www.gov.uk/service-manual/helping-people-to-use-your-service' %>.
+      that these sites meet our <%= link_to 'accessibility requirements', 'https://www.gov.uk/service-manual/helping-people-to-use-your-service', class: 'govuk-link' %>.
     </p>
 
     <p>
-      You can read a blog about <%= link_to 'accessibility at GDS', 'https://accessibility.blog.gov.uk/' %>.
+      You can read a blog about <%= link_to 'accessibility at GDS', 'https://accessibility.blog.gov.uk/', class: 'govuk-link' %>.
     </p>
 
     <h2 class="heading-medium">
@@ -58,13 +58,13 @@
     </p>
 
     <ul class="list list-bullet">
-      <li><%= link_to 'make your mouse easier to use', 'https://mcmw.abilitynet.org.uk/making-your-mouse-easier-to-use/', target: :blank %></li>
-      <li><%= link_to 'use your keyboard instead of a mouse', 'https://mcmw.abilitynet.org.uk/category/keyboard-shortcuts/', target: :blank %></li>
-      <li><%= link_to 'talk to your device', 'https://mcmw.abilitynet.org.uk/talking-to-your-device/', target: :blank %></li>
-      <li><%= link_to 'make your device talk to you', 'https://mcmw.abilitynet.org.uk/category/making-your-mobile-or-tablet-talk/', target: :blank %></li>
-      <li><%= link_to 'make text larger', 'https://mcmw.abilitynet.org.uk/making-text-larger/', target: :blank %></li>
-      <li><%= link_to 'change your colours', 'https://mcmw.abilitynet.org.uk/changing-your-colours/', target: :blank %></li>
-      <li><%= link_to 'magnify the screen', 'https://mcmw.abilitynet.org.uk/magnifying-the-screen/', target: :blank %></li>
+      <li><%= link_to 'make your mouse easier to use', 'https://mcmw.abilitynet.org.uk/making-your-mouse-easier-to-use/', target: :blank, class: 'govuk-link' %></li>
+      <li><%= link_to 'use your keyboard instead of a mouse', 'https://mcmw.abilitynet.org.uk/category/keyboard-shortcuts/', target: :blank, class: 'govuk-link' %></li>
+      <li><%= link_to 'talk to your device', 'https://mcmw.abilitynet.org.uk/talking-to-your-device/', target: :blank, class: 'govuk-link' %></li>
+      <li><%= link_to 'make your device talk to you', 'https://mcmw.abilitynet.org.uk/category/making-your-mobile-or-tablet-talk/', target: :blank, class: 'govuk-link' %></li>
+      <li><%= link_to 'make text larger', 'https://mcmw.abilitynet.org.uk/making-text-larger/', target: :blank, class: 'govuk-link' %></li>
+      <li><%= link_to 'change your colours', 'https://mcmw.abilitynet.org.uk/changing-your-colours/', target: :blank, class: 'govuk-link' %></li>
+      <li><%= link_to 'magnify the screen', 'https://mcmw.abilitynet.org.uk/magnifying-the-screen/', target: :blank, class: 'govuk-link' %></li>
     </ul>
 
   </div>

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -16,7 +16,7 @@
 
     <p>
       Find open data is a data service provided by the
-      <%= link_to 'Government Digital Service', 'https://www.gov.uk/government/organisations/government-digital-service' %>
+      <%= link_to 'Government Digital Service', 'https://www.gov.uk/government/organisations/government-digital-service', class: 'govuk-link' %>
       (GDS) which is part of the Cabinet Office. Our job is the digital
       transformation of government.
     </p>
@@ -30,7 +30,7 @@
       The data controller for GDS is the Cabinet Office — a data controller
       determines how and why personal data is processed. For more
       information read the Cabinet Office’s entry in the
-      <%= link_to 'Data Protection Public Register', 'https://ico.org.uk/ESDWebPages/Entry/Z7414053' %>.
+      <%= link_to 'Data Protection Public Register', 'https://ico.org.uk/ESDWebPages/Entry/Z7414053', class: 'govuk-link' %>.
     </p>
 
     <h2 class="heading-medium">
@@ -118,7 +118,7 @@
       To make sure that your data is as safe as possible, we design and
       maintain systems with secure accounts. Your personal data will not be
       transferred outside of
-      the <%= link_to 'European Economic Area (EEA)', 'https://www.gov.uk/eu-eea' %>
+      the <%= link_to 'European Economic Area (EEA)', 'https://www.gov.uk/eu-eea', class: 'govuk-link' %>
       while it’s processed at GDS.
     </p>
 
@@ -193,11 +193,11 @@
       the  GDS Privacy Team if you have any questions or think that
       your personal data has been misused or mishandled.
     </p>
-    
+
     <p>
-      Email: <%= mail_to 'gds-privacy-office@digital.cabinet-office.gov.uk' %>
+      Email: <%= mail_to 'gds-privacy-office@digital.cabinet-office.gov.uk', nil, class: 'govuk-link' %>
     </p>
-    
+
     <p>
       The contact details for our Data Protection Officer are:
     </p>
@@ -205,7 +205,7 @@
     <div class="contact">
       <p>
         Data Protection Officer<br />
-        <%= mail_to 'DPO@cabinetoffice.gov.uk' %><br />
+        <%= mail_to 'DPO@cabinetoffice.gov.uk', nil, class: 'govuk-link' %><br />
         Cabinet Office<br />
         70 Whitehall<br />
         London <br />
@@ -216,17 +216,17 @@
     <p>
       The Data Protection Officer provides independent advice and monitoring of our use of personal information.
     </p>
-    
+
     <p>
       If you have a complaint, you can also contact
-      the <%= link_to 'Information Commissioner', 'https://ico.org.uk/' %>, who
+      the <%= link_to 'Information Commissioner', 'https://ico.org.uk/', class: 'govuk-link' %>, who
       is an independent regulator set up to uphold information rights.
     </p>
 
     <div class="contact">
       <p>
         Information Commissioner’s Office<br />
-        <%= mail_to 'casework@ico.org.uk' %><br />
+        <%= mail_to 'casework@ico.org.uk', nil, class: 'govuk-link' %><br />
         0303 123 1113</br>
         Wycliffe House<br />
         Water Lane<br />

--- a/app/views/pages/publishers.html.erb
+++ b/app/views/pages/publishers.html.erb
@@ -16,7 +16,7 @@
     </p>
 
     <p>
-      <%= link_to 'Sign in', '/user/login', role: 'button', class: 'button', rel: %w(nofollow) %>
+      <%= link_to 'Sign in', '/user/login', role: 'button', class: 'govuk-button', rel: %w(nofollow) %>
     </p>
 
     <div role="note" aria-label="Publisher information" class="panel panel-border-narrow text">
@@ -32,8 +32,8 @@
     </h2>
 
     <p>
-      To get started, take a look at the <%= link_to 'information about publishing datasets', 'https://guidance.data.gov.uk/publish_and_manage_data/', target: '_blank' %>.
-      You can also <%= link_to 'ask us for help', support_path %>.
+      To get started, take a look at the <%= link_to 'information about publishing datasets', 'https://guidance.data.gov.uk/publish_and_manage_data/', target: '_blank', class: 'govuk-link' %>.
+      You can also <%= link_to 'ask us for help', support_path, class: 'govuk-link' %>.
     </p>
   </div>
 </main>

--- a/app/views/pages/site_changes.html.erb
+++ b/app/views/pages/site_changes.html.erb
@@ -68,7 +68,7 @@
     </p>
 
     <p>
-      <a href="http://5stardata.info">The Five Stars of Openness</a> by Tim
+      <a href="http://5stardata.info" class="govuk-link">The Five Stars of Openness</a> by Tim
       Berners-Lee was included on data.gov.uk to help publishers reflect
       information about the quality and format of their open data.
     </p>
@@ -94,7 +94,7 @@
       We found that data users didn’t find the glossary useful, and so it’s been
       archived and removed. Instead we’ve focussed on helping users to find and
       use datasets. We would recommend using the glossary on
-      <a href="http://opendatahandbook.org/glossary">The
+      <a href="http://opendatahandbook.org/glossary" class="govuk-link">The
         Open Data handbook</a>.
     </p>
 
@@ -104,7 +104,7 @@
 
     <p>
       Take a look at the newly-designed
-      data.gov.uk, <%= link_to 'Find open data', root_path %>. We’d love to know
+      data.gov.uk, <%= link_to 'Find open data', root_path, class: 'govuk-link' %>. We’d love to know
       your thoughts. There’s a feedback link at the top of every page.
     </p>
 

--- a/app/views/pages/support.html.erb
+++ b/app/views/pages/support.html.erb
@@ -22,12 +22,12 @@
       </p>
 
       <p>
-        Please give us your feedback about the site using <%= link_to "our survey", "http://www.smartsurvey.co.uk/s/3SEXD/" %>.
+        Please give us your feedback about the site using <%= link_to "our survey", "http://www.smartsurvey.co.uk/s/3SEXD/", class: "govuk-link" %>.
       </p>
 
       <p>
-        To get answers about <%= link_to "GOV.UK", "https://www.gov.uk/" %> you can check the GOV.UK help pages
-        or <%= link_to "contact", "https://www.gov.uk/contact/govuk" %> the team.
+        To get answers about <%= link_to "GOV.UK", "https://www.gov.uk/", class: "govuk-link" %> you can check the GOV.UK help pages
+        or <%= link_to "contact", "https://www.gov.uk/contact/govuk", class: "govuk-link" %> the team.
       </p>
 
       <form action="tickets/new" method="get">
@@ -55,7 +55,7 @@
 
           </fieldset>
         </div>
-        <input class="button" type="submit" value="Continue">
+        <input class="govuk-button" type="submit" value="Continue">
       </form>
 
     </div>

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -17,7 +17,7 @@
     </h2>
 
     <p>
-      Find open data is managed by <%= link_to 'Government Digital Service', 'https://www.gov.uk/government/organisations/government-digital-service' %>
+      Find open data is managed by <%= link_to 'Government Digital Service', 'https://www.gov.uk/government/organisations/government-digital-service', class: 'govuk-link' %>
       (GDS) on behalf of the Crown. GDS is part of the Cabinet Office and will be referred to as 'we' from now on.
     </p>
 
@@ -61,7 +61,7 @@
 
     <p>
       Only publishers with accounts for Find open data can ask for datasets to be deleted.
-      <%= link_to 'Contact us', support_path %> to ask for datasets to be deleted if you are a publisher.
+      <%= link_to 'Contact us', support_path, class: 'govuk-link' %> to ask for datasets to be deleted if you are a publisher.
     </p>
 
     <p>

--- a/app/views/previews/show.html.erb
+++ b/app/views/previews/show.html.erb
@@ -3,7 +3,7 @@
 <main role="main" id="content">
   <div class="grid-row">
     <div class="column-two-thirds">
-      <%= link_to t('.back_link'), dataset_path(@dataset.uuid, @dataset.name), class: 'link-back' %>
+      <%= link_to t('.back_link'), dataset_path(@dataset.uuid, @dataset.name), class: 'link-back govuk-link' %>
       <h1 class="heading-large">
         <%= @dataset.title %>
         <span class="heading-secondary dgu-home-spacer__bottom"><%= @datafile.name %></span>
@@ -12,7 +12,7 @@
       <% if @datafile.csv? && @datafile.preview.exists? %>
         <p>You're previewing the first <%= @datafile.preview.line_count %> rows of this file.</p>
         <%= link_to download_text(@dataset, @datafile), @datafile.url,
-          class: "button",
+          class: "govuk-button",
           data: {
             "ga-event" => "preview-download",
             "ga-format" => "CSV",

--- a/app/views/search/_filters.html.erb
+++ b/app/views/search/_filters.html.erb
@@ -24,9 +24,9 @@
 
 <div class="form-group">
   <div class="dgu-filters__apply-button">
-    <input class="button" type="submit" value="<%= t('.accessibility.submit_button') %>"/>
+    <input class="govuk-button" type="submit" value="<%= t('.accessibility.submit_button') %>"/>
   </div>
   <div class="dgu-filters__remove-button">
-    <%= link_to t('.remove_filters'), search_path(q: @query) %>
+    <%= link_to t('.remove_filters'), search_path(q: @query), class: 'govuk-link' %>
   </div>
 </div>

--- a/app/views/search/search.html.erb
+++ b/app/views/search/search.html.erb
@@ -48,7 +48,7 @@
           <% @datasets.each do |dataset| %>
             <div class="dgu-results__result">
               <h2 class="heading-medium">
-                <%= link_to dataset.title, dataset_path(dataset.uuid, dataset.name) %>
+                <%= link_to dataset.title, dataset_path(dataset.uuid, dataset.name), class: 'govuk-link' %>
               </h2>
               <dl class="dgu-metadata__box">
                 <% unless dataset.released? %>

--- a/app/views/shared/_breadcrumb.html.erb
+++ b/app/views/shared/_breadcrumb.html.erb
@@ -3,7 +3,7 @@
     <div class="breadcrumbs">
       <nav aria-label="Breadcrumb">
         <ol>
-          <li><%= link_to t('.home'), root_path %></li>
+          <li><%= link_to t('.home'), root_path, class: 'govuk-link' %></li>
           <li aria-current="page"><%= yield :page_title %></li>
         </ol>
       </nav>

--- a/app/views/tickets/confirmation.html.erb
+++ b/app/views/tickets/confirmation.html.erb
@@ -10,7 +10,7 @@
       <p>
         <%= t('.operational_support') %>
       </p>
-      <%= link_to 'Go back to support', support_path %>
+      <%= link_to 'Go back to support', support_path, class: 'govuk-link' %>
     </div>
   </div>
 </main>

--- a/app/views/tickets/new.html.erb
+++ b/app/views/tickets/new.html.erb
@@ -61,7 +61,7 @@
                           id: "example-email") %>
         </div>
         <%= f.hidden_field(:support, :value => @ticket.support) %>
-          <%= f.submit t('.submit'), class: "button dgu-support__button" %>
+          <%= f.submit t('.submit'), class: "govuk-button dgu-support__button" %>
       <% end %>
     </div>
   </div>

--- a/spec/features/search_page_spec.rb
+++ b/spec/features/search_page_spec.rb
@@ -84,7 +84,7 @@ RSpec.feature "Search page", type: :feature, elasticsearch: true do
     check("Open Government Licence (OGL) only")
 
     within(".dgu-filters__apply-button") do
-      find(".button").click
+      find(".govuk-button").click
     end
 
     results = all("h2 a")


### PR DESCRIPTION
https://trello.com/c/Jl6RA26P/185-insufficient-colour-contrast-on-links-when-theyre-highlighted-medium

This adds the appropriate link class to links throughout the project to bring them in line with the design system. This brings with it inherited accessibility, in particular in this instance improving the focus state so that it matches the rest of gov.uk and meets contrast ratio requirements.

Wherever possible the link class govuk-link was added directly to the link. Exceptions are:

- Pagination is a separate library so this has been styled using a css selector and a
    design system mixin.
- Links masquerading as buttons have the more appropriate govuk-button class applied

## Screenshots
### Before
![Screenshot 2020-06-23 at 15 23 57](https://user-images.githubusercontent.com/31649453/85415741-9b4c1380-b565-11ea-9532-4638204b382c.png)
![Screenshot 2020-06-23 at 15 24 21](https://user-images.githubusercontent.com/31649453/85415746-9b4c1380-b565-11ea-871d-dfc9eed78661.png)

### After
![Screenshot 2020-06-23 at 15 21 56](https://user-images.githubusercontent.com/31649453/85415739-9a1ae680-b565-11ea-88c3-df862b1148b3.png)

![Screenshot 2020-06-23 at 15 22 59](https://user-images.githubusercontent.com/31649453/85415740-9ab37d00-b565-11ea-965e-7e7a5fcf956f.png)