### PR TITLE
Update markup on footer link pages

### DIFF
--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -2,68 +2,90 @@
   About
 <% end %>
 
-<main role="main" id="content">
+<main role="main" id="main-content" class="govuk-main-wrapper">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= render "govuk_publishing_components/components/title", {
+        title: "About Find open data"
+      } %>
 
-  <div class="text">
-   <h1 class="heading-large">
-     About Find open data
-   </h1>
+      <p class="govuk-body">Since 2010 data.gov.uk has been helping people to find and use open government data, and supporting government
+        publishers to maintain data. In March 2018, we re-designed the site and launched the Find open data service.</p>
 
-  <p>Since 2010 data.gov.uk has been helping people to find and use open government data, and supporting government
-     publishers to maintain data. In March 2018, we re-designed the site and launched the Find open data service.</p>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "What’s on Find open data",
+        margin_bottom: 4,
+        font_size: "m",
+      } %>
 
+      <p class="govuk-body">You can find:</p>
 
-    <h2 class="heading-medium">What’s on Find open data</h2>
+      <%= render "govuk_publishing_components/components/list", {
+        visible_counters: true,
+        items: [
+          "data published by central government, local authorities and public bodies",
+          "links to download data files",
+          "help on creating an account to publish data",
+        ]
+      } %>
 
-    <p>You can find:</p>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "How Find open data and policy work together",
+        margin_bottom: 4,
+        font_size: "m",
+      } %>
 
-    <ul class="list list-bullet">
-      <li>data published by central government, local authorities and public bodies</li>
-      <li>links to download data files</li>
-      <li>help on creating an account to publish data</li>
-    </ul>
+      <p class="govuk-body">Better data can help inform better policy-making and continuous improvement of services. Departments can combat
+        fraud and reduce waste.</p>
 
-    <h2 class="heading-medium">How Find open data and policy work together</h2>
+      <p class="govuk-body">By taking ethical, open, innovative and transparent approaches to data we can build greater levels of trust with
+        citizens, whilst delivering more cost-effective and better targeted and tailored services to their needs.</p>
 
-    <p>Better data can help inform better policy-making and continuous improvement of services. Departments can combat
-      fraud and reduce waste.</p>
+      <p class="govuk-body">Data is at the heart of digital transformation and a part of the <%= link_to "Government Transformation Strategy", "https://www.gov.uk/government/publications/government-transformation-strategy-2017-to-2020/government-transformation-strategy-better-use-of-data", class: "govuk-link" %>.</p>
 
-    <p>By taking ethical, open, innovative and transparent approaches to data we can build greater levels of trust with
-      citizens, whilst delivering more cost-effective and better targeted and tailored services to their needs.</p>
+      <p class="govuk-body">GDS works with other organisations both within and outside government on shaping the strategic direction on how
+        data is managed, accessed and used. We work collaboratively on a range of issues with the Office for National
+        Statistics, Department for Digital, Culture, Media & Sport and The National Cyber Security Centre.</p>
 
-    <p>Data is at the heart of digital transformation and a part of the
-      <a href="https://www.gov.uk/government/publications/government-transformation-strategy-2017-to-2020/government-transformation-strategy-better-use-of-data">Government
-        Transformation Strategy</a>.</p>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Reuse information published on Find open data",
+        margin_bottom: 4,
+        font_size: "m",
+      } %>
 
-    <p>GDS works with other organisations both within and outside government on shaping the strategic direction on how
-      data is managed, accessed and used. We work collaboratively on a range of issues with the Office for National
-      Statistics, Department for Digital, Culture, Media & Sport and The National Cyber Security Centre.</p>
+      <p class="govuk-body">You can republish any of the content on Find open data, as long as you meet the conditions of either the <%= link_to "Open Government Licence", "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/", class: "govuk-link" %> or
+        the licence it's covered by. For questions about a dataset, you can contact the publisher directly if they’ve
+        provided contact details on the relevant dataset page.</p>
+      
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Build services using registers",
+        margin_bottom: 4,
+        font_size: "m",
+      } %>
 
-    <h2 class="heading-medium">Reuse information published on Find open data</h2>
+      <p class="govuk-body">You can find <%= link_to "GOV.UK Registers", "https://www.registers.service.gov.uk/", class: "govuk-link" %> that are managed and approved by government and ready to use in your service.</p>
+      <p class="govuk-body">Using an approved register means you can trust the data. You can also combine data from different registers using the open API. </p>
+      <p class="govuk-body">Find out how government organisations including the Cabinet Office and Environment Agency are <%= link_to "using registers", "https://www.registers.service.gov.uk/services-using-registers", class: "govuk-link" %> in their services. For example, the UK Government and Parliament petitions service uses the country register to help users to choose their country.</p>
 
-    <p>You can republish any of the content on Find open data, as long as you meet the conditions of either the
-      <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">Open Government Licence</a> or
-      the licence it's covered by. For questions about a dataset, you can contact the publisher directly if they’ve
-      provided contact details on the relevant dataset page.</p>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Linking to datasets on GOV.UK",
+        margin_bottom: 4,
+        font_size: "m",
+      } %>
 
-     <h2 class="heading-medium">Build services using registers</h2>
+      <p class="govuk-body">Data is integral to our work to transform government. Organisations can publish data on Find open data by linking to
+        datasets published on GOV.UK. To help organisations prepare and publish data on GOV.UK, we have some
+        recommendations for publishing:</p>
 
