### PR TITLE
Update dataset page markup

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,6 +16,7 @@
 //= require govuk_toolkit
 //= require accessible-autocomplete/dist/accessible-autocomplete.min
 //= require govuk_publishing_components/dependencies
+//= require govuk_publishing_components/modules
 //= require govuk_publishing_components/all_components
 //= require_tree ./organograms/lib
 //= require_tree ./organograms

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -27,6 +27,7 @@ $govuk-use-legacy-palette: false;
 @import 'govuk_publishing_components/components/_layout-header';
 @import 'govuk_publishing_components/components/_lead-paragraph';
 @import 'govuk_publishing_components/components/_notice';
+@import 'govuk_publishing_components/components/_breadcrumbs';
 @import 'govuk_publishing_components/components/_details';
 @import 'govuk_publishing_components/components/_radio';
 @import 'govuk_publishing_components/components/_search';

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -28,6 +28,7 @@ $govuk-use-legacy-palette: false;
 @import 'govuk_publishing_components/components/_lead-paragraph';
 @import 'govuk_publishing_components/components/_notice';
 @import 'govuk_publishing_components/components/_breadcrumbs';
+@import 'govuk_publishing_components/components/_accordion';
 @import 'govuk_publishing_components/components/_details';
 @import 'govuk_publishing_components/components/_radio';
 @import 'govuk_publishing_components/components/_search';

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -27,6 +27,7 @@ $govuk-use-legacy-palette: false;
 @import 'govuk_publishing_components/components/_layout-header';
 @import 'govuk_publishing_components/components/_lead-paragraph';
 @import 'govuk_publishing_components/components/_notice';
+@import 'govuk_publishing_components/components/_details';
 @import 'govuk_publishing_components/components/_radio';
 @import 'govuk_publishing_components/components/_search';
 @import 'govuk_publishing_components/components/_select';

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -7,7 +7,7 @@
 
 .dgu-highlight {
   background: $grey-3;
-  padding: em(2) em(5) em(2) em(5);
+  padding: 2px govuk-spacing(1);
 }
 
 .table-wrapper {
@@ -80,15 +80,15 @@
   }
 }
 
-.dgu-metadata__box {
+.dgu-metadata {
+  margin-top: govuk-spacing(1);
+  margin-bottom: govuk-spacing(4);
 
   &--in-dataset {
     background: $highlight-colour;
-    padding: 25px 30px 15px 30px;
+    padding: govuk-spacing(5) govuk-spacing(6) govuk-spacing(3) govuk-spacing(6);
   }
 
-  margin-top: 5px;
-  margin-bottom: 10px;
   dt, dd {
     display: inline-block;
     margin-bottom: 5px;
@@ -110,6 +110,11 @@
     }
   }
 
+}
+
+.dataset-summary {
+  line-height: 1.5em;
+  overflow: hidden;
 }
 
 // pagination controls =========================================================

--- a/app/views/datasets/_additional_info.html.erb
+++ b/app/views/datasets/_additional_info.html.erb
@@ -1,81 +1,103 @@
+<section id="dgu-additional-info">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: t('.additional_info'),
+        margin_bottom: 4,
+        heading_level: 2,
+        font_size: "m"
+      } %>
 
-  <section class="dgu-additional-info">
-    <h2 class="heading-medium">
-      <%= t('.additional_info') %>
-    </h2>
-    <% if dataset.description.present? %>
-      <p class="dgu-additional-info__notes">
-        <%= dataset.description %>
-      </p>
-    <% end %>
+      <% if dataset.description.present? %>
+        <p class="govuk-body">
+          <%= dataset.description %>
+        </p>
+      <% end %>
 
-    <% if dataset.inspire_dataset.present? %>
-      <% i = dataset.inspire_dataset %>
+      <% if dataset.inspire_dataset.present? %>
+        <%
+          i = dataset.inspire_dataset
+          translations = {
+            added: t('.inspire_added'),
+            access_constraints: t('.inspire_access_constraints'),
+            access_constraints_unspecified: t('.inspire_access_constraints_unspecified'),
+            guid: t('.inspire_guid'),
+            extent: t('.inspire_extent'),
+            latitude: t('.inspire_latitude'),
+            longitude: t('.inspire_longitude'),
+            to: t('.inspire_to'),
+            spatial_ref_system: t('.inspire_spatial_ref_system'),
+            dataset_ref_date: t('.inspire_dataset_ref_date'),
+            frequency: t('.inspire_frequency'),
+            responsible_party: t('.inspire_responsible_party'),
+            iso_resource: t('.inspire_iso_resource'),
+            metadata_lang: t('.inspire_metadata_lang'),
+            gemini_record: t('.inspire_gemini_record'),
+            xml: t('.xml'),
+            html: t('.html'),
+          }
+        %>
 
-      <details>
-        <% unless browser.ie? || browser.edge? %>
-          <summary><span class="summary"><%= t('.view_additional_metadata') %></span></summary>
-        <% end %>
-
-
-        <div class="panel panel-border-narrow">
-
-          <dl class="dgu-deflist">
+        <%= render "govuk_publishing_components/components/details", {
+          title: t('.view_additional_metadata')
+        } do %>
+          <dl class="dgu-deflist govuk-clearfix">
             <% if i['metadata_date'] %>
-              <dt><%= t('.inspire_added') %></dt>
+              <dt><%= translations[:added] %></dt>
               <dd><%= i['metadata_date'] %></dd>
             <% end %>
             <% if i['access_constraints'] %>
               <% ref = JSON.parse(i['access_constraints']) %>
