### PR TITLE
Update search markup

### DIFF
--- a/app/assets/javascripts/govuk.js
+++ b/app/assets/javascripts/govuk.js
@@ -15,33 +15,25 @@ $(document).ready(function () {
   var showHide = new ShowHide()
   showHide.init()
 
-  if (document.getElementById('publisher')) {
-    accessibleAutocomplete.enhanceSelectElement({
-      selectElement: document.querySelector('#publisher'),
-      showAllValues: true,
-      preserveNullOptions: true
-    })
+  var autocompleteSelects = document.getElementsByClassName('js-accessible-autocomplete')
+
+  if (autocompleteSelects.length > 0) {
+    for (var i = 0; i < autocompleteSelects.length; i += 1) {
+      accessibleAutocomplete.enhanceSelectElement({
+        selectElement: autocompleteSelects[i],
+        showAllValues: true,
+        preserveNullOptions: true
+      })
+    }
   }
 
-  if (document.getElementById('format')) {
-    accessibleAutocomplete.enhanceSelectElement({
-      selectElement: document.querySelector('#format'),
-      showAllValues: true,
-      preserveNullOptions: true
+  var sortDatasets = document.getElementById('sort-datasets')
+
+  if (sortDatasets) {
+    sortDatasets.addEventListener('change', function(event) {
+      event.target.form.submit()
     })
   }
-
-  if(document.getElementById('topic')) {
-    accessibleAutocomplete.enhanceSelectElement({
-      selectElement: document.querySelector('#topic'),
-      showAllValues: true,
-      preserveNullOptions: true
-    })
-  }
-
-  document.getElementById('sort-datasets').addEventListener('change', function(event) {
-    event.target.form.submit()
-  })
 
   new FoldableText('.js-summary', 200)
     .init()

--- a/app/assets/javascripts/govuk.js
+++ b/app/assets/javascripts/govuk.js
@@ -39,6 +39,10 @@ $(document).ready(function () {
     })
   }
 
+  document.getElementById('sort-datasets').addEventListener('change', function(event) {
+    event.target.form.submit()
+  })
+
   new FoldableText('.js-summary', 200)
     .init()
 
@@ -69,7 +73,7 @@ ShowHide.prototype = {
     event.preventDefault()
 
     var openCloseAllControl = $(event.target)
-    var dataLinks = $(this.selector);
+    var dataLinks = $(this.selector)
     var dataLinkContent = dataLinks.find(this.contentSelector)
     var dataLinkExpand = dataLinks.find(this.expandSelector)
     var allOpen = openCloseAllControl.data('allOpen')
@@ -156,7 +160,7 @@ LimitDatasets.prototype.toggle = function (event) {
   if (folded === 'folded') {
     $target.text('Show less')
     this.moreFiles.show()
-    $(this.moreFiles[0]).attr('tabindex', -1).focus();
+    $(this.moreFiles[0]).attr('tabindex', -1).focus()
     $target.data('folded', 'unfolded')
   } else {
     $target.text('Show more')

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -25,6 +25,8 @@ $govuk-use-legacy-palette: false;
 @import 'govuk_publishing_components/components/_title';
 @import 'govuk_publishing_components/components/_search';
 @import 'govuk_publishing_components/components/_lead-paragraph';
+@import 'govuk_publishing_components/components/_select';
+@import 'govuk_publishing_components/components/_checkboxes';
 @import 'govuk_publishing_components/components/_notice';
 @import 'govuk_publishing_components/components/_heading';
 @import 'govuk_publishing_components/components/_govspeak';

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -134,38 +134,7 @@
 // sorting controls ============================================================
 
 .dgu-sort {
-
-  &__apply {
-    float: right;
-    margin-left: 1em;
-
-    input {
-      background: none;
-      border: none;
-      color: #005ea5;
-      text-decoration: underline;
-      cursor: pointer;
-    }
-  }
-
-  &__sort-type {
-    margin-top: 5px;
-    float: right;
-    width: 128px;
-    background: image-url("triangle-down.png") no-repeat right 8px;
-    background-size: 8%;
-    select {
-      @include copy-19;
-      width: 128px;
-      background: transparent;
-      border: none;
-      -webkit-appearance: none;
-      -moz-appearance: none;
-    }
-    select::-ms-expand {
-      display: none;
-    }
-  }
+  float: right;
 }
 
 // Datafiles ===================================================================

--- a/app/views/search/_filters.html.erb
+++ b/app/views/search/_filters.html.erb
@@ -1,32 +1,32 @@
-<h2 class="heading-medium"> <%= t('.filter_by') %></h2>
+<h2 class="heading-medium"> <%= t(".filter_by") %></h2>
 
-<div class="form-group">
-  <%= label_tag 'publisher', t('.filter_by_publisher'), class: 'form-label' %>
-  <%= select_tag('filters[publisher]', options_for_select(dataset_publishers_for_select, selected_publisher), id: 'publisher', class: 'form-control dgu-filters__filter', include_blank: true) %>
+<div class="govuk-form-group">
+  <%= label_tag "publisher", t(".filter_by_publisher"), class: "govuk-label" %>
+  <%= select_tag("filters[publisher]", options_for_select(dataset_publishers_for_select, selected_publisher), id: "publisher", class: "govuk-select dgu-filters__filter", include_blank: true) %>
 </div>
 
-<div class="form-group">
-  <%= label_tag 'topic', t('.filter_by_topic'), class: 'form-label' %>
-  <%= select_tag('filters[topic]', options_for_select(dataset_topics_for_select, selected_topic), id: 'topic', class: 'form-control dgu-filters__filter', include_blank: true) %>
+<div class="govuk-form-group">
+  <%= label_tag "topic", t(".filter_by_topic"), class: "govuk-label" %>
+  <%= select_tag("filters[topic]", options_for_select(dataset_topics_for_select, selected_topic), id: "topic", class: "govuk-select dgu-filters__filter", include_blank: true) %>
 </div>
 
-<div class="form-group">
-  <%= label_tag 'format', t('.filter_by_format'), class: 'form-label' %>
-  <%= select_tag('filters[format]', options_for_select(datafile_formats_for_select, selected_format), id: 'format', class: 'form-control dgu-filters__filter', include_blank: true) %>
+<div class="govuk-form-group">
+  <%= label_tag "format", t(".filter_by_format"), class: "govuk-label" %>
+  <%= select_tag("filters[format]", options_for_select(datafile_formats_for_select, selected_format), id: "format", class: "govuk-select dgu-filters__filter", include_blank: true) %>
 </div>
 
-<div class="form-group">
-  <div class="multiple-choice">
-    <%= check_box_tag 'filters[licence_code]', 'uk-ogl', @licence_code == 'uk-ogl' %>
-    <%= label_tag 'filters[licence_code]', t('.filter_by_ogl') %>
-  </div>
-</div>
+<%= render "govuk_publishing_components/components/checkboxes", {
+  name: "filters[licence_code]",
+  items: [
+    {
+      label: t(".filter_by_ogl"),
+      value: "uk-ogl"
+    }
+  ]
+} %>
 
-<div class="form-group">
-  <div class="dgu-filters__apply-button">
-    <input class="govuk-button" type="submit" value="<%= t('.accessibility.submit_button') %>"/>
-  </div>
-  <div class="dgu-filters__remove-button">
-    <%= link_to t('.remove_filters'), search_path(q: @query), class: 'govuk-link' %>
-  </div>
-</div>
+<%= render "govuk_publishing_components/components/button", {
+  text: t(".accessibility.submit_button"),
+  margin_bottom: true
+} %>
+<p class="govuk-body"><%= link_to t(".remove_filters"), search_path(q: @query), class: "govuk-link" %></p>

--- a/app/views/search/_filters.html.erb
+++ b/app/views/search/_filters.html.erb
@@ -2,17 +2,17 @@
 
 <div class="govuk-form-group">
   <%= label_tag "publisher", t(".filter_by_publisher"), class: "govuk-label" %>
-  <%= select_tag("filters[publisher]", options_for_select(dataset_publishers_for_select, selected_publisher), id: "publisher", class: "govuk-select dgu-filters__filter", include_blank: true) %>
+  <%= select_tag("filters[publisher]", options_for_select(dataset_publishers_for_select, selected_publisher), id: "publisher", class: "govuk-select dgu-filters__filter js-accessible-autocomplete", include_blank: true) %>
 </div>
 
 <div class="govuk-form-group">
   <%= label_tag "topic", t(".filter_by_topic"), class: "govuk-label" %>
-  <%= select_tag("filters[topic]", options_for_select(dataset_topics_for_select, selected_topic), id: "topic", class: "govuk-select dgu-filters__filter", include_blank: true) %>
+  <%= select_tag("filters[topic]", options_for_select(dataset_topics_for_select, selected_topic), id: "topic", class: "govuk-select dgu-filters__filter js-accessible-autocomplete", include_blank: true) %>
 </div>
 
 <div class="govuk-form-group">
   <%= label_tag "format", t(".filter_by_format"), class: "govuk-label" %>
-  <%= select_tag("filters[format]", options_for_select(datafile_formats_for_select, selected_format), id: "format", class: "govuk-select dgu-filters__filter", include_blank: true) %>
+  <%= select_tag("filters[format]", options_for_select(datafile_formats_for_select, selected_format), id: "format", class: "govuk-select dgu-filters__filter js-accessible-autocomplete", include_blank: true) %>
 </div>
 
 <%= render "govuk_publishing_components/components/checkboxes", {

--- a/app/views/search/_sort.html.erb
+++ b/app/views/search/_sort.html.erb
@@ -1,15 +1,24 @@
 <div class="dgu-sort">
-  <div class="dgu-sort__apply visuallyhidden">
-    <input type="submit" value=<%= t('.accessibility.submit_button') %>/>
-  </div>
-
-  <div class="dgu-sort__sort-type">
-    <label>
-      <span class="visuallyhidden"> <%= t('.accessibility.sort_type_label') %></span>
-      <select id="sort-datasets" name="sort" onchange="this.form.submit()">
-        <option <%= 'selected' if @sort!='recent' %> value="best"> <%= t('.match') %></option>
-        <option <%= 'selected' if @sort=='recent' %> value="recent"> <%= t('.recent') %></option>
-      </select>
-    </label>
+  <%= render "govuk_publishing_components/components/select", {
+    id: "sort-datasets",
+    name: "sort",
+    label: t('.sort_by'),
+    options: [
+      {
+        text: t('.match'),
+        value: 'best',
+        selected: @sort === 'best' || @sort != 'recent'
+      },
+      {
+        text: t('.recent'),
+        value: 'recent',
+        selected: @sort === 'recent'
+      }
+    ]
+  } %>
+  <div class="govuk-visually-hidden">
+    <%= render "govuk_publishing_components/components/button", {
+      text: t('.accessibility.submit_button'),
+    } %>
   </div>
 </div>

--- a/app/views/search/search.html.erb
+++ b/app/views/search/search.html.erb
@@ -13,9 +13,9 @@
       } %>
 
       <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
+        <div class="govuk-grid-column-two-thirds" id="search-box"> 
           <%= render "govuk_publishing_components/components/search", {
-            label_text: t('.search_data_gov_uk')
+            label_text: t('.search_data_gov_uk'),
           } %>
         </div>
       </div>

--- a/app/views/search/search.html.erb
+++ b/app/views/search/search.html.erb
@@ -3,81 +3,90 @@
     t('.search_results') %><% end %>
 
 <form action="/search" method="GET">
-  <main role="main" id="content">
-  <h1 class="heading-large"> <%= t('.search_results_heading') %></h1>
-  <div class="grid-row">
-    <div class="column-two-thirds dgu-search-box">
-      <label for="q" class="visuallyhidden"> <%= t('.accessibility.search_box_label') %></label>
-      <input id="q"
-             name="q"
-             type="text"
-             class="form-control dgu-search-box__input"
-             value="<%= @query %>"/><button type="submit"
-                                            class="dgu-search-box__button">
-               <%= t('.accessibility.search_button_label') %>
-             </button>
-    </div>
-  </div>
+  <main role="main" id="main-content" class="govuk-main-wrapper">
+    <div class="govuk-width-container">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: t(".search_results_heading"),
+        margin_bottom: 6,
+        heading_level: 1,
+        font_size: "l",
+      } %>
 
-  <div class="grid-row dgu-filters">
-    <div class="column-one-third">
-      <%= render 'filters' %>
-    </div>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <%= render "govuk_publishing_components/components/search", {
+            label_text: t('.search_data_gov_uk')
+          } %>
+        </div>
+      </div>
 
-    <div class="column-two-thirds dgu-results">
-      <%= render 'sort' if @num_results > 1 %>
-      <span class="dgu-results__summary">
-        <span class="bold-small"><%= number_with_delimiter(@num_results) %></span>
-        <%= t('.result').pluralize(@num_results) %> <%= t('.found') %>
-      </span>
+      <div class="govuk-grid-row dgu-filters">
+        <div class="govuk-grid-column-one-third">
+          <%= render 'filters' %>
+        </div>
 
-      <div>
-        <% if @num_results.zero? %>
-          <div class="dgu-results__zero">
-            <h2 class="heading-medium"> <%= t('.zero_result_tips.try') %>:</h2>
-            <ul class="list list-bullet">
-              <li><%= t('.zero_result_tips.different_words') %></li>
-              <li><%= t('.zero_result_tips.remove_filters') %></li>
-            </ul>
-            <h2 class="heading-medium"> <%= t('.zero_result_tips.older_content') %></h2>
-            <p><%= t('.zero_result_tips.we_can_help') %></p>
-            <p><%= t('.zero_result_tips.expand_your_search') %></p>
+        <div class="govuk-grid-column-two-thirds dgu-results">
+          <%= render 'sort' if @num_results > 1 %>
+          <span class="dgu-results__summary">
+            <span class="govuk-body-s govuk-!-font-weight-bold"><%= number_with_delimiter(@num_results) %></span>
+            <%= t('.result').pluralize(@num_results) %> <%= t('.found') %>
+          </span>
 
-          </div>
-        <% else %>
-          <% @datasets.each do |dataset| %>
-            <div class="dgu-results__result">
-              <h2 class="heading-medium">
-                <%= link_to dataset.title, dataset_path(dataset.uuid, dataset.name), class: 'govuk-link' %>
-              </h2>
-              <dl class="dgu-metadata__box">
-                <% unless dataset.released? %>
-                  <dt><%= t('.meta_data_box.availability') %>:</dt>
-                  <dd class="availability">
-                  <span class="dgu-highlight">Not released</span>
-                  </dd>
-                <% end %>
-                <dt><%= t('.meta_data_box.published_by') %>:</dt>
-                <dd class="published_by"><%= dataset.organisation['title'] %></dd>
-                <dt><%= t('.meta_data_box.last_updated') %>:</dt>
-                <% if dataset.public_updated_at.present? %>
-                  <dd class="last_updated"><%= format_timestamp(dataset.public_updated_at) %></dd>
-                <% else %>
-                  <dd class="last_updated dgu-secondary-text"> <%= t('.meta_data_box.not_applicable') %></dd>
-                <% end %>
-              </dl>
-              <p><%= truncate(strip_tags(dataset.summary), length: 200, separator: ' ') %></p>
+          <% if @num_results.zero? %>
+            <div class="dgu-results__zero">
+              <%= render "govuk_publishing_components/components/heading", {
+                text: "#{t(".zero_result_tips.try")}:",
+                margin_bottom: 4,
+                heading_level: 2,
+                font_size: "m",
+              } %>
+              <ul class="govuk-list govuk-list--bullet">
+                <li><%= t('.zero_result_tips.different_words') %></li>
+                <li><%= t('.zero_result_tips.remove_filters') %></li>
+              </ul>
+              <%= render "govuk_publishing_components/components/heading", {
+                text: t('.zero_result_tips.older_content'),
+                margin_bottom: 4,
+                heading_level: 2,
+                font_size: "m",
+              } %>
+              <p class="govuk-body"><%= t('.zero_result_tips.we_can_help') %></p>
+              <p class="govuk-body"><%= t('.zero_result_tips.expand_your_search') %></p>
+            </div>
+          <% else %>
+            <% @datasets.each do |dataset| %>
+              <div class="dgu-results__result">
+                <h2 class="govuk-heading-m">
+                  <%= link_to dataset.title, dataset_path(dataset.uuid, dataset.name), class: 'govuk-link' %>
+                </h2>
+                <dl class="dgu-metadata__box">
+                  <% unless dataset.released? %>
+                    <dt><%= t('.meta_data_box.availability') %>:</dt>
+                    <dd>
+                      <span class="dgu-highlight"><%= t('.meta_data_box.not_released') %></span>
+                    </dd>
+                  <% end %>
+                  <dt><%= t('.meta_data_box.published_by') %>:</dt>
+                  <dd class="published_by"><%= dataset.organisation['title'] %></dd>
+                  <dt><%= t('.meta_data_box.last_updated') %>:</dt>
+                  <% if dataset.public_updated_at.present? %>
+                    <dd><%= format_timestamp(dataset.public_updated_at) %></dd>
+                  <% else %>
+                    <dd class="dgu-secondary-text"> <%= t('.meta_data_box.not_applicable') %></dd>
+                  <% end %>
+                </dl>
+                <p><%= truncate(strip_tags(dataset.summary), length: 200, separator: ' ') %></p>
+              </div>
+            <% end %>
+            <div class="dgu-pagination">
+              <nav>
+                <%= page_entries_info @datasets, entry_name: 'dataset' %>
+                <span class="dgu-pagination__numbers"><%= paginate @datasets, window: 2 %></span>
+              </nav>
             </div>
           <% end %>
-          <div class="dgu-pagination">
-            <nav>
-              <%= page_entries_info @datasets, entry_name: 'dataset' %>
-              <span class="dgu-pagination__numbers"><%= paginate @datasets, window: 2 %></span>
-            </nav>
-          </div>
-        <% end %>
+        </div>
       </div>
     </div>
   </main>
-  </div>
 </form>

--- a/config/locales/views/search/en.yml
+++ b/config/locales/views/search/en.yml
@@ -39,6 +39,6 @@ en:
     sort:
       match: "Best match"
       recent: "Most recent"
+      sort_by: "Sort by"
       accessibility:
         submit_button: "Apply sorting"
-        sort_type_label: "Sorting type"

--- a/config/locales/views/search/en.yml
+++ b/config/locales/views/search/en.yml
@@ -4,6 +4,7 @@ en:
       results_page_title: 'Results for "%{query}"'
       search_results: 'Search Results'
       search_results_heading: "Search results"
+      search_data_gov_uk: "Search data.gov.uk"
       accessibility:
         search_box_label: "Search"
         search_button_label: "Find data"
@@ -23,6 +24,7 @@ en:
         last_updated: "Last updated"
         geo_area: "Geographical area"
         not_applicable: "Not applicable"
+        not_released: "Not released"
     filters:
       filter_by: "Filter by"
       filter_by_geo: "Geographical area"

--- a/spec/features/search_page_spec.rb
+++ b/spec/features/search_page_spec.rb
@@ -32,21 +32,21 @@ RSpec.feature "Search page", type: :feature, elasticsearch: true do
     index(old_dataset, new_dataset)
 
     search_for("Old Interesting Dataset")
-    expect(page).to have_css("option[selected]", text: "Best match")
+    expect(page).to have_select("sort", selected: "Best match")
 
     elements = all("h2 a")
     expect(elements[0]).to have_content "Old"
     expect(elements[1]).to have_content "Recent"
 
     filtered_search_for("Interesting Dataset", "Most recent")
-    expect(page).to have_css("option[selected]", text: "Most recent")
+    expect(page).to have_select("sort", selected: "Most recent")
 
     elements = all("h2 a")
     expect(elements[0]).to have_content "Recent"
     expect(elements[1]).to have_content "Old"
 
     filtered_search_for("Old Interesting Dataset", "Best match")
-    expect(page).to have_css("option[selected]", text: "Best match")
+    expect(page).to have_select("sort", selected: "Best match")
 
     elements = all("h2 a")
     expect(elements[0]).to have_content "Old"
@@ -79,10 +79,10 @@ RSpec.feature "Search page", type: :feature, elasticsearch: true do
     visit("/search")
     assert_data_set_length_is(2)
 
-    check("Open Government Licence (OGL) only")
+    find(".govuk-checkboxes__input").click
 
-    within(".dgu-filters__apply-button") do
-      find(".govuk-button").click
+    within("#search-box") do
+      find(".gem-c-search__submit").click
     end
 
     results = all("h2 a")
@@ -188,9 +188,9 @@ RSpec.feature "Search page", type: :feature, elasticsearch: true do
 
     expect(page).to have_title('Results for "Government"')
 
-    within "#content" do
+    within "#main-content" do
       fill_in "q", with: "bear"
-      find(".dgu-search-box__button").click
+      find(".gem-c-search__submit").click
     end
 
     expect(page).to have_title('Results for "bear"')

--- a/spec/support/dataset_helper.rb
+++ b/spec/support/dataset_helper.rb
@@ -26,9 +26,9 @@ end
 
 def filtered_search_for(query, sort_method)
   visit "/search"
-  within "#content" do
+  within "#main-content" do
     fill_in "q", with: query
-    select sort_method, from: "Sorting type"
-    find(".dgu-search-box__button").click
+    select sort_method, from: "Sort by"
+    find(".gem-c-search__submit").click
   end
 end


### PR DESCRIPTION
## What
Update the markup, classnames and styling on the search view and associated components (filters and sort). There should be no discernible difference between this PR and production.

## Why
DGU Find is currently using govuk elements, an outdated implementation of the govuk design system. This PR is one of several that attempts to slowly remove the elements implementation and replace it with up to date implementations from govuk frontend and govuk publishing components.

**Card:** https://trello.com/c/EbYBZqRv/232-update-markup-on-find-search-page