### PR TITLE
Update markup for data preview view

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -29,6 +29,7 @@ $govuk-use-legacy-palette: false;
 @import 'govuk_publishing_components/components/_checkboxes';
 @import 'govuk_publishing_components/components/_notice';
 @import 'govuk_publishing_components/components/_heading';
+@import 'govuk_publishing_components/components/_table';
 @import 'govuk_publishing_components/components/_govspeak';
 @import 'govuk_publishing_components/components/_radio';
 @import 'govuk_publishing_components/components/_button';

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -269,27 +269,6 @@
 // preview page
 
 .dgu-datafile-preview {
-  border: 5px solid #dee0e2;
-  margin: 30px 0 30px;
-  margin-top: 40px;
-  table {
-    border: 2px solid $panel-colour;
-    background: #fff;
-    th, td {
-      padding-left: 20px;
-      padding-right: 20px;
-    }
-    th, tr:nth-child(2n) {
-      background-color: $highlight-colour;
-    }
-    tr td {
-      border-bottom: none;
-    }
-  }
-}
-.dgu-datafile-preview__inner {
-  border: 1px solid $panel-colour;
-  padding: 4px;
   overflow: auto;
 }
 

--- a/app/helpers/previews_helper.rb
+++ b/app/helpers/previews_helper.rb
@@ -6,4 +6,8 @@ module PreviewsHelper
       t(".download_file")
     end
   end
+
+  def is_numeric(string)
+    string.match?(/\d/)
+  end
 end

--- a/app/views/previews/show.html.erb
+++ b/app/views/previews/show.html.erb
@@ -1,16 +1,46 @@
 <% content_for :page_title do %><%= @datafile.name %><% end %>
 
-<main role="main" id="content">
-  <div class="grid-row">
-    <div class="column-two-thirds">
+<main role="main" id="main-content" class="govuk-main-wrapper">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
       <%= link_to t('.back_link'), dataset_path(@dataset.uuid, @dataset.name), class: 'link-back govuk-link' %>
-      <h1 class="heading-large">
-        <%= @dataset.title %>
-        <span class="heading-secondary dgu-home-spacer__bottom"><%= @datafile.name %></span>
-      </h1>
+
+      <%= render "govuk_publishing_components/components/heading", {
+        text: sanitize("#{@dataset.title}<span class=\"govuk-caption-l gem-c-title__context\">#{@datafile.name}</span>"),
+        margin_bottom: 8,
+        heading_level: 1,
+        font_size: "l"
+      } %>
 
       <% if @datafile.csv? && @datafile.preview.exists? %>
-        <p>You're previewing the first <%= @datafile.preview.line_count %> rows of this file.</p>
+        <%
+          table_rows = []
+          table_headings = []
+
+          if @datafile.preview.rows.present?
+            @datafile.preview.rows.each do |row|
+              table_row = []
+              row.each do |col|
+                table_row << {
+                  text: col,
+                  format: is_numeric(col) ? "numeric" : false
+                }
+              end
+              table_rows <<  table_row
+            end
+          end
+
+          if @datafile.preview.headers.present?
+            @datafile.preview.headers.each_with_index do |col, index|
+              table_headings << {
+                text: col,
+                format: (table_rows.select {|row| row[index][:format] == "numeric"}).length > 0 ? "numeric" : false
+              }
+            end
+          end
+        %>
+        
+        <p class="govuk-body"><%= t('.preview_line', line_count: @datafile.preview.line_count) %></p>
         <%= link_to download_text(@dataset, @datafile), @datafile.url,
           class: "govuk-button",
           data: {
@@ -21,40 +51,29 @@
         %>
 
         <% if @dataset.organogram? %>
-          <%= link_to "View the full organogram", "#organogram", class: "button" %>
+          <%= link_to t('.view_full_organogram'), "#organogram", class: "govuk-button" %>
         <% end %>
-    </div>
-    <div class = 'column-full'>
-      <section class="dgu-datafile-preview">
-        <div class="dgu-datafile-preview__inner">
-          <table>
-            <thead>
-              <tr>
-                <% @datafile.preview.headers.each do |col| %>
-                  <th><%= col %></th>
-                <% end %>
-              </tr>
-            </thead>
-            <tbody>
-              <% @datafile.preview.rows.each do |row| %>
-                <tr>
-                  <% row.each do |col| %>
-                    <td><%= col %></td>
-                  <% end %>
-                </tr>
-              <% end %>
-            </tbody>
-          </table>
-        </div>
-        <% else %>
-          <p><%= "#{t('.no_preview_avail')} \"#{@datafile.name}\"" %></p>
-        <% end %>
-      </section>
-
-      <% if @dataset.organogram? %>
-        <section id="organogram" data-csv-url="<%= @datafile.url %>">
-        </section>
+      <% else %>
+        <p class="govuk-body"><%= "#{t('.no_preview_avail')} \"#{@datafile.name}\"" %></p>
       <% end %>
     </div>
+
+    <% if @datafile.csv? && @datafile.preview.exists? %>
+      <div class="govuk-grid-column-full">
+        <section id="dgu-preview">
+          <div class="dgu-datafile-preview">
+            <%= render "govuk_publishing_components/components/table", {
+              head: table_headings,
+              rows: table_rows
+            } %>
+          </div>
+        </section>
+
+        <% if @dataset.organogram? %>
+          <section id="organogram" data-csv-url="<%= @datafile.url %>">
+          </section>
+        <% end %>
+      </div>
+    <% end %>
   </div>
 </main>

--- a/config/locales/views/datasets/en.yml
+++ b/config/locales/views/datasets/en.yml
@@ -2,6 +2,8 @@ en:
   previews:
     show:
       back_link: "Back to dataset"
+      preview_line: "You're previewing the first %{line_count} rows of this file."
+      view_full_organogram: "View the full organogram" 
       download_file: "Download this file"
       this_file: "this file."
       no_preview_avail: "Currently there is no preview available for"


### PR DESCRIPTION
## What
Update the markup, classnames and styling on the datafile preview view. Whilst there are mostly intended to be no discernible difference between this PR and production, it does replace the custom preview table with the govuk table component.

### Before
![Screenshot 2020-08-04 at 10 29 10](https://user-images.githubusercontent.com/64783893/89277982-6db2b980-d63d-11ea-95c8-924803b9f774.png)

### After
![Screenshot 2020-08-04 at 10 28 36](https://user-images.githubusercontent.com/64783893/89278004-74413100-d63d-11ea-88aa-b471f04f2041.png)

## Why
DGU Find is currently using govuk elements, an outdated implementation of the govuk design system. This PR is one of several that attempts to slowly remove the elements implementation and replace it with up to date implementations from govuk frontend and govuk publishing components.

**Card:** https://trello.com/c/jGqwrZ3n/248-update-markup-on-find-preview-pages