### PR TITLE
Add CKAN maintenance page

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -8,6 +8,10 @@ class PagesController < ApplicationController
     @datafiles_count_by_format = Dataset.datafiles["formats"]["buckets"]
   end
 
+  def ckan_maintenance
+    render "ckan_maintenance", status: :service_unavailable
+  end
+
 private
 
   def get_datasets_count

--- a/app/views/pages/ckan_maintenance.html.erb
+++ b/app/views/pages/ckan_maintenance.html.erb
@@ -1,0 +1,22 @@
+<% content_for :page_title do %>
+  CKAN maintenance
+<% end %>
+
+<main role="main" id="content">
+
+  <div class="text">
+   <h1 class="heading-large">
+     Data.gov.uk publishing freeze
+   </h1>
+
+  <p>data.gov.uk publishing freeze – 6:30am on Thursday 27 August to 11:59pm on Friday 28 August 2020</p>
+  <p>We’re making some improvements to your data.gov.uk publishing account.</p>
+  <p>You will not be able to publish, edit or delete datasets while we upgrade the data publishing tool.</p>
+  <p>There will not be any downtime for visitors to data.gov.uk – only publishing will be affected.</p>
+  <h2 class="heading-medium">Why we need to upgrade</h2>
+  <p>We’re upgrading to CKAN 2.8. This will make data.gov.uk more stable for users and publishers. It will also allow us to make further improvements to the publishing tool later this year.</p>
+  <p>You can see a detailed list of the CKAN 2.8 changes at: <a href="https://github.com/ckan/ckan/blob/2.8/CHANGELOG.rst#v283-2019-07-03">https://github.com/ckan/ckan/blob/2.8/CHANGELOG.rst#v283-2019-07-03</a></p>
+
+  <p>If you have any questions or concerns about the upgrade, please let us know: <a href="https://data.gov.uk/support">https://data.gov.uk/support</a></p>
+  </div>
+</main>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,7 @@ Rails.application.routes.draw do
     get 'site-changes', to: :site_changes
     get 'support'
     get 'terms'
+    get 'ckan_maintenance'
   end
 
   match "404", to: "errors#not_found", via: :all


### PR DESCRIPTION
## What

Add a maintenance page for CKAN downtime when we do the upgrade work, response status code will be 503

![image](https://user-images.githubusercontent.com/22152807/91175284-76e0f480-e6d8-11ea-9c55-fbfefb7abae2.png)

## Reference 

https://trello.com/c/Mz0Psh36/264-create-503-page-on-dgufind