### PR TITLE
Fix Elasticsearch URI not found in VCAP_SERVICES

### DIFF
--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -4,7 +4,7 @@ host = es_config[:host]
 
 if host.blank?
   vcap = JSON.parse(es_config[:vcap_services])
-  host = vcap.dig(:elasticsearch, 0, :credentials, :uri)
+  host = vcap.dig("elasticsearch", 0, "credentials", "uri")
 end
 
 raise StandardError.new("No elasticsearch environment variables found") if host.blank?


### PR DESCRIPTION
Rails 6 deprecated the use of string keys to access the hashes generated
by config_for, so a change was done to use symbols instead.

However, an incorrect change was also done to the way the keys of
VCAP_SERVICES are accessed, which must be done with strings, resulting
in the app not being able to find the Elasticsearch URI.

Revert keys to strings to restore correct behaviour.