-    <p>You can find <a href="https://registers.cloudapps.digital/">GOV.UK registers</a> that are managed and approved by government and ready to use in your service.</p>
-    <p>Using an approved register means you can trust the data. You can also combine data from different registers using the open API. </p>
-    <p>Find out how government organisations including the Cabinet Office and Environment Agency are <a href="https://registers.cloudapps.digital/services-using-registers">using registers</a> in their services. For example, the UK Government and Parliament petitions service uses the country register to help users to choose their country.</p>
-
-     <h2 class="heading-medium">Linking to datasets on GOV.UK</h2>
-
-    <p>Data is integral to our work to transform government. Organisations can publish data on Find open data by linking to
-      datasets published on GOV.UK. To help organisations prepare and publish data on GOV.UK, we have some
-      recommendations for publishing:</p>
-
-    <ul class="list list-bullet">
-      <li><a href="https://www.gov.uk/government/collections/how-to-publish-central-government-transparency-data">central
-        government transparency data</a></li>
-      <li><a href="https://www.gov.uk/guidance/how-to-publish-prompt-payment-data">payment data</a></li>
-      <li><a href="https://www.gov.uk/guidance/how-to-publish-spend-control-data">spend control data</a></li>
-    </ul>
-
+      
+      <%= render "govuk_publishing_components/components/list", {
+        visible_counters: true,
+        items: [
+          sanitize(link_to "central government transparency data", "https://www.gov.uk/government/collections/how-to-publish-central-government-transparency-data", class: "govuk-link"),
+          sanitize(link_to "payment data", "https://www.gov.uk/guidance/how-to-publish-prompt-payment-data", class: "govuk-link"),
+          sanitize(link_to "spend control data", "https://www.gov.uk/guidance/how-to-publish-spend-control-data", class: "govuk-link"),
+        ]
+      } %>
+    </div>
   </div>
 </main>

--- a/app/views/pages/accessibility.html.erb
+++ b/app/views/pages/accessibility.html.erb
@@ -2,142 +2,171 @@
   Accessibility
 <% end %>
 
-<main role="main" id="content">
+<main role="main" id="main-content" class="govuk-main-wrapper">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= render "govuk_publishing_components/components/title", {
+        title: "Accessibility statement for Find open data"
+      } %>
 
-  <div class="text">
+      <p class="govuk-body">
+        This accessibility statement applies to Find open data at <%= link_to "https://data.gov.uk/", "/", class: "govuk-link" %>
+      </p>
 
-    <h1 class="heading-large">
-      Accessibility statement for Find open data
-    </h1>
+      <p class="govuk-body">
+      This website is run by the GOV.UK team at the Government Digital Service (GDS).
+      We want as many people as possible to be able to use this website. For example, that means you should be able to:
+      </p>
 
-    <p>
-      This accessibility statement applies to Find open data at <%= link_to 'https://data.gov.uk/', '/', target: :blank, class: 'govuk-link' %>
-    </p>
+      <%= render "govuk_publishing_components/components/list", {
+        visible_counters: true,
+        items: [
+          "change colours, contrast levels and fonts",
+          "zoom in up to 300% without problems",
+          "navigate most of the website using just a keyboard",
+          "navigate most of the website using speech recognition software",
+          "listen to most of the website using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)",
+        ]
+      } %>
 
-    <p>
-     This website is run by the GOV.UK team at the Government Digital Service (GDS).
-     We want as many people as possible to be able to use this website. For example, that means you should be able to:
-    </p>
+      <p class="govuk-body">
+        We’ve also made the website text as simple as possible to understand.
+      </p>
 
-    <ul class="list list-bullet">
-      <li>change colours, contrast levels and fonts</li>
-      <li>zoom in up to 300% without problems</li>
-      <li>navigate most of the website using just a keyboard</li>
-      <li>navigate most of the website using speech recognition software</li>
-      <li>listen to most of the website using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)</li>
-    </ul>
+      <p class="govuk-body">
+        <%= link_to "AbilityNet", "https://mcmw.abilitynet.org.uk/", class: "govuk-link" %> has advice on making your device easier to use if you have a disability.
+      </p>
 
-    <p>
-      We’ve also made the website text as simple as possible to understand.
-    </p>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "How accessible this website is",
+        margin_bottom: 4,
+        font_size: "m",
+      } %>
 
-    <p>
-      <%= link_to 'AbilityNet', 'https://mcmw.abilitynet.org.uk/', target: :blank, class: 'govuk-link' %> has advice on making your device easier to use if you have a disability.
-    </p>
+      <p class="govuk-body">
+        We know some parts of this website are not fully accessible for the following reasons:
+      </p>
 
-    <h2 class="heading-medium">
-      How accessible this website is
-    </h2>
+      <%= render "govuk_publishing_components/components/list", {
+        visible_counters: true,
+        items: [
+          "Find open data links to several external websites belonging to other government organisations. We cannot guarantee that these websites meet our accessibility requirements.",
+          "Some data sets have broken links.",
+        ]
+      } %>
 
-    <p>
-      We know some parts of this website are not fully accessible for the following reasons:
-    </p>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Feedback and contact information",
+        margin_bottom: 4,
+        font_size: "m",
+      } %>
 
-    <ul class="list list-bullet">
-      <li>Find open data links to several external websites belonging to other government organisations. We cannot guarantee that these websites meet our accessibility requirements.</li>
-      <li>Some data sets have broken links.</li>
-    </ul>
+      <p class="govuk-body">
+        If you need any part of this service in a different format like large print, audio recording or braille, please contact the data set publisher.
+        Their contact details should be on the data set’s page.
+      </p>
 
-    <h2 class="heading-medium">
-      Feedback and contact information
-    </h2>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Reporting accessibility problems with this website",
+        margin_bottom: 4,
+        font_size: "m",
+      } %>
 
-    <p>
-      If you need any part of this service in a different format like large print, audio recording or braille, please contact the data set publisher.
-      Their contact details should be on the data set’s page.
-    </p>
+      <p class="govuk-body">
+        We’re always looking to improve the accessibility of this website.
+        If you find any problems not listed on this page or think we’re not meeting accessibility requirements, please select ‘Report a problem’ on the <%= link_to "data.gov.uk support page", "/support", class: "govuk-link" %>.
+      </p>
 
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Enforcement procedure",
+        margin_bottom: 4,
+        font_size: "m",
+      } %>
 
