### PR TITLE
Add auth file to prove ownership of data.gov.uk

### DIFF
--- a/public/googlea6393a390aadfbaa.html
+++ b/public/googlea6393a390aadfbaa.html
@@ -1,0 +1,1 @@
+google-site-verification: googlea6393a390aadfbaa.html


### PR DESCRIPTION
We need to ask google to purge their cached copies of some files. In order for them to trust us we need to prove ownership of data.gov.uk. This adds a file that can be scraped by google to prove we are who we say we are.