### PR TITLE
Update markup on the data.gov.uk hompage

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -23,6 +23,8 @@ $govuk-use-legacy-palette: false;
 @import 'govuk_publishing_components/components/_layout-header';
 @import 'govuk_publishing_components/components/_layout-footer';
 @import 'govuk_publishing_components/components/_title';
+@import 'govuk_publishing_components/components/_search';
+@import 'govuk_publishing_components/components/_lead-paragraph';
 @import 'govuk_publishing_components/components/_notice';
 @import 'govuk_publishing_components/components/_heading';
 @import 'govuk_publishing_components/components/_govspeak';

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -16,25 +16,19 @@
 }
 
 // Home ==================================================================
-.dgu-home-search {
-  padding-top: 2.5em;
-}
-
 .dgu-topics {
-
-  margin-top: 2em;
-
-  h2 {
-    font-weight: bold;
+  &__heading {
+    margin-bottom: 5px;
   }
+  &__list {
+    columns: 3;
 
-  @media (min-width: 641px) {
     li {
-      min-height: 6em;
+      display: inline-block;
+      width: 100%;
     }
   }
 }
-
 
 // Search box ==================================================================
 .dgu-search-box {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,7 +22,7 @@
   <body class="govuk-template__body">
     <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
 
-    <a href="#content" class="govuk-skip-link"><%= content_for?(:skip_link_message) ? yield(:skip_link_message) : "Skip to main content" %></a>
+    <%= render "govuk_publishing_components/components/skip_link", {} %>
 
     <%= render "govuk_publishing_components/components/cookie_banner", {
       text: sanitize("We use <a href='/cookies' class='govuk-link'>cookies to collect information</a> about how you use data.gov.uk. We use this information to make the website work as well as possible."),
@@ -49,7 +49,9 @@
       </div>
     </div>
 
-    <%= yield %>
+    <div class="govuk-width-container">
+      <%= yield %>
+    </div>
 
     <%= render "govuk_publishing_components/components/layout_footer", {
       meta: {

--- a/app/views/pages/_search.html.erb
+++ b/app/views/pages/_search.html.erb
@@ -1,20 +1,7 @@
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <h1 class="heading-xlarge">
-      <%= t('.find_gov_data') %>
-    </h1>
-    <p class="lede">
-    <%= t('.lede') %>
-    </p>
-  </div>
-</div>
-<div class="grid-row">
-  <div class="column-two-thirds dgu-search-box">
-    <form action="/search" method="GET">
-      <label for="q" class="visuallyhidden"><%= t('.accessibility.search_box_label') %></label>
-      <input id="q" name="q" type="text" class="form-control dgu-search-box__input" /><!-- Make sure there is no space between the input and button else the button will become detached --><button type="submit" class="dgu-search-box__button">
-        <%= t('.accessibility.search_button_label') %>
-      </button>
-    </form>
-  </div>
+<div class="govuk-grid-row">
+  <form action="/search" method="GET" class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/search", {
+      label_text: t('.accessibility.search_button_label')
+    } %>
+  </form>
 </div>

--- a/app/views/pages/_topics.html.erb
+++ b/app/views/pages/_topics.html.erb
@@ -1,69 +1,55 @@
-<div class="grid-row dgu-topics">
-  <div class="column-one-third">
-    <div>
-      <ol>
-        <li>
-          <h2><%= link_to t('.business_and_economy_label'), search_path(filters: { topic: 'Business and economy' }), class: 'govuk-link' %></h2>
-          <p><%= t('.business_and_economy_description') %></p>
-        </li>
-        <li>
-          <h2><%= link_to t('.crime_and_justice_label'), search_path(filters: { topic: 'Crime and justice' }), class: 'govuk-link' %></h2>
-          <p><%= t('.crime_and_justice_description') %></p>
-        </li>
-        <li>
-          <h2><%= link_to t('.defence_label'), search_path(filters: { topic: 'Defence' }), class: 'govuk-link' %></h2>
-          <p><%= t('.defence_description') %></p>
-        </li>
-        <li>
-          <h2><%= link_to t('.education_label'), search_path(filters: { topic: 'Education' }), class: 'govuk-link' %></h2>
-          <p><%= t('.education_description') %></p>
-        </li>
-      </ol>
-    </div>
-  </div>
-
-  <div class="column-one-third">
-    <div>
-      <ol>
-        <li>
-          <h2><%= link_to t('.environment_label'), search_path(filters: { topic: 'Environment' }), class: 'govuk-link' %></h2>
-          <p><%= t('.environment_description') %></p>
-        </li>
-        <li>
-          <h2><%= link_to t('.government_label'), search_path(filters: { topic: 'Government' }), class: 'govuk-link' %></h2>
-          <p><%= t('.government_description') %></p>
-        </li>
-        <li>
-          <h2><%= link_to t('.government_spending_label'), search_path(filters: { topic: 'Government spending' }), class: 'govuk-link' %></h2>
-          <p><%= t('.government_spending_description') %></p>
-        </li>
-        <li>
-          <h2><%= link_to t('.health_label'), search_path(filters: { topic: 'Health' }), class: 'govuk-link' %></h2>
-          <p><%= t('.health_description') %></p>
-        </li>
-      </ol>
-    </div>
-  </div>
-  <div class="column-one-third">
-    <div>
-      <ol>
-        <li>
-          <h2><%= link_to t('.mapping_label'), search_path(filters: { topic: 'Mapping' }), class: 'govuk-link' %></h2>
-          <p><%= t('.mapping_description') %></p>
-        </li>
-        <li>
-          <h2><%= link_to t('.society_label'), search_path(filters: { topic: 'Society' }), class: 'govuk-link' %></h2>
-          <p><%= t('.society_description') %></p>
-        </li>
-        <li>
-          <h2><%= link_to t('.towns_and_cities_label'), search_path(filters: { topic: 'Towns and cities' }), class: 'govuk-link' %></h2>
-          <p><%= t('.towns_and_cities_description') %></p>
-        </li>
-        <li>
-          <h2><%= link_to t('.transport_label'), search_path(filters: { topic: 'Transport' }), class: 'govuk-link' %></h2>
-          <p><%= t('.transport_description') %></p>
-        </li>
-      </ol>
-    </div>
+<div class="govuk-grid-row">
+  <h2 class="govuk-visually-hidden"><%= t('.topics_heading') %></h2>
+  <div class="govuk-grid-column-full">
+    <ul class="govuk-list dgu-topics__list">
+      <li>
+        <h3 class="govuk-heading-s dgu-topics__heading"><%= link_to t('.business_and_economy_label'), search_path(filters: { topic: 'Business and economy' }), class: 'govuk-link' %></h3>
+        <p class="govuk-body"><%= t('.business_and_economy_description') %></p>
+      </li>
+      <li>
+        <h3 class="govuk-heading-s dgu-topics__heading"><%= link_to t('.crime_and_justice_label'), search_path(filters: { topic: 'Crime and justice' }), class: 'govuk-link' %></h3>
+        <p class="govuk-body"><%= t('.crime_and_justice_description') %></p>
+      </li>
+      <li>
+        <h3 class="govuk-heading-s dgu-topics__heading"><%= link_to t('.defence_label'), search_path(filters: { topic: 'Defence' }), class: 'govuk-link' %></h3>
+        <p class="govuk-body"><%= t('.defence_description') %></p>
+      </li>
+      <li>
+        <h3 class="govuk-heading-s dgu-topics__heading"><%= link_to t('.education_label'), search_path(filters: { topic: 'Education' }), class: 'govuk-link' %></h3>
+        <p class="govuk-body"><%= t('.education_description') %></p>
+      </li>
+      <li>
+        <h3 class="govuk-heading-s dgu-topics__heading"><%= link_to t('.environment_label'), search_path(filters: { topic: 'Environment' }), class: 'govuk-link' %></h3>
+        <p class="govuk-body"><%= t('.environment_description') %></p>
+      </li>
+      <li>
+        <h3 class="govuk-heading-s dgu-topics__heading"><%= link_to t('.government_label'), search_path(filters: { topic: 'Government' }), class: 'govuk-link' %></h3>
+        <p class="govuk-body"><%= t('.government_description') %></p>
+      </li>
+      <li>
+        <h3 class="govuk-heading-s dgu-topics__heading"><%= link_to t('.government_spending_label'), search_path(filters: { topic: 'Government spending' }), class: 'govuk-link' %></h3>
+        <p class="govuk-body"><%= t('.government_spending_description') %></p>
+      </li>
+      <li>
+        <h3 class="govuk-heading-s dgu-topics__heading"><%= link_to t('.health_label'), search_path(filters: { topic: 'Health' }), class: 'govuk-link' %></h3>
+        <p class="govuk-body"><%= t('.health_description') %></p>
+      </li>
+      <li>
+        <h3 class="govuk-heading-s dgu-topics__heading"><%= link_to t('.mapping_label'), search_path(filters: { topic: 'Mapping' }), class: 'govuk-link' %></h3>
+        <p class="govuk-body"><%= t('.mapping_description') %></p>
+      </li>
+      <li>
+        <h3 class="govuk-heading-s dgu-topics__heading"><%= link_to t('.society_label'), search_path(filters: { topic: 'Society' }), class: 'govuk-link' %></h3>
+        <p class="govuk-body"><%= t('.society_description') %></p>
+      </li>
+      <li>
+        <h3 class="govuk-heading-s dgu-topics__heading"><%= link_to t('.towns_and_cities_label'), search_path(filters: { topic: 'Towns and cities' }), class: 'govuk-link' %></h3>
+        <p class="govuk-body"><%= t('.towns_and_cities_description') %></p>
+      </li>
+      <li>
+        <h3 class="govuk-heading-s dgu-topics__heading"><%= link_to t('.transport_label'), search_path(filters: { topic: 'Transport' }), class: 'govuk-link' %></h3>
+        <p class="govuk-body"><%= t('.transport_description') %></p>
+      </li>
+    </ul>
   </div>
 </div>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,6 +1,6 @@
 <% content_for :page_title do %><%= t('.find_open_data') %><% end %>
 
-<main role="main" id="content">
+<main role="main" id="main-content" class="govuk-main-wrapper">
   <%= render 'search' %>
   <%= render 'topics' %>
 </main>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,6 +1,18 @@
 <% content_for :page_title do %><%= t('.find_open_data') %><% end %>
 
 <main role="main" id="main-content" class="govuk-main-wrapper">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= render "govuk_publishing_components/components/title", {
+        title: t('.find_open_data')
+      } %>
+
+      <%= render "govuk_publishing_components/components/lead_paragraph", {
+        text: t('.lede')
+      } %>
+    </div>
+  </div>
+
   <%= render 'search' %>
   <%= render 'topics' %>
 </main>

--- a/config/locales/views/pages/en.yml
+++ b/config/locales/views/pages/en.yml
@@ -1,12 +1,10 @@
 en:
   pages:
     search:
-      find_gov_data: "Find open data"
-      lede: "Find data published by central government, local authorities and public bodies to help you build products and services"
       accessibility:
-        search_box_label: "Search"
-        search_button_label: "Find data"
+        search_button_label: "Search data.gov.uk"
     topics:
+      topics_heading: "Data topics"
       business_and_economy_label: "Business and economy"
       business_and_economy_description: "Small businesses, industry, imports, exports and trade"
       crime_and_justice_label: "Crime and justice"
@@ -33,3 +31,4 @@ en:
       transport_description: "Airports, roads, freight, electric vehicles, parking, buses and footpaths"
     home:
       find_open_data: "Find open data"
+      lede: "Find data published by central government, local authorities and public bodies to help you build products and services"

--- a/spec/support/dataset_helper.rb
+++ b/spec/support/dataset_helper.rb
@@ -18,9 +18,9 @@ end
 
 def search_for(query)
   visit "/"
-  within "#content" do
+  within "#main-content" do
     fill_in "q", with: query
-    find(".dgu-search-box__button").click
+    find(".gem-c-search__submit").click
   end
 end
 


### PR DESCRIPTION
## What
Update the markup, classnames and styling on the homepage view and associated components (search and search topics). There should be no discernible difference between this PR and production.

## Why
DGU Find is currently using govuk elements, an outdated implementation of the govuk design system. This PR is one of several that attempts to slowly remove the elements implementation and replace it with up to date implementations from govuk frontend and govuk publishing components.

**Card:** https://trello.com/c/MHM8t3z8/231-update-markup-on-find-homepage