-    <h2 class="heading-medium">
-      Reporting accessibility problems with this website
-    </h2>
+      <p class="govuk-body">
+        The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’).
+        If you’re not happy with how we respond to your complaint, <%= link_to "contact the Equality Advisory and Support Service (EASS)", "https://www.equalityadvisoryservice.com/", class: "govuk-link" %>.
+      </p>
 
-    <p>
-      We’re always looking to improve the accessibility of this website.
-      If you find any problems not listed on this page or think we’re not meeting accessibility requirements, please select ‘Report a problem’ on the data.gov.uk <%= link_to 'Support page', '/support', target: :blank, class: 'govuk-link' %>.
-    </p>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Technical information about this website’s accessibility",
+        margin_bottom: 4,
+        font_size: "m",
+      } %>
 
-    <h2 class="heading-medium">
-      Enforcement procedure
-    </h2>
+      <p class="govuk-body">
+        GDS is committed to making its website accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
+      </p>
 
-    <p>
-      The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’).
-      If you’re not happy with how we respond to your complaint, <%= link_to 'contact the Equality Advisory and Support Service (EASS)', 'https://www.equalityadvisoryservice.com/', target: :blank, class: 'govuk-link' %>.
-    </p>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Compliance status",
+        margin_bottom: 4,
+        font_size: "m",
+      } %>
 
-    <h2 class="heading-medium">
-      Technical information about this website’s accessibility
-    </h2>
+      <p class="govuk-body">
+        This website is partially compliant with the <%= link_to "Web Content Accessibility Guidelines version 2.1","https://www.w3.org/TR/WCAG21/", class: "govuk-link"%> AA standard, due to the non-compliances listed below.
+      </p>
 
-    <p>
-      GDS is committed to making its website accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
-    </p>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Non-accessible content",
+        margin_bottom: 2,
+        heading_level: 3,
+        font_size: "s",
+      } %>
 
-    <h2 class="heading-medium">
-      Compliance status
-    </h2>
+      <p class="govuk-body">
+        The content listed below is non-accessible for the following reasons.
+      </p>
 
-    <p>
-      This website is partially compliant with the <%= link_to 'Web Content Accessibility Guidelines version 2.1','https://www.w3.org/TR/WCAG21/', target: :blank, class: 'govuk-link'%> AA standard, due to the non-compliances listed below.
-    </p>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Non-compliance with the accessibility regulations",
+        margin_bottom: 2,
+        heading_level: 3,
+        font_size: "s",
+      } %>
 
-    <h2 class="heading-small">
-      Non-accessible content
-    </h2>
+      <p class="govuk-body">
+        Find open data links to several external websites belonging to other government organisations. We cannot guarantee that these websites meet our accessibility requirements. This is not a fail under any specific WCAG criterion, but should be looked at in order to maximise accessibility.
+      </p>
 
-    <p>
-      The content listed below is non-accessible for the following reasons.
-    </p>
+      <p class="govuk-body">
+        Some data sets have broken links. This fails WCAG 2.1 success criterion 2.4.4 (Link Purpose).
+      </p>
 
-    <h3 class="heading-small">
-      Non-compliance with the accessibility regulations
-    </h3>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "How we tested this website",
+        margin_bottom: 4,
+        font_size: "m",
+      } %>
 
-    <p>
-      Find open data links to several external websites belonging to other government organisations. We cannot guarantee that these websites meet our accessibility requirements. This is not a fail under any specific WCAG criterion, but should be looked at in order to maximise accessibility.
-    </p>
+      <p class="govuk-body">
+        We commissioned an expert agency (Digital Accessibility Centre) to review the website.
+      </p>
 
-    <p>
-      Some data sets have broken links. This fails WCAG 2.1 success criterion 2.4.4 (Link Purpose).
-    </p>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "What we’re doing to improve accessibility",
+        margin_bottom: 4,
+        font_size: "m",
+      } %>
 
-    <h2 class="heading-medium">
-      How we tested this website
-    </h2>
+      <p class="govuk-body">
+        We will adopt improvements to the GOV.UK design system as part of any future work on Find Open Data.
+      </p>
 
-    <p>
-      We commissioned an expert agency (Digital Accessibility Centre) to review the website.
-    </p>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Preparation of this accessibility statement",
+        margin_bottom: 4, 
+        font_size: "m",
+      } %>
 
-    <h2 class="heading-medium">
-      What we’re doing to improve accessibility
-    </h2>
+      <p class="govuk-body">
+        This statement was prepared on 21 September 2020. It was last reviewed on 22 September 2020.
+      </p>
 
-    <p>
-      We will adopt improvements to the GOV.UK design system as part of any future work on Find Open Data.
-    </p>
-
-    <h2 class="heading-medium">
-      Preparation of this accessibility statement
-    </h2>
-
-    <p>
-      This statement was prepared on 21 September 2020. It was last reviewed on 22 September 2020.
-    </p>
-
-    <p>
-      This website was last tested in May 2019. The test was carried out by Digital Accessibility Centre.
-    </p>
+      <p class="govuk-body">
+        This website was last tested in May 2019. The test was carried out by Digital Accessibility Centre.
+      </p>
+    </div>
   </div>
 </main>

--- a/app/views/pages/cookies.html.erb
+++ b/app/views/pages/cookies.html.erb
@@ -1,156 +1,159 @@
 <% content_for :page_title, "Cookies on GOV.UK" %>
-<main id="content" role="main" class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds govuk-!-padding-0">
-    <div class="cookie-settings__confirmation" data-cookie-confirmation="true">
-      <%= render "govuk_publishing_components/components/notice", {
-        title: "Cookies on data.gov.uk",
-        aria_live: true,
-      } do %>
-        <p><%= "Your cookie settings were saved" %></p>
-        <a class="govuk-link cookie-settings__prev-page" href='#'>
-          <%= "Go back to the page you were looking at" %>
-        </a>
-      <% end %>
-    </div>
 