-              <dt><%= t('.inspire_access_constraints') %></dt>
-              <dd><%= ref.first || t('.inspire_access_constraints_unspecified') %></dd>
+              <dt><%= translations[:access_constraints] %></dt>
+              <dd><%= ref.first || translations[:access_constraints_unspecified] %></dd>
             <% end %>
             <% if i['guid'] %>
-              <dt><%= t('.inspire_guid') %></dt>
+              <dt><%= translations[:guid] %></dt>
               <dd><%= i['guid'] %></dd>
             <% end %>
             <% if i['bbox_east_long'] and i['bbox_west_long'] and i['bbox_north_lat'] and i['bbox_south_lat'] %>
-              <dt><%= t('.inspire_extent') %></dt>
+              <dt><%= translations[:extent] %></dt>
               <dd>
-                <%= t('.inspire_latitude') %>: <%= i['bbox_north_lat'] %>° <%= t('.inspire_to') %> <%= i['bbox_south_lat'] %>°</dd>
+                <%= translations[:latitude] %>: <%= i['bbox_north_lat'] %>° <%= translations[:to] %> <%= i['bbox_south_lat'] %>°</dd>
               <dd>
-                <%= t('.inspire_longitude') %>: <%= i['bbox_west_long'] %>° <%= t('.inspire_to') %> <%= i['bbox_east_long'] %>°
+                <%= translations[:longitude] %>: <%= i['bbox_west_long'] %>° <%= translations[:to] %> <%= i['bbox_east_long'] %>°
               </dd>
             <% end %>
             <% if i['spatial_reference_system'] %>
-              <dt><%= t('.inspire_spatial_ref_system') %></dt>
+              <dt><%= translations[:spatial_ref_system] %></dt>
               <dd><%= i['spatial_reference_system'] %></dd>
             <% end %>
             <% if i['dataset_reference_date'] %>
               <% ref = JSON.parse(i['dataset_reference_date']) %>
-              <dt><%= t('.inspire_dataset_ref_date') %></dt>
+              <dt><%= translations[:dataset_ref_date] %></dt>
               <% ref.each do |date| %>
                 <dd><%= date['value'] %> (<%= date['type'] %>)</dd>
               <% end %>
             <% end %>
             <% if i['frequency_of_update'] %>
-              <dt><%= t('.inspire_frequency') %></dt>
+              <dt><%= translations[:frequency] %></dt>
               <dd><%= i['frequency_of_update'] %></dd>
             <% end %>
             <% if i['responsible_party'] %>
-              <dt><%= t('.inspire_responsible_party') %></dt>
+              <dt><%= translations[:responsible_party] %></dt>
               <dd><%= i['responsible_party'] %></dd>
             <% end %>
             <% if i['resource_type'] %>
-              <dt><%= t('.inspire_iso_resource') %></dt>
+              <dt><%= translations[:iso_resource] %></dt>
               <dd><%= i['resource_type'] %></dd>
             <% end %>
             <% if i['metadata_language'] %>
-              <dt><%= t('.inspire_metadata_lang') %></dt>
+              <dt><%= translations[:metadata_lang] %></dt>
               <dd><%= i['metadata_language'] %></dd>
             <% end %>
             <% if i['harvest_object_id'] %>
-              <dt><%= t('.inspire_gemini_record') %></dt>
-              <dd><%= link_to t('.xml'), "/api/2/rest/harvestobject/#{ i['harvest_object_id'] }/xml", class: 'govuk-link' %></dd>
-              <dd><%= link_to t('.html'), "/api/2/rest/harvestobject/#{ i['harvest_object_id'] }/html", class: 'govuk-link' %></dd>
+              <dt><%= translations[:gemini_record] %></dt>
+              <dd><%= link_to translations[:xml], "/api/2/rest/harvestobject/#{ i['harvest_object_id'] }/xml", class: 'govuk-link' %></dd>
+              <dd><%= link_to translations[:html], "/api/2/rest/harvestobject/#{ i['harvest_object_id'] }/html", class: 'govuk-link' %></dd>
             <% end %>
           </dl>
-        </div>
-      </details>
-    <% end %>
-  </section>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+</section>

--- a/app/views/datasets/_breadcrumb.html.erb
+++ b/app/views/datasets/_breadcrumb.html.erb
@@ -1,26 +1,25 @@
 <% if @dataset %>
-  <div class="grid-row">
-    <!-- Only display breadcrumb if the referrer host matches the application host  -->
-    <div class="column-full">
-      <div class="breadcrumbs">
-        <nav aria-label="Breadcrumb">
-          <ol>
-            <li>
-              <%= link_to t('.home'), root_path, class: 'govuk-link' %>
-            </li>
-            <li>
-              <% if @referer_query.nil? %>
-                <%= @dataset.organisation.title %>
-              <% else %>
-                <%= link_to t('.search'), "/search?#{@referrer}", class: 'govuk-link' %>
-              <% end %>
-            </li>
-            <li aria-current="page">
-              <%= shorten_title(@dataset.title) %>
-            </li>
-          </ol>
-        </nav>
+  <section id="dgu-breadcrumb">
+    <div class="govuk-grid-row">
+      <!-- Only display breadcrumb if the referrer host matches the application host  -->
+      <div class="govuk-grid-column-full">
+        <%= render "govuk_publishing_components/components/breadcrumbs", {
+          collapse_on_mobile: true,
+          breadcrumbs: [
+            {
+              title: t('.home'),
+              url: root_path
+            },
+            {
+              title: @referer_query.nil? ? @dataset.organisation.title : t('.search'),
+              url: @referer_query.nil? ? false : "/search?#{@referrer}"
+            },
+            {
+              title: shorten_title(@dataset.title)
+            }
+          ]
+        } %>
       </div>
     </div>
-  </div>
+  </section>
 <% end %>

