### PR TITLE
Update support journey markup

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -33,6 +33,9 @@ $govuk-use-legacy-palette: false;
 @import 'govuk_publishing_components/components/_skip-link';
 @import 'govuk_publishing_components/components/_table';
 @import 'govuk_publishing_components/components/_title';
+@import 'govuk_publishing_components/components/_error-summary';
+@import 'govuk_publishing_components/components/_textarea';
+@import 'govuk_publishing_components/components/_input';
 
 $path: "/assets/";
 $helvetica-regular: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica", sans-serif;

--- a/app/views/pages/support.html.erb
+++ b/app/views/pages/support.html.erb
@@ -4,63 +4,69 @@
   <%= render 'shared/breadcrumb' %>
 <% end%>
 
-<main role="main" id="content">
+<main role="main" id="main-content" class="govuk-main-wrapper">
 
-  <div class="grid-row inner">
-    <div class="column-two-thirds">
-      <h1 class='heading-large'>Support</h1>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Support",
+        margin_bottom: 6,
+        heading_level: 1,
+        font_size: "l",
+      } %>
 
-      <p>The Government Digital Service (GDS) maintains the technical service behind data.gov.uk
+      <p class="govuk-body">The Government Digital Service (GDS) maintains the technical service behind data.gov.uk
          and helps government publishers to manage and update their data.</p>
 
-      <p>It cannot</p>
+      <p class="govuk-body">It cannot</p>
       <ul class="list list-bullet">
         <li>help you find or research datasets</li>
         <li>provide personal information or medical records</li>
         <li>combine data from multiple datasets</li>
       </ul>
 
-      <p>For questions about <%= link_to "GOV.UK", "https://www.gov.uk/", class: "govuk-link" %> check the GOV.UK help pages
-         or <%= link_to "contact", "https://www.gov.uk/contact/govuk", class: "govuk-link" %> the team.</p>
+      <p class="govuk-body">For questions about GOV.UK check the <%= link_to "GOV.UK help pages", "https://www.gov.uk/help", class: "govuk-link" %> or <%= link_to "contact GOV.UK", "https://www.gov.uk/contact/govuk", class: "govuk-link" %>.</p>
+      <p class="govuk-body">The NHS <%= link_to "publishes its own data.", "https://digital.nhs.uk/data-and-information/data-collections-and-data-sets/data-sets", class: "govuk-link" %></p>
 
-      <p>The NHS <%= link_to "publishes its own data.", "https://digital.nhs.uk/data-and-information/data-collections-and-data-sets/data-sets", class: "govuk-link" %></p>
-
-      <h1 class="heading-medium">If you have a question about a dataset</h1>
-      <p>If you have a question about a specific dataset, contact the publisher directly.</p>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "If you have a question about a dataset",
+        margin_bottom: 4,
+        heading_level: 2,
+        font_size: "m",
+      } %>
+      <p class="govuk-body">If you have a question about a specific dataset, contact the publisher directly.</p>
 
       <form action="tickets/new" method="get">
-        <div class="form-group">
-          <fieldset>
+        <%= render "govuk_publishing_components/components/radio", {
+          name: "support",
+          heading: "How can we help you?",
+          items: [
+            {
+              value: "feedback",
+              text: "I want to report a problem"
+            },
+            {
+              value: "data",
+              text: "I want government to publish new data"
+            },
+            {
+              value: "publish",
+              text: "I want to publish for an organisation"
+            },
+            {
+              value: "accessibility",
+              text: "I want to report an accessibility issue"
+            },
+          ]
+        } %>
 
-            <legend>
-              <h1 class="heading-medium">How can we help you?</h1>
-            </legend>
-
-            <div class="multiple-choice">
-              <input id="support-1" type="radio" name="support" value="feedback">
-              <label for="support-1">I want to report a problem</label>
-            </div>
-
-            <div class="multiple-choice">
-              <input id="support-2" type="radio" name="support" value="data">
-              <label for="support-2">I want government to publish new data</label>
-            </div>
-
-            <div class="multiple-choice">
-              <input id="support-3" type="radio" name="support" value="publish">
-              <label for="support-3">I want to publish for an organisation</label>
-            </div>
-
-            <div class="multiple-choice">
-              <input id="support-4" type="radio" name="support" value="accessibility">
-              <label for="support-4">I want to report an accessibility issue</label>
-            </div>
-          </fieldset>
-        </div>
-        <input class="govuk-button" type="submit" value="Continue">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Continue",
+          margin_bottom: true,
+        } %>
       </form>
 