-    <%= render "govuk_publishing_components/components/title", {
-      title: "Cookies on data.gov.uk"
-    } %>
-
-    <%= render "govuk_publishing_components/components/govspeak", {
-    } do %>
-      <p>Cookies are files saved on your phone, tablet or computer when you visit a website.</p>
-      <p>We use cookies to store information about how you use the data.gov.uk website, such as the pages you visit.</p>
-
-    <% end %>
-
-    <%= render "govuk_publishing_components/components/heading", {
-      text: "Cookie settings",
-      padding: true,
-      heading_level: 2
-    } %>
-
-    <div class="cookie-settings__no-js">
-      <%= render "govuk_publishing_components/components/govspeak", {
+<main role="main" id="main-content" class="govuk-main-wrapper">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds govuk-!-padding-0">
+      <div class="cookie-settings__confirmation" data-cookie-confirmation="true">
+        <%= render "govuk_publishing_components/components/notice", {
+          title: "Cookies on data.gov.uk",
+          aria_live: true,
         } do %>
-        <p>We use Javascript to set most of our cookies. Unfortunately Javascript is not running on your browser, so you cannot change your settings. You can try:</p>
-        <ul>
-          <li>reloading the page</li>
-          <li>turning on Javascript in your browser</li>
-        </ul>
+          <p><%= "Your cookie settings were saved" %></p>
+          <a class="govuk-link cookie-settings__prev-page" href='#'>
+            <%= "Go back to the page you were looking at" %>
+          </a>
+        <% end %>
+      </div>
+
+      <%= render "govuk_publishing_components/components/title", {
+        title: "Cookies on data.gov.uk"
+      } %>
+
+      <%= render "govuk_publishing_components/components/govspeak", {
+      } do %>
+        <p>Cookies are files saved on your phone, tablet or computer when you visit a website.</p>
+        <p>We use cookies to store information about how you use the data.gov.uk website, such as the pages you visit.</p>
+
       <% end %>
-    </div>
 
-    <div class="cookie-settings__form-wrapper">
-      <p>We use 4 types of cookie. You can choose which cookies you're happy for us to use.</p>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Cookie settings",
+        padding: true,
+      } %>
 
-      <form data-module="cookie-settings">
-
-        <% cookies_usage_hint = capture do %>
-          We use Google Analytics to measure how you use the website so we can improve it based on user needs. Google Analytics sets cookies that store anonymised information about:
-          <ul class="cookie-settings__list">
-            <li>how you got to the site</li>
-            <li>the pages you visit on data.gov.uk, and how long you spend on each page</li>
-            <li>what you click on while you're visiting the site</li>
-          </ul>
-          We do not allow Google to use or share the data about how you use this site.
-          <p>These are the Google Analytics cookies we’ll use:</p>
-
-          <div class="table-wrapper">
-            <table>
-              <thead>
-                <tr>
-                  <th>Name</th>
-                  <th>Purpose</th>
-                  <th>Expires</th>
-                </tr>
-              </thead>
-
-              <tbody>
-                <tr>
-                  <td>_ga, _gid</td>
-                  <td>These help us count how many people visit data.gov.uk by tracking if you’ve visited before
-                  </td>
-                  <td>_ga 2 years<br/>
-                    _gid 24 hours</td>
-                </tr>
-
-                <tr>
-                  <td>_gat</td>
-                  <td>Used to manage the rate at which page view requests are made</td>
-                  <td>10 minutes</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        <% end %>
-
-        <%= render "govuk_publishing_components/components/radio", {
-          name: "cookies-usage",
-          inline: false,
-          heading: "Cookies that measure website use",
-          hint: cookies_usage_hint,
-          items: [
-            {
-              value: "on",
-              text: "Use cookies that measure my website use"
-            },
-            {
-              value: "off",
-              text: "Do not use cookies that measure my website use"
-            }
-          ]
-        } %>
-
-        <% cookies_campaigns_hint = capture do %>
-          These cookies may be set by third party websites. We don't currently use any cookies in this category.
-        <% end %>
-
-        <%= render "govuk_publishing_components/components/radio", {
-          name: "cookies-campaigns",
-          inline: false,
-          heading: "Cookies that help with our communications and marketing",
-          hint: cookies_campaigns_hint,
-          items: [
-            {
-              value: "on",
-              text: "Use cookies that help with communications and marketing"
-            },
-            {
-              value: "off",
-              text: "Do not use cookies that help with communications and marketing"
-            }
-          ]
-        } %>
-
-        <%= render "govuk_publishing_components/components/radio", {
-          name: "cookies-settings",
-          inline: false,
-          heading: "Cookies that remember your settings",
-          hint: "These cookies do things like remember your preferences and the choices you make, to personalise your experience of using the site.",
-          items: [
-            {
-              value: "on",
-              text: "Use cookies that remember my settings on the site"
-            },
-            {
-              value: "off",
-              text: "Do not use cookies that remember my settings on the site"
-            }
-          ]
-        } %>
-
+      <noscript>
         <%= render "govuk_publishing_components/components/govspeak", {
           } do %>
-          <h2>Strictly necessary cookies</h2>
-          <p>These essential cookies do things like remember your cookie preferences, so we don't ask for them again.</p>
-          <p>They always need to be on.</p>
+          <p>We use Javascript to set most of our cookies. Unfortunately Javascript is not running on your browser, so you cannot change your settings. You can try:</p>
+          <ul>
+            <li>reloading the page</li>
+            <li>turning on Javascript in your browser</li>
+          </ul>
         <% end %>
+      </noscript>
 
