### PR TITLE
Update dataset page markup for datafile tables

### DIFF
--- a/app/views/datasets/_datafile_table.html.erb
+++ b/app/views/datasets/_datafile_table.html.erb
@@ -1,14 +1,16 @@
-<table class="dgu-datafiles">
-  <tr>
-    <th class="title small"><%= t('.link_to_data') %></th>
-    <th><%= t('.format') %></th>
-    <th><%= t('.file_added') %></th>
-    <th><%= t('.data_preview') %></th>
-  </tr>
-  <tbody>
+<table class="govuk-table govuk-!-margin-bottom-4">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header"><%= t('.link_to_data') %></th>
+      <th scope="col" class="govuk-table__header"><%= t('.format') %></th>
+      <th scope="col" class="govuk-table__header"><%= t('.file_added') %></th>
+      <th scope="col" class="govuk-table__header"><%= t('.data_preview') %></th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
     <% sort_by_created_at(datafiles).each_with_index do |datafile, index| %>
-      <tr class="<%= show_more?(index) %> dgu-datafile">
-        <td class="title small">
+      <tr class="<%= show_more?(index) %> js-datafile-visible govuk-table__row">
+        <td class="govuk-table__cell">
           <%= link_to datafile.url,
               :data => {
                 'ga-event' => "download",
@@ -16,39 +18,43 @@
                 'ga-publisher' => @dataset.organisation.name
               },
               class: 'govuk-link' do %>
-            <span class="visually-hidden">Download </span>
-            <%= (datafile.name ? datafile.name : 'Data') %>
-            <span class='visually-hidden'>, Format: <%= format_of(datafile) %>, Dataset: <%= @dataset.title %></span>
+                <span class="visually-hidden">Download </span>
+                <%= (datafile.name ? datafile.name : 'Data') %>
+                <span class='visually-hidden'>, Format: <%= format_of(datafile) %>, Dataset: <%= @dataset.title %></span>
+              <% end %>
+        </td>
+        
+        <td class="govuk-table__cell">
+          <% if datafile.format.blank? %>
+            <span class="dgu-secondary-text">N/A</span>
+          <% else %>
+            <%= datafile.format.upcase %>
+            <% if datafile.size %>
+              (<%= datafile.size.number_to_human_size %>)
+            <% end %>
           <% end %>
         </td>
-        <% if datafile.format.blank? %>
-          <td class="dgu-secondary-text">N/A</td>
-        <% else %>
-          <td><%= datafile.format.upcase %>
-          <% if datafile.size %>
-            (<%= datafile.size.number_to_human_size %> )
+
+        <td class="govuk-table__cell">
+          <% if datafile.created_at.present? %>
+              <%= format_timestamp(datafile.created_at) %>
+          <% else %>
+            <span class="dgu-secondary-text">Not available</span>
           <% end %>
-          </td>
-        <% end %>
-        <% if datafile.created_at.present? %>
-          <td>
-            <%= format_timestamp(datafile.created_at) %>
-          </td>
-        <% else %>
-          <td class="dgu-secondary-text">Not available</td>
-        <% end %>
-        <td class="datafiles__preview">
+        </td>
+
+        <td class="govuk-table__cell">
           <% if datafile.csv? %>
             <%= link_to datafile_preview_path(@dataset.uuid, @dataset.name, datafile.uuid),
                 :data => {
                   'ga-event' => 'preview',
                   'ga-format' => (datafile.format.presence || 'n/a').upcase,
                   'ga-publisher' => @dataset.organisation.name
-                  },
-                  class: 'govuk-link' do %>
+                },
+                class: 'govuk-link' do %>
                   Preview
                   <span class='visually-hidden'> CSV '<%= datafile.name %>', Dataset: <%= @dataset.title %></span>
-                  <% end %>
+                <% end %>
           <% elsif datafile.wms? && @dataset.inspire_dataset.present? %>
             <%= link_to t('.map_preview'), map_preview_url(@dataset, datafile) %>
           <% else %>
@@ -61,5 +67,5 @@
 </table>
 
 <% if datafiles.length > 5 && !browser.ie?(version: 8) %>
-  <button class="button secondary show-toggle" aria-label="Show more data links">Show more</button>
+  <button class="govuk-button govuk-button--secondary show-toggle" aria-label="Show more data links">Show more</button>
 <% end %>

--- a/app/views/datasets/_no_datafiles.html.erb
+++ b/app/views/datasets/_no_datafiles.html.erb
@@ -1,10 +1,12 @@
-<div class="panel panel-border-narrow">
-  <p><%= t('datasets.show.not_released') %><br />
-  <% if contact_information_exists?(dataset) %>
-    <%= t('datasets.show.contact_the_publisher') %>
-  <% else %>
-    <%= t('datasets.show.contact_the_team') %>
-    <%= link_to 'data.gov.uk/support', support_path, class: 'govuk-link' %>
-    <%= t('datasets.show.if_you_have_questions') %>
-  <% end %>
+<div class="govuk-details__text govuk-!-margin-bottom-4">
+  <p class="govuk-body"><%= t('datasets.show.not_released') %></p>
+  <p class="govuk-body">
+    <% if contact_information_exists?(dataset) %>
+      <%= t('datasets.show.contact_the_publisher') %>
+    <% else %>
+      <%= t('datasets.show.contact_the_team') %>
+      <%= link_to 'data.gov.uk/support', support_path, class: 'govuk-link' %>
+      <%= t('datasets.show.if_you_have_questions') %>
+    <% end %>
+  </p>
 </div>

--- a/spec/features/dataset_show_page_spec.rb
+++ b/spec/features/dataset_show_page_spec.rb
@@ -339,12 +339,12 @@ RSpec.feature "Dataset page", type: :feature, elasticsearch: true do
       index_and_visit(dataset)
 
       expect(page).to have_css("js-show-more-datafiles", count: 0)
-      expect(page).to have_css(".dgu-datafile", count: 5)
+      expect(page).to have_css(".js-datafile-visible", count: 5)
       expect(page).to have_css(".show-toggle", text: "Show more")
 
       find(".show-toggle").click
 
-      expect(page).to have_css(".dgu-datafile", count: 20)
+      expect(page).to have_css(".js-datafile-visible", count: 20)
       expect(page).to have_css(".show-toggle", text: "Show less")
     end
   end


### PR DESCRIPTION
## What
Update the markup, classnames and styling on the individual dataset view datafile partial as well as the partial displayed for no resources.

## Why
DGU Find is currently using govuk elements, an outdated implementation of the govuk design system. This PR is one of several that attempts to slowly remove the elements implementation and replace it with up to date implementations from govuk frontend and govuk publishing components.

This PR was created as part of an effort to [break down the existing dataset view PR](https://github.com/alphagov/datagovuk_find/pull/794) which had grown too large to safely review in one go as it contains a large number of individual features.

## Visual changes
Minor visual change from applying the design system classes to the datafile table.

### Before
![Screenshot 2020-10-07 at 13 16 21](https://user-images.githubusercontent.com/64783893/95329873-8d659880-089f-11eb-84e1-ed7553dfd44b.png)

### After
![Screenshot 2020-10-07 at 13 15 16](https://user-images.githubusercontent.com/64783893/95329891-96566a00-089f-11eb-9502-12cb8942e6b6.png)

**Card:**  https://trello.com/c/h0XbWxq8/233-update-markup-on-find-dataset-page