-      <p>Please give us your feedback about the site using <%= link_to "our survey", "http://www.smartsurvey.co.uk/s/3SEXD/", class: "govuk-link" %>.</p>
+      <p class="govuk-body">Please give us your feedback about the site using <%= link_to "our survey", "http://www.smartsurvey.co.uk/s/3SEXD/", class: "govuk-link" %>.</p>
     </div>
   </div>
 </main>

--- a/app/views/tickets/confirmation.html.erb
+++ b/app/views/tickets/confirmation.html.erb
@@ -1,13 +1,18 @@
 <% content_for :page_title do %>Confirmation<% end %>
 
-<main role="main" id="content">
-  <div class="grid-row inner">
-    <div class="column-two-thirds">
-      <h1 class='heading-large'><%= t('.thanks_for_contacting') %></h1>
-      <p>
+<main role="main" id="main-content" class="govuk-main-wrapper">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/heading", {
+        text: t('.thanks_for_contacting'),
+        margin_bottom: 6,
+        heading_level: 1,
+        font_size: "l",
+      } %>
+      <p class="govuk-body">
         <%= t('.built_by_gds') %>
       </p>
-      <p>
+      <p class="govuk-body">
         <%= t('.operational_support') %>
       </p>
       <%= link_to 'Go back to support', support_path, class: 'govuk-link' %>

--- a/app/views/tickets/new.html.erb
+++ b/app/views/tickets/new.html.erb
@@ -4,64 +4,77 @@
   <%= render 'shared/breadcrumb' %>
 <% end%>
 
-<main role="main" id="content">
-  <div class="grid-row inner">
-    <div class="column-full">
+<main role="main" id="main-content" class="govuk-main-wrapper">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
       <% if @ticket.errors.any? %>
-        <div class="error-summary" role="alert" aria-labelledby="error-summary-heading">
-          <h2 class="heading-medium error-summary-heading" id="error-summary-heading">
-            <%= t('.problem')%>
-          </h2>
-          <ul class="error-summary-list">
-            <% @ticket.errors.messages.each do |attr, error| %>
-              <li><a href="#error-<%= attr.to_s %>"> <%= error[0] %></a></li>
-            <% end %>
-          </ul>
-        </div>
+        <%
+          errors = @ticket.errors.messages.map do |attr, error|
+            {
+              text: error[0],
+              href: "#error-#{attr.to_s}"
+            }
+          end
+        %>
+        
+        <%= render "govuk_publishing_components/components/error_summary", {
+          title: t('.problem'),
+          items: errors
+        } %>
       <% end %>
 
-      <h1 class='heading-medium'>
-        <%= t(".#{@ticket.support}_request") %>
-      </h1>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: t(".#{@ticket.support}_request"),
+        margin_bottom: 4,
+        heading_level: 1,
+        font_size: "l",
+      } %>
 
       <%= form_for @ticket, url: { action: "create", controller: "tickets" } do |f| %>
-        <div class="form-group <% if @ticket.errors[:content].any? %> form-group-error <% end %>">
-          <label for="example-content" id="error-content">
-            <span class="form-label dgu-support__form-label"><%= t('.your_message') %></span>
-            <% if @ticket.errors[:content].any? %>
-              <span class="error-message"><%= t('.enter_a_message') %></span>
-            <% end %>
-          </label>
-          <%= f.text_area(:content,
-                          class: input_box_class_for(@ticket, :content),
-                          id: "example-content",
-                          rows: 8 ) %>
-        </div>
-        <div class="form-group <% if @ticket.errors[:name].any? %> form-group-error <% end %>">
-          <label for="example-name" id="error-name">
-            <span class="form-label dgu-support__form-label"><%= t('.name') %></span>
-            <% if @ticket.errors[:name].any? %>
-              <span class="error-message"><%= t('.enter_a_name') %></span>
-            <% end %>
-          </label>
-          <%= f.text_field(:name,
-                          class: input_box_class_for(@ticket, :name),
-                          id: "example-name") %>
-        </div>
-        <div class="form-group <% if @ticket.errors[:email].any? %> form-group-error <% end %>" >
-          <label for="example-email" id="error-email">
-            <span class="form-label dgu-support__form-label"><%= t('.email_address') %></span>
-            <% if @ticket.errors[:email].any? %>
-              <span class="error-message"><%= t('.enter_an_email') %></span>
-            <% end %>
-          </label>
-          <span class="form-hint"><%= t('.use_this_to_reply') %></span>
-          <%= f.text_field(:email,
-                          class: input_box_class_for(@ticket, :email),
-                          id: "example-email") %>
-        </div>
+        <%
+          content_error = t('.enter_a_message') if @ticket.errors[:content].any?
+          content_error_id = "error-content" if @ticket.errors[:content].any?
+          name_error = t('.enter_a_name') if @ticket.errors[:name].any?
+          name_error_id = "error-name" if @ticket.errors[:name].any?
+          email_error = t('.enter_an_email') if @ticket.errors[:email].any?
+          email_error_id = "error-email" if @ticket.errors[:email].any?
+        %>
+
+        <%= render "govuk_publishing_components/components/textarea", {
+          label: {
+            text: t('.your_message'),
+          },
+          name: "ticket[content]",
+          error_message: content_error,
+          id: content_error_id,
+          rows: 8,
+        } %>
+
+        <%= render "govuk_publishing_components/components/input", {
+          label: {
+            text: t('.name'),
+          },
+          name: "ticket[name]",
+          error_message: name_error,
+          id: name_error_id,
+          autocomplete: "name",
+        } %>
+
+        <%= render "govuk_publishing_components/components/input", {
+          label: {
+            text: t('.email_address'),
+          },
+          name: "ticket[email]",
+          error_message: email_error,
+          id: email_error_id,
+          hint: t('.use_this_to_reply'),
+          autocomplete: "email",
+        } %>
+
         <%= f.hidden_field(:support, :value => @ticket.support) %>