-        <%= render "govuk_publishing_components/components/button", {
-          text: "Save changes"
-        } %>
-      </form>
+      <div class="cookie-settings__form-wrapper">
+        <p>We use 4 types of cookie. You can choose which cookies you're happy for us to use.</p>
+
+        <form data-module="cookie-settings">
+
+          <% cookies_usage_hint = capture do %>
+            We use Google Analytics to measure how you use the website so we can improve it based on user needs. Google Analytics sets cookies that store anonymised information about:
+            <ul class="cookie-settings__list">
+              <li>how you got to the site</li>
+              <li>the pages you visit on data.gov.uk, and how long you spend on each page</li>
+              <li>what you click on while you're visiting the site</li>
+            </ul>
+            We do not allow Google to use or share the data about how you use this site.
+            <p>These are the Google Analytics cookies we’ll use:</p>
+
+            <div class="table-wrapper">
+              <table>
+                <thead>
+                  <tr>
+                    <th>Name</th>
+                    <th>Purpose</th>
+                    <th>Expires</th>
+                  </tr>
+                </thead>
+
+                <tbody>
+                  <tr>
+                    <td>_ga, _gid</td>
+                    <td>These help us count how many people visit data.gov.uk by tracking if you’ve visited before
+                    </td>
+                    <td>_ga 2 years<br/>
+                      _gid 24 hours</td>
+                  </tr>
+
+                  <tr>
+                    <td>_gat</td>
+                    <td>Used to manage the rate at which page view requests are made</td>
+                    <td>10 minutes</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          <% end %>
+
+          <%= render "govuk_publishing_components/components/radio", {
+            name: "cookies-usage",
+            inline: false,
+            heading: "Cookies that measure website use",
+            hint: cookies_usage_hint,
+            items: [
+              {
+                value: "on",
+                text: "Use cookies that measure my website use"
+              },
+              {
+                value: "off",
+                text: "Do not use cookies that measure my website use"
+              }
+            ]
+          } %>
+
+          <% cookies_campaigns_hint = capture do %>
+            These cookies may be set by third party websites. We don't currently use any cookies in this category.
+          <% end %>
+
+          <%= render "govuk_publishing_components/components/radio", {
+            name: "cookies-campaigns",
+            inline: false,
+            heading: "Cookies that help with our communications and marketing",
+            hint: cookies_campaigns_hint,
+            items: [
+              {
+                value: "on",
+                text: "Use cookies that help with communications and marketing"
+              },
+              {
+                value: "off",
+                text: "Do not use cookies that help with communications and marketing"
+              }
+            ]
+          } %>
+
+          <%= render "govuk_publishing_components/components/radio", {
+            name: "cookies-settings",
+            inline: false,
+            heading: "Cookies that remember your settings",
+            hint: "These cookies do things like remember your preferences and the choices you make, to personalise your experience of using the site.",
+            items: [
+              {
+                value: "on",
+                text: "Use cookies that remember my settings on the site"
+              },
+              {
+                value: "off",
+                text: "Do not use cookies that remember my settings on the site"
+              }
+            ]
+          } %>
+
+          <%= render "govuk_publishing_components/components/govspeak", {
+            } do %>
+            <h2>Strictly necessary cookies</h2>
+            <p>These essential cookies do things like remember your cookie preferences, so we don't ask for them again.</p>
+            <p>They always need to be on.</p>
+          <% end %>
+
+          <%= render "govuk_publishing_components/components/button", {
+            text: "Save changes"
+          } %>
+        </form>
+      </div>
+    
     </div>
   </div>
 </main>

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -1,239 +1,261 @@
 <% content_for :page_title do %>Privacy<% end %>
 
-<main role="main" id="content">
+<main role="main" id="main-content" class="govuk-main-wrapper">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= render "govuk_publishing_components/components/title", {
+        title: "Privacy"
+      } %>
 
-  <div class="text">
+      <p class="govuk-body">Last updated 23 May 2018</p>
 
-    <h1 class="heading-large">
-      Privacy
-    </h1>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Who we are",
+        margin_bottom: 4,
+        font_size: "m",
+      } %>
 
