### PR TITLE
Stop reporting unactionable errors to Sentry

### DIFF
--- a/app/controllers/map_previews_controller.rb
+++ b/app/controllers/map_previews_controller.rb
@@ -18,8 +18,7 @@ class MapPreviewsController < ApplicationController
     base_wms_url = url_param.gsub(/;jsessionid=[a-z0-9]+/i, ";jsessionid=")
     response = URI(base_wms_url).read
     render xml: Nokogiri::XML(response)
-  rescue StandardError => e
-    Raven.capture_exception(e)
+  rescue StandardError
     head :bad_request
   end
 
@@ -36,8 +35,7 @@ class MapPreviewsController < ApplicationController
                  .force_encoding("ISO-8859-1")
                  .encode("UTF-8")
     render xml: Nokogiri::XML(response)
-  rescue StandardError => e
-    Raven.capture_exception(e)
+  rescue StandardError
     head :bad_request
   end
 


### PR DESCRIPTION
We're seeing [`Net::ReadTimeout`](https://sentry.io/organizations/govuk/issues/2042804257/events/c15035a40e8742fcb0c8d95f2735a313/?project=275549) and [`OpenURI::HTTPError`](https://sentry.io/organizations/govuk/issues/2042232149/events/latest/?project=275549&statsPeriod=24h) Sentry errors stemming from the [MapPreviewsController](https://github.com/alphagov/datagovuk_find/blob/b68b35267bf776a0f3d9540e7521c50a2dfd3bbf/app/controllers/map_previews_controller.rb#L26-L42) in [datagovuk_find](https://github.com/alphagov/datagovuk_find).

Between them, these errors have occurred almost 5k times in 4 months. This 'map preview' was [added in June 2018](https://github.com/alphagov/datagovuk_find/pull/634/files#diff-959bc9abc46a55332bb64d5155a79323afa75a50ec1a2137ddd22d926f62c6c5) with little explanation.

The errors seem to come from trying to read third-party URLs that no longer ‘work’. For example, https://sentry.io/organizations/govuk/issues/2042804257/events/c15035a40e8742fcb0c8d95f2735a313/ …is trying to load http://inspire.misoportal.com/geoserver/sandwell_metropolitan_borough_council_tpo/wms?request=getCapabilities, but it gets a timeout (as do I if I curl or visit in browser).

We _could_ add another `rescue` [here](https://github.com/alphagov/datagovuk_find/blob/e4e30100fc1a3959c3ae4fa6852a0a256f50a254/app/controllers/map_previews_controller.rb#L39) to prevent the `OpenURI::HTTPError`, but that would just cause more `Net::ReadTimeout` errors, so our conclusion is to [remove this line](https://github.com/alphagov/datagovuk_find/blob/e4e30100fc1a3959c3ae4fa6852a0a256f50a254/app/controllers/map_previews_controller.rb#L40), as the errors are not really actionable.

Ideally we would add the following tests too, but as there aren't any existing tests around the `MapPreviewsController`, and we're not changing application behaviour, this seems out of scope. For future reference, however, I dud put together a [very rough spike](https://github.com/alphagov/datagovuk_find/pull/905) as a starting point. We ought to write tests that it returns a 400 Bad Request:

- when the URL contains a `request=` URL param that is anything other than `getcapabilities` or `getfeatureinfo` (case doesn't matter).
- when the URL contains a `service=` URL param that is anything other than `WMS` (case probably doesn't matter here either).
- when the URL 404s

We should also test that it returns a [504](https://httpstatuses.com/504) when the URL times out.