### PR TITLE
Restyle table to be clearly separated on page and focusable for keyboard users

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -269,7 +269,19 @@
 // preview page
 
 .dgu-datafile-preview {
-  overflow: auto;
+  border: 5px solid govuk-colour("light-grey");
+  margin-bottom: govuk-spacing(6);
+
+  &__inner {
+    border: 1px solid govuk-colour("mid-grey");
+    padding: govuk-spacing(2) govuk-spacing(4);
+    overflow: auto;
+
+    &:focus {
+      border: 3px solid govuk-colour("black");
+      outline: 3px solid govuk-colour("yellow");
+    }
+  }
 }
 
 // =============================================================================

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -282,6 +282,11 @@
       outline: 3px solid govuk-colour("yellow");
     }
   }
+
+  &__organogram:focus {
+    border: 3px solid govuk-colour("black");
+    outline: 3px solid govuk-colour("yellow");
+  }
 }
 
 // =============================================================================

--- a/app/views/previews/show.html.erb
+++ b/app/views/previews/show.html.erb
@@ -62,10 +62,12 @@
       <div class="govuk-grid-column-full">
         <section id="dgu-preview">
           <div class="dgu-datafile-preview">
-            <%= render "govuk_publishing_components/components/table", {
-              head: table_headings,
-              rows: table_rows
-            } %>
+            <div class="dgu-datafile-preview__inner" tabindex="0">
+              <%= render "govuk_publishing_components/components/table", {
+                head: table_headings,
+                rows: table_rows,
+              } %>
+            </div>
           </div>
         </section>
 

--- a/app/views/previews/show.html.erb
+++ b/app/views/previews/show.html.erb
@@ -72,7 +72,7 @@
         </section>
 
         <% if @dataset.organogram? %>
-          <section id="organogram" data-csv-url="<%= @datafile.url %>">
+          <section id="organogram" class="dgu-datafile-preview__organogram" data-csv-url="<%= @datafile.url %>" tabindex="0">
           </section>
         <% end %>
       </div>


### PR DESCRIPTION
## What
Restyles the table element on the data preview view to wrap it in a set of parent elements that make it more clearly visually distinct and add `tabindex="0"`, allowing the table to be focused when tabbing through the page and for overflowing tables to be navigable via the left and right keys.

## Why
Besides the quality of life change for sighted users, ensuring that tables are navigable for keyboard users is necessary for WCAG 2.1 SC 2.1.1. This PR is also to make completely sure that our preview view doesn't fail SC 1.4.10.

## Visual changes
### Before
![Screenshot 2020-11-03 at 18 05 39](https://user-images.githubusercontent.com/64783893/98023691-36e86d00-1dff-11eb-9073-3e5b5af9b658.png)

### After
![Screenshot 2020-11-03 at 15 40 09](https://user-images.githubusercontent.com/64783893/98023725-436cc580-1dff-11eb-8fc8-200522556c84.png)
![Screenshot 2020-11-03 at 15 40 19](https://user-images.githubusercontent.com/64783893/98023734-47004c80-1dff-11eb-8282-eb4d1bf5d27c.png)