-    <p>Last updated 23 May 2018</p>
-
-    <h2 class="heading-medium">
-      Who we are
-    </h2>
-
-    <p>
-      Find open data is a data service provided by the
-      <%= link_to 'Government Digital Service', 'https://www.gov.uk/government/organisations/government-digital-service', class: 'govuk-link' %>
-      (GDS) which is part of the Cabinet Office. Our job is the digital
-      transformation of government.
-    </p>
-
-    <p>
-      Data.gov.uk helps people to find and use open government data, and
-      supports government publishers to maintain data.
-    </p>
-
-    <p>
-      The data controller for GDS is the Cabinet Office — a data controller
-      determines how and why personal data is processed. For more
-      information read the Cabinet Office’s entry in the
-      <%= link_to 'Data Protection Public Register', 'https://ico.org.uk/ESDWebPages/Entry/Z7414053', class: 'govuk-link' %>.
-    </p>
-
-    <h2 class="heading-medium">
-      What data we need
-    </h2>
-
-    <p>
-      The personal data we collect from you will include:
-    </p>
-
-    <ul class="list list-bullet">
-      <li>your name</li>
-      <li>your email address</li>
-      <li>your organisation</li>
-    </ul>
-
-    <p>
-      The legal basis for processing this data is in the exercise of a public
-      task of a Government Department to undertake its functions.
-    </p>
-
-    <h2 class="heading-medium">
-      Why we need it
-    </h2>
-
-    <p>
-      We collect your personal data so we can provide access to the publishing
-      service and to send you email notifications about service changes.
-    </p>
-
-    <p>
-      We collect an email address and name so we can verify you work for the
-      publishing organisation.
-    </p>
-
-    <h2 class="heading-medium">
-      What we do with it
-    </h2>
-
-    <p>
-      We use the data you provide to set up your account so you can manage and
-      publish data. From time to time, we might need to update you about changes
-      in the service.
-    </p>
-
-    <p>We will not:</p>
-
-    <ul class="list list-bullet">
-      <li>sell or rent your data to third parties</li>
-      <li>share your data with third parties for marketing purposes</li>
-    </ul>
-
-    <p>
-      We will share your data if we are required to do so by law — for example,
-      by court order, or to prevent fraud or other crime.
-    </p>
-
-    <h2 class="heading-medium">
-      How long we keep your data
-    </h2>
-
-    <p>
-      We will only retain your personal data for as long as it is required by
-      law. In general, this means that we will only hold your personal data for
-      the length of time you use this service, or up to 12 months after you
-      leave the service whereby all information will then be deleted.
-    </p>
-
-    <h2 class="heading-medium">
-      Children’s privacy protection
-    </h2>
-
-    <p>
-      We understand the importance of protecting children’s privacy online. Our
-      service is not designed for, or intentionally targeted at, children 13
-      years of age or younger. It is not our policy to intentionally collect or
-      maintain data about anyone under the age of 13.
-    </p>
-
-    <h2 class="heading-medium">
-      Where your data is processed and stored
-    </h2>
-
-    <p>
-      To make sure that your data is as safe as possible, we design and
-      maintain systems with secure accounts. Your personal data will not be
-      transferred outside of
-      the <%= link_to 'European Economic Area (EEA)', 'https://www.gov.uk/eu-eea', class: 'govuk-link' %>
-      while it’s processed at GDS.
-    </p>
-
-    <h2 class="heading-medium">
-      How we protect your data and keep it secure
-    </h2>
-
-    <p>
-      We are committed to doing all that we can to keep your data secure. To
-      prevent unauthorised access or disclosure we have put in place technical
-      and organisational procedures to secure the data we collect about you.
-    </p>
-
-    <p>
-      For example, we protect your data using varying levels of encryption. We
-      also make sure that any third parties that we deal with have an obligation
-      to keep all personal data they process on our behalf secure.
-    </p>
-
-    <h2 class="heading-medium">
-      What are your rights
-    </h2>
-
-    <p>You have the right to:</p>
-
-    <ul class="list list-bullet">
-      <li>request information about how your personal data is processed and to
-        request a copy of that personal data
-      </li>
-      <li>request that any inaccuracies in your personal data are rectified
-        without delay
-      </li>
-      <li>request that any incomplete personal data is completed, including by
-        means of a supplementary statement
-      </li>
-      <li>request that your personal data is erased if there is no longer a
-        justification for it to be processed
-      </li>
-      <li>request that the processing of your personal data is restricted in
-        certain circumstances — for example, where accuracy is contested
-      </li>
-    </ul>
-
-    <p>If your personal data is processed on the basis of consent, you have the
-      right to:
-    </p>
-
-    <ul class="list list-bullet">
-      <li>request a copy of any personal data you have provided, and for this to
-        be provided in a structured, commonly used and machine-readable format
-      </li>
-    </ul>
-
-    <h2 class="heading-medium">
-      Changes to this notice
-    </h2>
-
-    <p>
-      We may change this privacy notice at our discretion at any time. In that
-      case the ‘Last updated’ date at the top of this page will also change. Any
-      changes to this privacy notice will apply to you and your data
-      immediately. If these changes affect how your personal data is processed,
-      GDS will take reasonable steps to make sure you know.
-    </p>
-
-    <h2 class="heading-medium">
-      Questions and complaints
-    </h2>
-
-    <p>
-      The data controller for your personal data is the Cabinet Office. Contact
-      the  GDS Privacy Team if you have any questions or think that
-      your personal data has been misused or mishandled.
-    </p>
-
-    <p>
-      Email: <%= mail_to 'gds-privacy-office@digital.cabinet-office.gov.uk', nil, class: 'govuk-link' %>
-    </p>
-
-    <p>
-      The contact details for our Data Protection Officer are:
-    </p>
-
-    <div class="contact">
-      <p>
-        Data Protection Officer<br />
-        <%= mail_to 'DPO@cabinetoffice.gov.uk', nil, class: 'govuk-link' %><br />
-        Cabinet Office<br />
-        70 Whitehall<br />
-        London <br />
-        SW1A 2AS
+      <p class="govuk-body">
+        Find open data is a data service provided by the
+        <%= link_to 'Government Digital Service', 'https://www.gov.uk/government/organisations/government-digital-service', class: 'govuk-link' %>
+        (GDS) which is part of the Cabinet Office. Our job is the digital
+        transformation of government.
       </p>
-    </div>
 
-    <p>
-      The Data Protection Officer provides independent advice and monitoring of our use of personal information.
-    </p>
-
-    <p>
-      If you have a complaint, you can also contact
-      the <%= link_to 'Information Commissioner', 'https://ico.org.uk/', class: 'govuk-link' %>, who
-      is an independent regulator set up to uphold information rights.
-    </p>
-
-    <div class="contact">
-      <p>
-        Information Commissioner’s Office<br />
-        <%= mail_to 'casework@ico.org.uk', nil, class: 'govuk-link' %><br />
-        0303 123 1113</br>
-        Wycliffe House<br />
-        Water Lane<br />
-        Wilmslow<br />
-        Cheshire<br />
-        SK9 5AF
+      <p class="govuk-body">
+        Data.gov.uk helps people to find and use open government data, and
+        supports government publishers to maintain data.
       </p>
