### PR TITLE
Add a manual workaround for Kaminari security issue

### DIFF
--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -4,3 +4,12 @@ end
 
 Kaminari::Hooks.init if defined?(Kaminari::Hooks)
 Elasticsearch::Model::Response::Response.__send__ :include, Elasticsearch::Model::Response::Pagination::Kaminari
+
+# This is a workaround suggested by the Kaminari team to fix a security issue:
+#  https://github.com/kaminari/kaminari/security/advisories/GHSA-r5jw-62xg-j433
+#
+# Ideally we would upgrade to Kaminari 1.2, but we can't because:
+#  https://github.com/elastic/elasticsearch-rails/issues/966
+module Kaminari::Helpers
+  PARAM_KEY_EXCEPT_LIST = [:authenticity_token, :commit, :utf8, :_method, :script_name, :original_script_name].freeze
+end


### PR DESCRIPTION
The details are in the comments, but basically we can't upgrade to a more recent version of Kaminari because of an issue with the Elasticsearch Rails Gem. However, we can put in this workaround as suggested by the Kaminari devs.

[Trello Card](https://trello.com/c/KmPaKL6Z/2240-5-upgrade-kaminari-or-put-in-work-around)