### PR TITLE
Update copy for support and data request pages

### DIFF
--- a/app/views/pages/support.html.erb
+++ b/app/views/pages/support.html.erb
@@ -10,25 +10,23 @@
     <div class="column-two-thirds">
       <h1 class='heading-large'>Support</h1>
 
-      <p>
-        The Government Digital Service (GDS) maintains the service behind data.gov.uk and helps
-        publishers to manage and update their data. GDS provides operational support
-        from 9am to 5pm, Monday to Friday.
-      </p>
+      <p>The Government Digital Service (GDS) maintains the technical service behind data.gov.uk
+         and helps government publishers to manage and update their data.</p>
 
-      <p>
-        For questions about a dataset, you can contact the publisher directly if they’ve provided contact details on the
-        dataset page.
-      </p>
+      <p>It cannot</p>
+      <ul class="list list-bullet">
+        <li>help you find or research datasets</li>
+        <li>provide personal information or medical records</li>
+        <li>combine data from multiple datasets</li>
+      </ul>
 
-      <p>
-        Please give us your feedback about the site using <%= link_to "our survey", "http://www.smartsurvey.co.uk/s/3SEXD/", class: "govuk-link" %>.
-      </p>
+      <p>For questions about <%= link_to "GOV.UK", "https://www.gov.uk/", class: "govuk-link" %> check the GOV.UK help pages
+         or <%= link_to "contact", "https://www.gov.uk/contact/govuk", class: "govuk-link" %> the team.</p>
 
-      <p>
-        To get answers about <%= link_to "GOV.UK", "https://www.gov.uk/", class: "govuk-link" %> you can check the GOV.UK help pages
-        or <%= link_to "contact", "https://www.gov.uk/contact/govuk", class: "govuk-link" %> the team.
-      </p>
+      <p>The NHS <%= link_to "publishes its own data.", "https://digital.nhs.uk/data-and-information/data-collections-and-data-sets/data-sets", class: "govuk-link" %></p>
+
+      <h1 class="heading-medium">If you have a question about a dataset</h1>
+      <p>If you have a question about a specific dataset, contact the publisher directly.</p>
 
       <form action="tickets/new" method="get">
         <div class="form-group">
@@ -45,7 +43,7 @@
 
             <div class="multiple-choice">
               <input id="support-2" type="radio" name="support" value="data">
-              <label for="support-2">I have a data request</label>
+              <label for="support-2">I want government to publish new data</label>
             </div>
 
             <div class="multiple-choice">
@@ -58,6 +56,7 @@
         <input class="govuk-button" type="submit" value="Continue">
       </form>
 
+      <p>Please give us your feedback about the site using <%= link_to "our survey", "http://www.smartsurvey.co.uk/s/3SEXD/", class: "govuk-link" %>.</p>
     </div>
   </div>
 </main>

--- a/config/locales/views/tickets/en.yml
+++ b/config/locales/views/tickets/en.yml
@@ -2,7 +2,7 @@ en:
   tickets:
     new:
       problem: "There was a problem"
-      data_request: "Send a data request"
+      data_request: "Ask the government to publish new data"
       feedback_request: "Report a problem"
       publish_request: "Publish for an organisation"
       your_message: "Your message"

--- a/spec/features/support_spec.rb
+++ b/spec/features/support_spec.rb
@@ -26,13 +26,13 @@ RSpec.feature "Support tickets", type: :feature do
     end
   end
 
-  feature "Asking for data" do
+  feature "Asking government to publish new data" do
     let(:ticket) { build :ticket, support: "data" }
 
     scenario "Send a support ticket to Zendesk" do
-      choose "I have a data request"
+      choose "I want government to publish new data"
       click_on "Continue"
-      expect(page).to have_content "Send a data request"
+      expect(page).to have_content "Ask the government to publish new data"
 
       fill_in "example-content", with: ticket.content
       fill_in "example-name", with: ticket.name
@@ -72,7 +72,7 @@ RSpec.feature "Support tickets", type: :feature do
     let(:ticket) { build :ticket, email: "foo" }
 
     scenario "Show the errors in the ticket form" do
-      choose "I have a data request"
+      choose "I want government to publish new data"
       click_on "Continue"
       fill_in "example-email", with: ticket.email
 


### PR DESCRIPTION
This updates the copy on the support and data publication request pages to clarify what a "data request" is in this context, and add some additional information on the purposes of DGU.

[trello](https://trello.com/c/ZL9fhZwK/2090-2-change-content-of-datagovuk-support-page)