-          <%= f.submit t('.submit'), class: "govuk-button dgu-support__button" %>
+        <%= render "govuk_publishing_components/components/button", {
+          text: t('.submit'),
+        } %>      
       <% end %>
     </div>
   </div>

--- a/spec/features/support_spec.rb
+++ b/spec/features/support_spec.rb
@@ -13,9 +13,9 @@ RSpec.feature "Support tickets", type: :feature do
       click_on "Continue"
       expect(page).to have_content "Report a problem"
 
-      fill_in "example-content", with: ticket.content
-      fill_in "example-name", with: ticket.name
-      fill_in "example-email", with: ticket.email
+      fill_in "Your message", with: ticket.content
+      fill_in "Name", with: ticket.name
+      fill_in "Email address", with: ticket.email
 
       expect(Zendesk.client)
         .to receive_message_chain("tickets.create!")
@@ -34,9 +34,9 @@ RSpec.feature "Support tickets", type: :feature do
       click_on "Continue"
       expect(page).to have_content "Ask the government to publish new data"
 
-      fill_in "example-content", with: ticket.content
-      fill_in "example-name", with: ticket.name
-      fill_in "example-email", with: ticket.email
+      fill_in "Your message", with: ticket.content
+      fill_in "Name", with: ticket.name
+      fill_in "Email address", with: ticket.email
 
       expect(Zendesk.client)
         .to receive_message_chain("tickets.create!")
@@ -55,9 +55,9 @@ RSpec.feature "Support tickets", type: :feature do
       click_on "Continue"
       expect(page).to have_content "Publish for an organisation"
 
-      fill_in "example-content", with: ticket.content
-      fill_in "example-name", with: ticket.name
-      fill_in "example-email", with: ticket.email
+      fill_in "Your message", with: ticket.content
+      fill_in "Name", with: ticket.name
+      fill_in "Email address", with: ticket.email
 
       expect(Zendesk.client)
         .to receive_message_chain("tickets.create!")
@@ -74,7 +74,7 @@ RSpec.feature "Support tickets", type: :feature do
     scenario "Show the errors in the ticket form" do
       choose "I want government to publish new data"
       click_on "Continue"
-      fill_in "example-email", with: ticket.email
+      fill_in "Email address", with: ticket.email
 
       click_on "Submit"
       expect(page).to have_content "Enter a valid email address"
@@ -91,9 +91,9 @@ RSpec.feature "Support tickets", type: :feature do
       click_on "Continue"
       expect(page).to have_content "Report an accessibility issue"
 
-      fill_in "example-content", with: ticket.content
-      fill_in "example-name", with: ticket.name
-      fill_in "example-email", with: ticket.email
+      fill_in "Your message", with: ticket.content
+      fill_in "Name", with: ticket.name
+      fill_in "Email address", with: ticket.email
 
       expect(Zendesk.client)
         .to receive_message_chain("tickets.create!")


### PR DESCRIPTION
## What
Update the markup, classnames and styling on the support journey. This includes the following views:

- [The base support page](https://data.gov.uk/support)
- [The form page for submitting support tickets](https://data.gov.uk/tickets/new)
- [The confirmation page for support tickets](https://data.gov.uk/tickets/confirmation)

## Why
DGU Find is currently using govuk elements, an outdated implementation of the govuk design system. This PR is one of several that attempts to slowly remove the elements implementation and replace it with up to date implementations from govuk frontend and govuk publishing components.

No visual changes.

**Card:** https://trello.com/c/OSaqcWr0/235-update-markup-on-find-support-pages