--- a/app/views/datasets/_contact.html.erb
+++ b/app/views/datasets/_contact.html.erb
@@ -7,37 +7,44 @@
   mail = contact_email_is_email?(dataset) ? mail_to(contact_email_for(dataset), email_name, link_attrs) : link_to(email_name, contact_email_for(dataset), link_attrs)
   foi_mail = foi_email_is_email?(dataset) ? mail_to(foi_email_for(dataset), foi_name, link_attrs) : link_to(foi_name, foi_email_for(dataset), link_attrs)
 %>
-<section class="contact">
-  <h2 class="heading-medium">
-    <%= t('datasets.contact.contact') %>
-  </h2>
-
-  <% if contact_email_exists?(dataset) %>
-    <div class="column-one-half enquiries">
-      <h3 class="heading-small">
-        <%= t('datasets.contact.enquiries') %>
-      </h3>
-      <p>
-        <%= content_tag(:span, mail) if mail.present? %>
-      </p>
+<section id="dgu-contact">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: t('datasets.contact.contact'),
+        margin_bottom: 8,
+        heading_level: 2,
+        font_size: "m"
+      } %>
     </div>
-  <% end %>
 
-  <% if foi_details_exist?(dataset) %>
-    <div class="column-one-half foi">
-      <h3 class="heading-small">
-        <%= t('datasets.contact.foi_requests') %>
-      </h3>
+    <% if contact_email_exists?(dataset) %>
+      <div class="govuk-grid-column-one-half">
+        <%= render "govuk_publishing_components/components/heading", {
+          text: t('datasets.contact.enquiries'),
+          margin_bottom: 4,
+          heading_level: 3,
+          font_size: "s"
+        } %>
+        
+        <p class="govuk-body"><%= mail %></p>
+      </div>
+    <% end %>
 
-      <p>
-        <%= content_tag(:span, foi_mail) if foi_mail.present? %>
+    <% if foi_details_exist?(dataset) %>
+      <div class="column-one-half foi">
+        <%= render "govuk_publishing_components/components/heading", {
+          text: t('datasets.contact.foi_requests'),
+          margin_bottom: 4,
+          heading_level: 3,
+          font_size: "s"
+        } %>
+
+        <p class="govuk-body"><%= foi_mail %></p>
         <% if foi_web_address_for(dataset).present? %>
-          <%= content_tag(:span) do %>
-            <%= link_to(t('datasets.contact.foi_message'), foi_web_address_for(dataset), link_attrs) %>
-          <% end %>
+          <p class="govuk-body"><%= link_to(t('datasets.contact.foi_message'), foi_web_address_for(dataset), link_attrs) %></p>
         <% end %>
-
-      </p>
-    </div>
-  <% end %>
+      </div>
+    <% end %>
+  </div>
 </section>

--- a/app/views/datasets/_datafile_table.html.erb
+++ b/app/views/datasets/_datafile_table.html.erb
@@ -1,14 +1,16 @@
-<table class="dgu-datafiles">
-  <tr>
-    <th class="title small"><%= t('.link_to_data') %></th>
-    <th><%= t('.format') %></th>
-    <th><%= t('.file_added') %></th>
-    <th><%= t('.data_preview') %></th>
-  </tr>
-  <tbody>
+<table class="govuk-table govuk-!-margin-bottom-4">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header"><%= t('.link_to_data') %></th>
+      <th scope="col" class="govuk-table__header"><%= t('.format') %></th>
+      <th scope="col" class="govuk-table__header"><%= t('.file_added') %></th>
+      <th scope="col" class="govuk-table__header"><%= t('.data_preview') %></th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
     <% sort_by_created_at(datafiles).each_with_index do |datafile, index| %>
-      <tr class="<%= show_more?(index) %> dgu-datafile">
-        <td class="title small">
+      <tr class="<%= show_more?(index) %> js-datafile-visible govuk-table__row">
+        <td class="govuk-table__cell">
           <%= link_to datafile.url,
               :data => {
                 'ga-event' => "download",
@@ -16,39 +18,43 @@
                 'ga-publisher' => @dataset.organisation.name
               },
               class: 'govuk-link' do %>
-            <span class="visually-hidden">Download </span>
-            <%= (datafile.name ? datafile.name : 'Data') %>
-            <span class='visually-hidden'>, Format: <%= format_of(datafile) %>, Dataset: <%= @dataset.title %></span>
+                <span class="visually-hidden">Download </span>
+                <%= (datafile.name ? datafile.name : 'Data') %>
+                <span class='visually-hidden'>, Format: <%= format_of(datafile) %>, Dataset: <%= @dataset.title %></span>
+              <% end %>
+        </td>
+        
+        <td class="govuk-table__cell">
+          <% if datafile.format.blank? %>
+            <span class="dgu-secondary-text">N/A</span>
+          <% else %>
+            <%= datafile.format.upcase %>
+            <% if datafile.size %>
+              (<%= datafile.size.number_to_human_size %>)
+            <% end %>
           <% end %>
         </td>
-        <% if datafile.format.blank? %>
-          <td class="dgu-secondary-text">N/A</td>
-        <% else %>
-          <td><%= datafile.format.upcase %>
-          <% if datafile.size %>
-            (<%= datafile.size.number_to_human_size %> )
+
+        <td class="govuk-table__cell">
+          <% if datafile.created_at.present? %>
+              <%= format_timestamp(datafile.created_at) %>
+          <% else %>
+            <span class="dgu-secondary-text">Not available</span>
           <% end %>