+
+      <p class="govuk-body">
+        The data controller for GDS is the Cabinet Office — a data controller
+        determines how and why personal data is processed. For more
+        information read the Cabinet Office’s entry in the
+        <%= link_to 'Data Protection Public Register', 'https://ico.org.uk/ESDWebPages/Entry/Z7414053', class: 'govuk-link' %>.
+      </p>
+
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "What data we need",
+        margin_bottom: 4,
+        font_size: "m",
+      } %>
+
+      <p class="govuk-body">
+        The personal data we collect from you will include:
+      </p>
+
+      <%= render "govuk_publishing_components/components/list", {
+        visible_counters: true,
+        items: [
+          "your name",
+          "your email address",
+          "your organisation",
+        ]
+      } %>
+
+      <p class="govuk-body">
+        The legal basis for processing this data is in the exercise of a public
+        task of a Government Department to undertake its functions.
+      </p>
+
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Why we need it",
+        margin_bottom: 4,
+        font_size: "m",
+      } %>
+
+      <p class="govuk-body">
+        We collect your personal data so we can provide access to the publishing
+        service and to send you email notifications about service changes.
+      </p>
+
+      <p class="govuk-body">
+        We collect an email address and name so we can verify you work for the
+        publishing organisation.
+      </p>
+
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "What we do with it",
+        margin_bottom: 4,
+        font_size: "m",
+      } %>
+
+      <p class="govuk-body">
+        We use the data you provide to set up your account so you can manage and
+        publish data. From time to time, we might need to update you about changes
+        in the service.
+      </p>
+
+      <p class="govuk-body">We will not:</p>
+
+      <%= render "govuk_publishing_components/components/list", {
+        visible_counters: true,
+        items: [
+          "sell or rent your data to third parties",
+          "share your data with third parties for marketing purposes",
+        ]
+      } %>
+
+      <p class="govuk-body">
+        We will share your data if we are required to do so by law — for example,
+        by court order, or to prevent fraud or other crime.
+      </p>
+
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "How long we keep your data",
+        margin_bottom: 4,
+        font_size: "m",
+      } %>
+
+      <p class="govuk-body">
+        We will only retain your personal data for as long as it is required by
+        law. In general, this means that we will only hold your personal data for
+        the length of time you use this service, or up to 12 months after you
+        leave the service whereby all information will then be deleted.
+      </p>
+
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Children’s privacy protection",
+        margin_bottom: 4,
+        font_size: "m",
+      } %>
+
+      <p class="govuk-body">
+        We understand the importance of protecting children’s privacy online. Our
+        service is not designed for, or intentionally targeted at, children 13
+        years of age or younger. It is not our policy to intentionally collect or
+        maintain data about anyone under the age of 13.
+      </p>
+
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Where your data is processed and stored",
+        margin_bottom: 4,
+        font_size: "m",
+      } %>
+
+      <p class="govuk-body">
+        To make sure that your data is as safe as possible, we design and
+        maintain systems with secure accounts. Your personal data will not be
+        transferred outside of
+        the <%= link_to 'European Economic Area (EEA)', 'https://www.gov.uk/eu-eea', class: 'govuk-link' %>
+        while it’s processed at GDS.
+      </p>
+
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "How we protect your data and keep it secure",
+        margin_bottom: 4,
+        font_size: "m",
+      } %>
+
+      <p class="govuk-body">
+        We are committed to doing all that we can to keep your data secure. To
+        prevent unauthorised access or disclosure we have put in place technical
+        and organisational procedures to secure the data we collect about you.
+      </p>
+
+      <p class="govuk-body">
+        For example, we protect your data using varying levels of encryption. We
+        also make sure that any third parties that we deal with have an obligation
+        to keep all personal data they process on our behalf secure.
+      </p>
+
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "What are your rights",
+        margin_bottom: 4,
+        font_size: "m",
+      } %>
+
+      <p class="govuk-body">You have the right to:</p>
+
+      <%= render "govuk_publishing_components/components/list", {
+        visible_counters: true,
+        items: [
+          "request information about how your personal data is processed and to request a copy of that personal data",
+          "request that any inaccuracies in your personal data are rectified without delay",
+          "request that any incomplete personal data is completed, including by means of a supplementary statement",
+          "request that your personal data is erased if there is no longer a justification for it to be processed",
+          "request that the processing of your personal data is restricted in certain circumstances — for example, where accuracy is contested",
+        ]
+      } %>
+
+      <p class="govuk-body">If your personal data is processed on the basis of consent, you have the
+        right to:
+      </p>
+
+      <%= render "govuk_publishing_components/components/list", {
+        visible_counters: true,
+        items: [
+          "request a copy of any personal data you have provided, and for this to be provided in a structured, commonly used and machine-readable format",
+        ]
+      } %>
+
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Changes to this notice",
+        margin_bottom: 4,
+        font_size: "m",
+      } %>
+
+      <p class="govuk-body">
+        We may change this privacy notice at our discretion at any time. In that
+        case the ‘Last updated’ date at the top of this page will also change. Any
+        changes to this privacy notice will apply to you and your data
+        immediately. If these changes affect how your personal data is processed,
+        GDS will take reasonable steps to make sure you know.
+      </p>
+
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Questions and complaints",
+        margin_bottom: 4,
+        font_size: "m",
+      } %>
+
+      <p class="govuk-body">
+        The data controller for your personal data is the Cabinet Office. Contact
+        the  GDS Privacy Team if you have any questions or think that
+        your personal data has been misused or mishandled.
+      </p>
+
+      <p class="govuk-body">
+        Email: <%= mail_to 'gds-privacy-office@digital.cabinet-office.gov.uk', nil, class: 'govuk-link' %>
+      </p>
+
+      <p class="govuk-body">
+        The contact details for our Data Protection Officer are:
+      </p>
+
+      <div class="contact">
+        <p class="govuk-body">
+          Data Protection Officer<br />
+          <%= mail_to 'DPO@cabinetoffice.gov.uk', nil, class: 'govuk-link' %><br />
+          Cabinet Office<br />
+          70 Whitehall<br />
+          London <br />
+          SW1A 2AS
+        </p>
+      </div>
+
+      <p class="govuk-body">
+        The Data Protection Officer provides independent advice and monitoring of our use of personal information.
+      </p>
+
+      <p class="govuk-body">
+        If you have a complaint, you can also contact
+        the <%= link_to 'Information Commissioner', 'https://ico.org.uk/', class: 'govuk-link' %>, who
+        is an independent regulator set up to uphold information rights.
+      </p>
+
+      <div class="contact">
+        <p class="govuk-body">
+          Information Commissioner’s Office<br />
+          <%= mail_to 'casework@ico.org.uk', nil, class: 'govuk-link' %><br />
+          0303 123 1113<br />
+          Wycliffe House<br />
+          Water Lane<br />
+          Wilmslow<br />
+          Cheshire<br />
+          SK9 5AF
+        </p>
+      </div>
     </div>
   </div>
 </main>

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -1,85 +1,99 @@
 <% content_for :page_title do %>Terms and conditions<% end %>
 
-<main role="main" id="content">
+<main role="main" id="main-content" class="govuk-main-wrapper">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= render "govuk_publishing_components/components/title", {
+        title: "Terms and conditions"
+      } %>
 
