### PR TITLE
Add govuk grid classes to header and nav items

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,12 +31,16 @@
 
     <header role="banner" class="govuk-header" data-module="govuk-header">
       <div class="govuk-header__container govuk-width-container">
-        <div class="govuk-header__logo">
-          <a href="<%= root_path %>" class="govuk-header__link govuk-header__link--homepage">
-              <%= t('.data_gov_uk')%> | <%= t('.find_open_data') %>
-            </a>
+        <div class="govuk-grid-row">
+          <div class="govuk-header__logo govuk-grid-column-one-half">
+            <a href="<%= root_path %>" class="govuk-header__link govuk-header__link--homepage">
+                <%= t('.data_gov_uk')%> | <%= t('.find_open_data') %>
+              </a>
+          </div>
+          <div class="govuk-grid-column-one-half">
+            <%= render 'layouts/proposition_header' %>
+          </div>
         </div>
-        <%= render 'layouts/proposition_header' %>
       </div>
     </header>
 


### PR DESCRIPTION
## What
Adds govuk-grid classes to the header.

## Why
This fixes a layout issue within the header. Find is the only app consuming the separately exposed `navigation_items` sub-component within the [layout header component](https://components.publishing.service.gov.uk/component-guide/layout_header) because it can't legally use the crown logo. Therefore it's missed out on some markup updates to the layout header.

Merging this change will mean that DGU is finally ready for a new release, including using the new, ICO compliant design system cookie banner, minimising risk of legal action against us via a blind spot like DGU.

This bug isn't visible on live but you can see it on staging [here](https://find-data-beta-staging.cloudapps.digital/).

## Visual changes
### Before
![Screenshot 2021-02-26 at 11 29 35](https://user-images.githubusercontent.com/64783893/109295842-592b4e00-7827-11eb-808c-ee7d9fd8f93c.png)

### After
![Screenshot 2021-02-26 at 11 34 31](https://user-images.githubusercontent.com/64783893/109295850-5d576b80-7827-11eb-8d2b-b575c2901204.png)