-          </td>
-        <% end %>
-        <% if datafile.created_at.present? %>
-          <td>
-            <%= format_timestamp(datafile.created_at) %>
-          </td>
-        <% else %>
-          <td class="dgu-secondary-text">Not available</td>
-        <% end %>
-        <td class="datafiles__preview">
+        </td>
+
+        <td class="govuk-table__cell">
           <% if datafile.csv? %>
             <%= link_to datafile_preview_path(@dataset.uuid, @dataset.name, datafile.uuid),
                 :data => {
                   'ga-event' => 'preview',
                   'ga-format' => (datafile.format.presence || 'n/a').upcase,
                   'ga-publisher' => @dataset.organisation.name
-                  },
-                  class: 'govuk-link' do %>
+                },
+                class: 'govuk-link' do %>
                   Preview
                   <span class='visually-hidden'> CSV '<%= datafile.name %>', Dataset: <%= @dataset.title %></span>
-                  <% end %>
+                <% end %>
           <% elsif datafile.wms? && @dataset.inspire_dataset.present? %>
             <%= link_to t('.map_preview'), map_preview_url(@dataset, datafile) %>
           <% else %>
@@ -61,5 +67,5 @@
 </table>
 
 <% if datafiles.length > 5 && !browser.ie?(version: 8) %>
-  <button class="button secondary show-toggle" aria-label="Show more data links">Show more</button>
+  <button class="govuk-button govuk-button--secondary show-toggle" aria-label="Show more data links">Show more</button>
 <% end %>

--- a/app/views/datasets/_meta_data.html.erb
+++ b/app/views/datasets/_meta_data.html.erb
@@ -8,15 +8,15 @@
   <% end %>
 <% end %>
 
-<section class="meta-data">
-  <div class="grid-row">
-    <div class="column-two-thirds">
-      <div class="dgu-metadata__box dgu-metadata__box--in-dataset">
-        <dl class="metadata">
+<section id="dgu-metadata">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <div class="dgu-metadata dgu-metadata--in-dataset">
+        <dl>
           <% unless @dataset.released %>
             <dt><%= t('.availability') %>:</dt>
             <dd>
-              <span class="dgu-highlight">Not released</span>
+              <span class="dgu-highlight"><%= t('.not_released') %></span>
             </dd>
           <% end %>
           <dt><%= t('.published_by') %>:</dt>
@@ -61,47 +61,64 @@
           </dd>
         </dl>
 
-        <h3 class="heading-small">
-          <%= t('.summary') %>
-        </h3>
-        <div class="js-summary" style="line-height: 1.5em; overflow: hidden" property="dc:description">
+        <%= render "govuk_publishing_components/components/heading", {
+          text: t('.summary'),
+          margin_bottom: 1,
+          heading_level: 3,
+          font_size: "s"
+        } %>
+
+        <div class="js-summary" class="dataset-summary" property="dc:description">
           <%= to_markdown(@dataset.summary) %>
         </div>
       </div>
     </div>
 
-    <div class="column-one-third dgu-dataset-right">
-      <div class="dgu-dataset-right__sidebar__publisher_datasets">
-        <h3 class="heading-small"><%= t('.publisher_datasets') %></h3>
+    <div class="govuk-grid-column-one-third dgu-dataset-right">
+      <div class="govuk-!-margin-bottom-4">
+        <%= render "govuk_publishing_components/components/heading", {
+          text: t('.publisher_datasets'),
+          heading_level: 3,
+          font_size: "s"
+        } %>
         <%= link_to search_path(filters: { publisher: @dataset.organisation.title }), class: 'govuk-link' do %>
           <%= "All datasets from #{@dataset.organisation.title}" %>
         <% end %>
       </div>
 
       <% unless @related_datasets.empty? %>
-        <div class="dgu-dataset-right__sidebar">
-          <h3 class="heading-small"><%= t('.related_datasets') %></h3>
-          <ul>
-            <% @related_datasets.each do |dataset| %>
-              <li>
-                <%= link_to unescape(dataset.title), dataset_path(dataset.uuid, dataset.name), class: 'govuk-link' %>
-              </li>
-            <% end %>
-          </ul>
+        <%
+          related_list_items = []
+          @related_datasets.each do |dataset|
+            related_list_items << sanitize(link_to unescape(dataset.title), dataset_path(dataset.uuid, dataset.name), class: "govuk-link")
+          end
+        %>
+
+        <div class="govuk-!-margin-bottom-4">
+          <%= render "govuk_publishing_components/components/heading", {
+            text: t('.related_datasets'),
+            heading_level: 3,
+            font_size: "s"
+          } %>
+          <%= render "govuk_publishing_components/components/list", {
+            items: related_list_items
+          } %>
         </div>
       <% end %>
 
-      <h3 class="heading-small"><%= t('.search_gov_data') %></h3>
-      <form action="/search" method="GET" class="dgu-search-box">
-        <label for="q" class="visuallyhidden"><%= t('.accessibility.search_box_label') %></label>
-        <input id="q"
-               name="q"
-               type="text"
-               class="form-control dgu-search-box__input"/><button type="submit"
-                                                                   class="dgu-search-box__button">
-                                                            <%= t('.accessibility.search_box_button')%>
-                                                           </button>
-      </form>
+      <div class="govuk-!-margin-bottom-4">
+        <%= render "govuk_publishing_components/components/heading", {
+          text: t('.search_gov_data'),
+          heading_level: 3,
+          font_size: "s"
+        } %>
+
+        <form action="/search" method="GET">
+          <%= render "govuk_publishing_components/components/search", {
+            label_text: t('.accessibility.search_box_label')
+          } %>
+        </form>
+      </div>
     </div>
   </div>
 </section>

--- a/app/views/datasets/_meta_data.html.erb
+++ b/app/views/datasets/_meta_data.html.erb
@@ -11,14 +11,6 @@
 <section class="meta-data">
   <div class="grid-row">
     <div class="column-two-thirds">