-  <div class="text">
-    <h1 class="heading-large">
-      Terms and conditions
-    </h1>
+      <p class="govuk-body">
+        This page and any pages it links to explains Find open data's terms of use. You must agree to these to use
+        Find open data.
+      </p>
 
-    <p>
-      This page and any pages it links to explains Find open data's terms of use. You must agree to these to use
-      Find open data.
-    </p>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Who we are",
+        margin_bottom: 4,
+        font_size: "m",
+      } %>
 
-    <h2 class="heading-medium">
-      Who we are
-    </h2>
+      <p class="govuk-body">
+        Find open data is managed by <%= link_to 'Government Digital Service', 'https://www.gov.uk/government/organisations/government-digital-service', class: 'govuk-link' %>
+        (GDS) on behalf of the Crown. GDS is part of the Cabinet Office and will be referred to as 'we' from now on.
+      </p>
 
-    <p>
-      Find open data is managed by <%= link_to 'Government Digital Service', 'https://www.gov.uk/government/organisations/government-digital-service', class: 'govuk-link' %>
-      (GDS) on behalf of the Crown. GDS is part of the Cabinet Office and will be referred to as 'we' from now on.
-    </p>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Using Find open data",
+        margin_bottom: 4,
+        font_size: "m",
+      } %>
 
-    <h2 class="heading-medium">
-      Using Find open data
-    </h2>
+      <p class="govuk-body">
+        You agree to use Find open data only for lawful purposes. You must also use it in a way that doesn't infringe the
+        rights of, or restrict or inhibit the use and enjoyment of, this site by anyone else.
+      </p>
 
-    <p>
-      You agree to use Find open data only for lawful purposes. You must also use it in a way that doesn't infringe the
-      rights of, or restrict or inhibit the use and enjoyment of, this site by anyone else.
-    </p>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Linking from Find open data",
+        margin_bottom: 4,
+        font_size: "m",
+      } %>
 
-    <h2 class="heading-medium">
-      Linking from Find open data
-    </h2>
+      <p class="govuk-body">
+        Find open data links to websites that are managed by other government departments and agencies, service providers or
+        other organisations. We don't have any control over the content on these websites.
+      </p>
 
-    <p>
-      Find open data links to websites that are managed by other government departments and agencies, service providers or
-      other organisations. We don't have any control over the content on these websites.
-    </p>
+      <p class="govuk-body">We're not responsible for:</p>
 
-    <p>We're not responsible for:</p>
+      <%= render "govuk_publishing_components/components/list", {
+        visible_counters: true,
+        items: [
+          "the protection of any information you give to these websites",
+          "any loss or damage that may come from your use of these websites, or any other websites they link to",
+        ]
+      } %>
 
-    <ul class="list list-bullet">
-      <li>the protection of any information you give to these websites</li>
-      <li>any loss or damage that may come from your use of these websites, or any other websites they link to</li>
-    </ul>
+      <p class="govuk-body">
+        You agree to release us from any claims or disputes that may come from using these websites.
+      </p>
 
-    <p>
-      You agree to release us from any claims or disputes that may come from using these websites.
-    </p>
+      <p class="govuk-body">
+        You should read all terms and conditions, privacy policies and end user licences that relate to these websites
+        before you use them.
+      </p>
 
-    <p>
-      You should read all terms and conditions, privacy policies and end user licences that relate to these websites
-      before you use them.
-    </p>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Responsibility for datasets",
+        margin_bottom: 4,
+        font_size: "m",
+      } %>
 
-    <h2 class="heading-medium">
-      Responsibility for datasets
-    </h2>
+      <p class="govuk-body">
+        Only publishers with accounts for Find open data can ask for datasets to be deleted.
+        <%= link_to 'Contact us', support_path, class: 'govuk-link' %> to ask for datasets to be deleted if you are a publisher.
+      </p>
 
-    <p>
-      Only publishers with accounts for Find open data can ask for datasets to be deleted.
-      <%= link_to 'Contact us', support_path, class: 'govuk-link' %> to ask for datasets to be deleted if you are a publisher.
-    </p>
+      <p class="govuk-body">
+        Find open data does not host datasets. They are the responsibility of the publishing organisation.
+        All requests for data under the Freedom of Information Act and the Data Protection Act should be sent to the publishing organisation.
+      </p>
 
-    <p>
-      Find open data does not host datasets. They are the responsibility of the publishing organisation.
-      All requests for data under the Freedom of Information Act and the Data Protection Act should be sent to the publishing organisation.
-    </p>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Changes to these terms and conditions",
+        margin_bottom: 4,
+        font_size: "m",
+      } %>
 
-    <h2 class="heading-medium">
-      Changes to these terms and conditions
-    </h2>
+      <p class="govuk-body">
+        Please check these terms and conditions regularly. We can update them at any time without notice.
+      </p>
 
-    <p>
-      Please check these terms and conditions regularly. We can update them at any time without notice.
-    </p>
-
-    <p>
-      You'll agree to any changes if you continue to use Find open data after the terms and conditions have been
-      updated.
-    </p>
+      <p class="govuk-body">
+        You'll agree to any changes if you continue to use Find open data after the terms and conditions have been
+        updated.
+      </p>
+    </div>
   </div>
 </main>


### PR DESCRIPTION
## What
Update the markup, classnames and styling on content pages found in the footer of data.gov.uk. Specifically:

- [the about page](https://data.gov.uk/about)
- [the accessibility statement](https://data.gov.uk/accessibility)
- [the cookie page](https://data.gov.uk/cookies)
- [the privacy policy](https://data.gov.uk/privacy)
- [the terms and conditions](https://data.gov.uk/terms)

## Why
DGU Find is currently using govuk elements, an outdated implementation of the govuk design system. This PR is one of several that attempts to slowly remove the elements implementation and replace it with up to date implementations from govuk frontend and govuk publishing components.

No visual changes.

**Card:** https://trello.com/c/BiH5aTNB/234-update-markup-on-find-content-pages