### PR TITLE
Relax WebMock elasticsearch host constraint

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -33,7 +33,7 @@ Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |f| require f }
 
 FactoryBot.find_definitions
 
-WebMock.disable_net_connect!(allow_localhost: true, allow: %w[elasticsearch elasticsearch6])
+WebMock.disable_net_connect!(allow_localhost: true, allow: /^elasticsearch[-a-z0-9]*$/)
 
 RSpec.configure do |config|
   # RSpec Rails can automatically mix in different behaviours to your tests


### PR DESCRIPTION
There are a range of elasticsearch host names in use by so allow any host that starts with elasticsearch but don't allow FQDN values such as elasticsearch.hosting.tld.