-      <h1 class="heading-large" property="dc:title">
-        <%= unescape(@dataset.title) %>
-      </h1>
-    </div>
-  </div>
-
-  <div class="grid-row">
-    <div class="column-two-thirds">
       <div class="dgu-metadata__box dgu-metadata__box--in-dataset">
         <dl class="metadata">
           <% unless @dataset.released %>

--- a/app/views/datasets/_no_datafiles.html.erb
+++ b/app/views/datasets/_no_datafiles.html.erb
@@ -1,10 +1,12 @@
-<div class="panel panel-border-narrow">
-  <p><%= t('datasets.show.not_released') %><br />
-  <% if contact_information_exists?(dataset) %>
-    <%= t('datasets.show.contact_the_publisher') %>
-  <% else %>
-    <%= t('datasets.show.contact_the_team') %>
-    <%= link_to 'data.gov.uk/support', support_path, class: 'govuk-link' %>
-    <%= t('datasets.show.if_you_have_questions') %>
-  <% end %>
+<div class="govuk-details__text govuk-!-margin-bottom-4">
+  <p class="govuk-body"><%= t('datasets.show.not_released') %></p>
+  <p class="govuk-body">
+    <% if contact_information_exists?(dataset) %>
+      <%= t('datasets.show.contact_the_publisher') %>
+    <% else %>
+      <%= t('datasets.show.contact_the_team') %>
+      <%= link_to 'data.gov.uk/support', support_path, class: 'govuk-link' %>
+      <%= t('datasets.show.if_you_have_questions') %>
+    <% end %>
+  </p>
 </div>

--- a/app/views/datasets/_supporting_docs.html.erb
+++ b/app/views/datasets/_supporting_docs.html.erb
@@ -1,26 +1,39 @@
-<section class="supporting docs">
-  <h2 class="heading-medium">
-    <%= t('.supporting_docs')%>
-  </h2>
+<% table_rows = [] %>
 
-  <table>
-    <thead>
-    <tr>
-      <th class="title"><%= t('.link_to_doc')%></th>
-      <th><%= t('.format')%></th>
-      <th><%= t('.date_added')%></th>
-    </tr>
-    </thead>
-    <tbody>
-    <% dataset.docs.each do |doc| %>
-      <tr>
-        <td class="title">
-          <a href="<%= doc.url%>" class="govuk-link"><%= doc.name %></a>
-        </td>
-        <td><%= doc.format or "N/A" %></td>
-        <td><%= format_timestamp(doc.created_at) or "N/A" %></td>
-      </tr>
-    <% end %>
-    </tbody>
-  </table>
+<% dataset.docs.each do |doc| %>
+<% table_rows << [
+  {
+    text: sanitize(link_to doc.name, doc.url, class: "govuk-link")
+  },
+  {
+    text: doc.format || "N/A"
+  },
+  {
+    text: format_timestamp(doc.created_at) || "N/A"
+  },
+] %>
+<% end %>
+
+<section id="supporting-docs">
+  <%= render "govuk_publishing_components/components/heading", {
+    text: t('.supporting_docs'),
+    margin_bottom: 4,
+    heading_level: 2,
+    font_size: "m"
+  } %>
+
+  <%= render "govuk_publishing_components/components/table", {
+    head: [
+      {
+        text: t('.link_to_doc')
+      },
+      {
+        text: t('.format')
+      },
+      {
+        text: t('.date_added')
+      },
+    ],
+    rows: table_rows
+  } %>
 </section>

--- a/app/views/datasets/_timeseries_data.html.erb
+++ b/app/views/datasets/_timeseries_data.html.erb
@@ -14,5 +14,6 @@
 %>
 
 <%= render "govuk_publishing_components/components/accordion", {
+  id: "dgu-datafiles-year",
   items: accordion_items
 } %>

--- a/app/views/datasets/_timeseries_data.html.erb
+++ b/app/views/datasets/_timeseries_data.html.erb
@@ -1,34 +1,18 @@
-<% if browser.ie?(8) %>
-  <ul>
-    <% group_and_order(datafiles).each do |year, datafiles| %>
-      <li>
-        <div>
-          <h3 class="heading-small">
-            <%= year.presence || "Other data files" %>
-          </h3>
-        </div>
-        <%= render partial: 'datafile_table', locals: { datafiles: datafiles } %>
-      <% end %>
-      </li>
-  </ul>
-<% else %>
-  <ul>
-    <% group_and_order(datafiles).each do |year, datafiles| %>
-      <li class="showHide">
-        <div class="year-expand showHide-control">
-          <h3 class="heading-small">
-            <button class="dgu-datafiles__year button secondary">
-              <%= year.presence || "Other data files" %>
-            </button>
-          </h3>
-          <div>
-            <button class="dgu-datafiles__expand js-expand button secondary">+</button>
-          </div>
-        </div>
-        <div class="showHide-content" style="display:none">
-          <%= render partial: 'datafile_table', locals: { datafiles: datafiles } %>
-        </div>
-      <% end %>
-      </li>
-  </ul>
-<% end %>
+<%
+  accordion_items = []
+
+  group_and_order(datafiles).each do |year, datafiles|
+    accordion_items << {
+      heading: {
+        text: year.presence || t('.other_data_files')
+      },
+      content: {
+        html: (render partial: 'datafile_table', locals: { datafiles: datafiles })
+      }
+    }
+  end
+%>
+
+<%= render "govuk_publishing_components/components/accordion", {
+  items: accordion_items
+} %>

