### PR TITLE
Upgrade to Ruby 2.7.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
 source "https://rubygems.org"
 
-ruby IO.read(".ruby-version").strip
-
 gem "rails", "6.0.3.2"
 
 gem "addressable"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,7 +193,7 @@ GEM
     mimemagic (0.3.5)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
-    minitest (5.14.1)
+    minitest (5.14.2)
     msgpack (1.3.3)
     multi_json (1.15.0)
     multipart-post (2.1.1)
@@ -437,9 +437,6 @@ DEPENDENCIES
   uglifier
   webmock
   zendesk_api
-
-RUBY VERSION
-   ruby 2.6.6
 
 BUNDLED WITH
    1.17.3


### PR DESCRIPTION
These are the necessary changes for Ruby 2.7.1

I've left the version as 2.6.6 as there is a script that automatically updates all govuk apps' at once.

One deprecation warning coming from Kaminari, PR merged but not deployed 
https://github.com/kaminari/kaminari/commit/011d6ac3b866d5e1836c246f9a598c79d1213fe5