--- a/app/views/datasets/show.html.erb
+++ b/app/views/datasets/show.html.erb
@@ -8,78 +8,96 @@
   <%= render 'breadcrumb' %>
 <% end%>
 
-<main role="main" id="content">
-  <div>
-    <%= render "meta_data" %>
-
-    <div class="grid-row">
-      <div class="column-full">
-        <section class="dgu-datalinks">
-          <h2 class="heading-medium"><%= t('.data_links')%>
-          <% unless @timeseries_datafiles.empty? %>
-            <!-- accordions for time series datasets -->
-            <% if !browser.ie?(8) %>
-              <span class="showHide-open-all"><%= t('.open_all') %></span>
-            <% end %>
-          <% end %>
-          </h2>
-
-          <% unless @timeseries_datafiles.empty? %>
-            <%= render partial: "timeseries_data", locals: { datafiles: @timeseries_datafiles } %>
-          <% end %>
-
-          <% unless @non_timeseries_datafiles.empty? %>
-            <%= render partial: "non_timeseries_data", locals: { datafiles: @non_timeseries_datafiles } %>
-          <% end %>
-
-          <% if @dataset.datafiles.empty? %>
-            <%= render partial: "no_datafiles", locals: { dataset: @dataset } %>
-          <% end %>
-
-        </section>
-      </div>
+<main role="main" id="main-content" class="govuk-main-wrapper">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= render "govuk_publishing_components/components/heading", {
+          text: unescape(@dataset.title),
+          margin_bottom: 8,
+          heading_level: 1,
+          font_size: "l"
+        } %>
     </div>
-
-    <% if @dataset.description.present? || @dataset.inspire_dataset.present? %>
-      <%= render partial: "additional_info", locals: { dataset: @dataset } %>
-    <% end %>
-
-    <% unless @dataset.docs.empty? %>
-      <%= render partial: "supporting_docs", locals: { dataset: @dataset } %>
-    <% end %>
-
-    <% if contact_information_exists?(@dataset) %>
-      <%= render partial: "contact", locals: { dataset: @dataset } %>
-    <% end %>
-
-    <% if @dataset.licence_custom.present? %>
-      <section class="dgu-licence-info">
-        <div class="grid-row">
-          <div class="column-full">
-            <h2 class="heading-medium" id="licence-info">
-              <%= t('.licence_information') %>
-            </h2>
-            <p class="dgu-licence-info__notes">
-              <%= to_markdown(@dataset.licence_custom) %>
-            </p>
-          </div>
-        </div>
-      </section>
-    <% end %>
-
-    <% if @dataset.editable? %>
-      <section>
-        <div class="grid-row">
-          <div class="column-full">
-            <h2 class="heading-medium"><%= t('datasets.publishers.title') %></h2>
-            <div role="note" aria-label="Publisher information" class="panel panel-border-narrow text">
-              <p><%= t('datasets.publishers.information') %></p>
-            </div>
-            <p><%= link_to t('datasets.publishers.button'), "/dataset/edit/#{@dataset.legacy_name}", role: 'button', class: 'govuk-button', rel: %w(nofollow) %></p>
-          </div>
-        </div>
-      </section>
-    <% end %>
-
   </div>
+
+  <%= render "meta_data" %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <section id="dgu-datalinks">
+        <%= render "govuk_publishing_components/components/heading", {
+          text: t('.data_links'),
+          margin_bottom: 4,
+          heading_level: 2,
+          font_size: "m"
+        } %>
+
+        <% unless @timeseries_datafiles.empty? %>
+          <%= render partial: "timeseries_data", locals: { datafiles: @timeseries_datafiles } %>
+        <% end %>
+
+        <% unless @non_timeseries_datafiles.empty? %>
+          <%= render partial: "non_timeseries_data", locals: { datafiles: @non_timeseries_datafiles } %>
+        <% end %>
+
+        <% if @dataset.datafiles.empty? %>
+          <%= render partial: "no_datafiles", locals: { dataset: @dataset } %>
+        <% end %>
+
+      </section>
+    </div>
+  </div>
+
+  <% if @dataset.description.present? || @dataset.inspire_dataset.present? %>
+    <%= render partial: "additional_info", locals: { dataset: @dataset } %>
+  <% end %>
+
+  <% unless @dataset.docs.empty? %>
+    <%= render partial: "supporting_docs", locals: { dataset: @dataset } %>
+  <% end %>
+
+  <% if contact_information_exists?(@dataset) %>
+    <%= render partial: "contact", locals: { dataset: @dataset } %>
+  <% end %>
+
+  <% if @dataset.licence_custom.present? %>
+    <section id="dgu-licence-info">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+          <%= render "govuk_publishing_components/components/heading", {
+            text: t('.licence_information'),
+            margin_bottom: 4,
+            heading_level: 2,
+            font_size: "m"
+          } %>
+          <p class="dgu-licence-info__notes">
+            <%= to_markdown(@dataset.licence_custom) %>
+          </p>
+        </div>
+      </div>
+    </section>
+  <% end %>
+
+  <% if @dataset.editable? %>
+    <section id="dgu-editable">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+          <%= render "govuk_publishing_components/components/heading", {
+            text: t('datasets.publishers.title'),
+            margin_bottom: 4,
+            heading_level: 2,
+            font_size: "m"
+          } %>
+          
+          <div class="govuk-details__text govuk-!-margin-bottom-4">
+            <%= t('datasets.publishers.information') %>
+          </div>
+          <%= render "govuk_publishing_components/components/button", {
+            text: t('datasets.publishers.button'),
+            href: "/dataset/edit/#{@dataset.legacy_name}"
+          } %>
+        </div>
+      </div>
+    </section>
+  <% end %>
 </main>

--- a/app/views/search/search.html.erb
+++ b/app/views/search/search.html.erb
@@ -59,7 +59,7 @@
                 <h2 class="govuk-heading-m">
                   <%= link_to dataset.title, dataset_path(dataset.uuid, dataset.name), class: 'govuk-link' %>
                 </h2>
-                <dl class="dgu-metadata__box">
+                <dl class="dgu-metadata">
                   <% unless dataset.released? %>
                     <dt><%= t('.meta_data_box.availability') %>:</dt>
                     <dd>

--- a/config/locales/views/datasets/en.yml
+++ b/config/locales/views/datasets/en.yml
@@ -51,6 +51,7 @@ en:
       map_preview: "Preview on map"
     meta_data:
       availability: "Availability"
+      not_released: "Not released"
       publisher_datasets: "More from this publisher"
       published_by: "Published by"
       last_updated: "Last updated"

--- a/config/locales/views/datasets/en.yml
+++ b/config/locales/views/datasets/en.yml
@@ -87,3 +87,5 @@ en:
       title: "Edit this dataset"
       information: "You must have an account for this publisher on data.gov.uk to make any changes to a dataset."
       button: "Sign in"
+    non_timeseries_data:
+      other_data_files: "Other data files"

--- a/config/locales/views/datasets/en.yml
+++ b/config/locales/views/datasets/en.yml
@@ -87,5 +87,5 @@ en:
       title: "Edit this dataset"
       information: "You must have an account for this publisher on data.gov.uk to make any changes to a dataset."
       button: "Sign in"
-    non_timeseries_data:
+    timeseries_data:
       other_data_files: "Other data files"

--- a/spec/controllers/datasets_controller_spec.rb
+++ b/spec/controllers/datasets_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe DatasetsController, type: :controller do
         request.env["HTTP_REFERER"] = "http://test.host/search?q=fancypants"
         get :show, params: { uuid: dataset.uuid, name: dataset.name }
 
-        expect(response.body).to have_css("div.breadcrumbs")
+        expect(response.body).to have_css("#dgu-breadcrumb")
         expect(response.body).to_not have_css("li", text: "Ministry of Defence")
         expect(response.body).to have_css("li", text: "Search")
       end
@@ -26,7 +26,7 @@ RSpec.describe DatasetsController, type: :controller do
         request.env["HTTP_REFERER"] = "http://unknown.host/search?q=fancypants"
         get :show, params: { uuid: dataset.uuid, name: dataset.name }
 
-        expect(response.body).to have_css("div.breadcrumbs")
+        expect(response.body).to have_css("#dgu-breadcrumb")
         expect(response.body).to have_css("li", text: "Ministry of Defence")
         expect(response.body).to_not have_css("li", text: "Search")
       end

--- a/spec/features/dataset_show_page_spec.rb
+++ b/spec/features/dataset_show_page_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature "Dataset page", type: :feature, elasticsearch: true do
       dataset = build :dataset, :with_ogl_licence
       index_and_visit(dataset)
 
-      within("section.meta-data") do
+      within("#dgu-metadata") do
         expect(page)
           .to have_link("Open Government Licence",
                         href: "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/")
@@ -35,13 +35,13 @@ RSpec.feature "Dataset page", type: :feature, elasticsearch: true do
 
       index_and_visit(dataset)
 
-      within("section.meta-data") do
+      within("#dgu-metadata") do
         expect(page)
           .to have_link("View licence information",
                         href: "#licence-info")
       end
 
-      within("section.dgu-licence-info") do
+      within("#dgu-licence-info") do
         expect(page).to have_content("Special case")
       end
     end
@@ -50,7 +50,7 @@ RSpec.feature "Dataset page", type: :feature, elasticsearch: true do
       dataset = build :dataset, :with_custom_licence
       index_and_visit(dataset)
 
-      within("section.meta-data") do
+      within("#dgu-metadata") do
         expect(page)
           .to have_content("Other Licence")
 
@@ -59,7 +59,7 @@ RSpec.feature "Dataset page", type: :feature, elasticsearch: true do
                         href: "#licence-info")
       end
 
-      within("section.dgu-licence-info") do
+      within("#dgu-licence-info") do
         expect(page).to have_content("Special case")
       end
     end
@@ -68,7 +68,7 @@ RSpec.feature "Dataset page", type: :feature, elasticsearch: true do
       dataset = build :dataset, :with_custom_licence_brackets
       index_and_visit(dataset)
 
-      within("section.meta-data") do
+      within("#dgu-metadata") do
         expect(page)
           .to have_content("Other Licence")
 
@@ -77,7 +77,7 @@ RSpec.feature "Dataset page", type: :feature, elasticsearch: true do
                         href: "#licence-info")
       end
 
-      within("section.dgu-licence-info") do
+      within("#dgu-licence-info") do
         expect(page).to have_content("Special case")
       end
     end
@@ -86,7 +86,7 @@ RSpec.feature "Dataset page", type: :feature, elasticsearch: true do
       dataset = build :dataset, :with_custom_licence_brackets_middle
       index_and_visit(dataset)
 
-      within("section.meta-data") do
+      within("#dgu-metadata") do
         expect(page)
           .to have_content("Other Licence")
 
@@ -95,7 +95,7 @@ RSpec.feature "Dataset page", type: :feature, elasticsearch: true do
                         href: "#licence-info")
       end
 
-      within("section.dgu-licence-info") do
+      within("#dgu-licence-info") do
         expect(page).to have_content("Special case")
       end
     end
@@ -104,7 +104,7 @@ RSpec.feature "Dataset page", type: :feature, elasticsearch: true do
       dataset = build :dataset, licence_title: "My Licence"
       index_and_visit(dataset)
 
-      within("section.meta-data") do
+      within("#dgu-metadata") do
         expect(page)
           .to have_content("My Licence")
       end
@@ -114,7 +114,7 @@ RSpec.feature "Dataset page", type: :feature, elasticsearch: true do
       dataset = build :dataset, licence_url: "http://licence.com"
       index_and_visit(dataset)
 
-      within("section.meta-data") do
+      within("#dgu-metadata") do
         expect(page)
           .to have_link("http://licence.com",
                         href: "http://licence.com")
@@ -125,7 +125,7 @@ RSpec.feature "Dataset page", type: :feature, elasticsearch: true do
       dataset = build :dataset
       index_and_visit(dataset)
 
-      within("section.meta-data") do
+      within("#dgu-metadata") do
         expect(page)
           .to have_content("None")
       end
@@ -271,7 +271,7 @@ RSpec.feature "Dataset page", type: :feature, elasticsearch: true do
       expect(page).to have_css("h2", text: "Contact")
       expect(page).to have_css("h3", text: "Enquiries")
 
-      within("section.contact .enquiries") do
+      within("#dgu-contact") do
         expect(page).to have_link(dataset.contact_name, href: "mailto:#{dataset.contact_email}")
       end
     end
@@ -286,7 +286,7 @@ RSpec.feature "Dataset page", type: :feature, elasticsearch: true do
       expect(page).to have_css("h2", text: "Contact")
       expect(page).to have_css("h3", text: "Enquiries")
 
-      within("section.contact .enquiries") do
+      within("#dgu-contact") do
         expect(page).to have_link(dataset.organisation.contact_name, href: "mailto:#{dataset.organisation.contact_email}")
       end
     end
@@ -308,7 +308,7 @@ RSpec.feature "Dataset page", type: :feature, elasticsearch: true do
       expect(page).to have_css("h2", text: "Contact")
       expect(page).to have_css("h3", text: "Freedom of Information (FOI) requests")
 
-      within("section.contact .foi") do
+      within("#dgu-contact") do
         expect(page).to have_link(dataset.foi_name, href: "mailto:#{dataset.foi_email}")
         expect(page).to have_link("Freedom of information requests for this dataset", href: dataset.foi_web)
       end
@@ -325,7 +325,7 @@ RSpec.feature "Dataset page", type: :feature, elasticsearch: true do
       expect(page).to have_css("h2", text: "Contact")
       expect(page).to have_css("h3", text: "Freedom of Information (FOI) requests")
 
-      within("section.contact .foi") do
+      within("#dgu-contact") do
         expect(page).to have_link(dataset.organisation.foi_name, href: "mailto:#{dataset.organisation.foi_email}")
         expect(page).to have_link("Freedom of information requests for this dataset", href: dataset.organisation.foi_web)
       end
@@ -339,12 +339,12 @@ RSpec.feature "Dataset page", type: :feature, elasticsearch: true do
       index_and_visit(dataset)
 
       expect(page).to have_css("js-show-more-datafiles", count: 0)
-      expect(page).to have_css(".dgu-datafile", count: 5)
+      expect(page).to have_css(".js-datafile-visible", count: 5)
       expect(page).to have_css(".show-toggle", text: "Show more")
 
       find(".show-toggle").click
 
-      expect(page).to have_css(".dgu-datafile", count: 20)
+      expect(page).to have_css(".js-datafile-visible", count: 20)
       expect(page).to have_css(".show-toggle", text: "Show less")
     end
   end
@@ -357,21 +357,23 @@ RSpec.feature "Dataset page", type: :feature, elasticsearch: true do
 
     scenario "are grouped by year when they contain timeseries datafiles" do
       index_and_visit(dataset)
-      expect(page).to have_css(".dgu-datafiles__year", count: 2)
+      expect(page).to have_css("#dgu-datafiles-year")
 
-      correct_order = [
-        Time.zone.parse(datafile2["start_date"]).year.to_s,
-        Time.zone.parse(datafile1["start_date"]).year.to_s,
-      ]
+      within("#dgu-datafiles-year") do
+        correct_order = [
+          Time.zone.parse(datafile2["start_date"]).year.to_s,
+          Time.zone.parse(datafile1["start_date"]).year.to_s,
+        ]
 
-      actual_order = all("button.dgu-datafiles__year").map(&:text)
-      expect(actual_order).to eq correct_order
+        actual_order = all(".govuk-accordion__section-button").map(&:text)
+        expect(actual_order).to eq correct_order
+      end
     end
 
     scenario "are not grouped when they contain non timeseries datafiles" do
       dataset = build :dataset, :with_datafile
       index_and_visit(dataset)
-      expect(page).to have_css(".dgu-datalinks__year", count: 0)
+      expect(page).to have_css("#dgu-datafiles-year", count: 0)
     end
   end
 


### PR DESCRIPTION
## What
Update the markup, classnames and styling on the individual dataset view and associated components and partials. Whilst there are mostly intended to be very few discernible difference between this PR and production, there are a number of visual changes introduced as a consequence of updating parts of the frontend tooling:

- The search box to the right of the metadata component is using the govuk search component with a blue button instead of a black one
- Several instances of data lists have been wrapped in the govuk details component instead of using custom styling to introduce the grey left-hand border synonymous with govuk detail components, which changes the width of some of these sections
- The "show more" link for if the datafile table is too long has been replaced by a secondary govuk button

## Why
DGU Find is currently using govuk elements, an outdated implementation of the govuk design system. This PR is one of several that attempts to slowly remove the elements implementation and replace it with up to date implementations from govuk frontend and govuk publishing components.

**Card:** https://trello.com/c/h0XbWxq8/233-update-markup-on-find-dataset-page