### PR TITLE
Rubocop fixes & Rails 6.1 upgrade

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "govuk_publishing_components"
 gem "htmlentities"
 gem "jbuilder"
 gem "jquery-rails"
-gem "kaminari", "< 1.2"  # do not upgrade this unless elasticsearch is also upgraded
+gem "kaminari", "< 1.2" # do not upgrade this unless elasticsearch is also upgraded
 gem "lograge"
 gem "logstash-event"
 gem "mime-types"

--- a/Rakefile
+++ b/Rakefile
@@ -5,4 +5,4 @@ require_relative "config/application"
 
 Rails.application.load_tasks
 
-task default: %i[brakeman spec]
+task default: %i[brakeman rubocop spec]

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,8 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require_relative 'config/application'
+require_relative "config/application"
 
 Rails.application.load_tasks
 
-task default: %i(brakeman spec)
+task default: %i[brakeman spec]

--- a/bin/rails
+++ b/bin/rails
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+load File.expand_path("spring", __dir__)
 APP_PATH = File.expand_path('../config/application', __dir__)
-require_relative '../config/boot'
-require 'rails/commands'
+require_relative "../config/boot"
+require "rails/commands"

--- a/bin/rake
+++ b/bin/rake
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
-require_relative '../config/boot'
-require 'rake'
+load File.expand_path("spring", __dir__)
+require_relative "../config/boot"
+require "rake"
 Rake.application.run

--- a/bin/setup
+++ b/bin/setup
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-require 'fileutils'
+require "fileutils"
 
 # path to your application root.
 APP_ROOT = File.expand_path('..', __dir__)
@@ -9,8 +9,8 @@ def system!(*args)
 end
 
 FileUtils.chdir APP_ROOT do
-  # This script is a way to setup or update your development environment automatically.
-  # This script is idempotent, so that you can run it at anytime and get an expectable outcome.
+  # This script is a way to set up or update your development environment automatically.
+  # This script is idempotent, so that you can run it at any time and get an expectable outcome.
   # Add necessary setup steps to this file.
 
   puts '== Installing dependencies =='
@@ -18,7 +18,7 @@ FileUtils.chdir APP_ROOT do
   system('bundle check') || system!('bundle install')
 
   # Install JavaScript dependencies
-  system!('bin/yarn')
+  system! 'bin/yarn'
 
   puts "\n== Removing old logs and tempfiles =="
   system! 'bin/rails log:clear tmp:clear'

--- a/bin/spring
+++ b/bin/spring
@@ -1,17 +1,14 @@
 #!/usr/bin/env ruby
+if !defined?(Spring) && [nil, "development", "test"].include?(ENV["RAILS_ENV"])
+  gem "bundler"
+  require "bundler"
 
-# This file loads spring without using Bundler, in order to be fast.
-# It gets overwritten when you run the `spring binstub` command.
-
-unless defined?(Spring)
-  require 'rubygems'
-  require 'bundler'
-
-  lockfile = Bundler::LockfileParser.new(Bundler.default_lockfile.read)
-  spring = lockfile.specs.detect { |spec| spec.name == "spring" }
-  if spring
+  # Load Spring without loading other gems in the Gemfile, for speed.
+  Bundler.locked_gems&.specs&.find { |spec| spec.name == "spring" }&.tap do |spring|
     Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
-    gem 'spring', spring.version
-    require 'spring/binstub'
+    gem "spring", spring.version
+    require "spring/binstub"
+  rescue Gem::LoadError
+    # Ignore when Spring is not installed.
   end
 end

--- a/bin/yarn
+++ b/bin/yarn
@@ -1,9 +1,15 @@
 #!/usr/bin/env ruby
 APP_ROOT = File.expand_path('..', __dir__)
 Dir.chdir(APP_ROOT) do
-  begin
-    exec "yarnpkg", *ARGV
-  rescue Errno::ENOENT
+  yarn = ENV["PATH"].split(File::PATH_SEPARATOR).
+    select { |dir| File.expand_path(dir) != __dir__ }.
+    product(["yarn", "yarn.cmd", "yarn.ps1"]).
+    map { |dir, file| File.expand_path(file, dir) }.
+    find { |file| File.executable?(file) }
+
+  if yarn
+    exec yarn, *ARGV
+  else
     $stderr.puts "Yarn executable was not detected in the system."
     $stderr.puts "Download Yarn at https://yarnpkg.com/en/docs/install"
     exit 1

--- a/config.ru
+++ b/config.ru
@@ -1,5 +1,6 @@
 # This file is used by Rack-based servers to start the application.
 
-require_relative 'config/environment'
+require_relative "config/environment"
 
 run Rails.application
+Rails.application.load_server

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,7 +38,7 @@ end
 module FindDataBeta
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 6.0
+    config.load_defaults 6.1
 
     # Make `form_with` generate non-remote forms.
     config.action_view.form_with_generates_remote_forms = false

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,4 +1,4 @@
-require_relative 'boot'
+require_relative "boot"
 
 require "active_model/railtie"
 require "action_controller/railtie"
@@ -13,10 +13,10 @@ Bundler.require(*Rails.groups)
 if ENV["VCAP_SERVICES"]
   services = JSON.parse(ENV["VCAP_SERVICES"])
 
-  if services.key?('user-provided')
+  if services.key?("user-provided")
     # Extract UPSes and pull out secrets configs
-    user_provided_services = services['user-provided'].select { |s| s['name'].include?('secrets') }
-    credentials = user_provided_services.map { |s| s['credentials'] }.reduce(:merge)
+    user_provided_services = services["user-provided"].select { |s| s["name"].include?("secrets") }
+    credentials = user_provided_services.map { |s| s["credentials"] }.reduce(:merge)
 
     # Take each credential and assign to ENV
     credentials.each do |k, v|
@@ -40,12 +40,12 @@ module FindDataBeta
     # https://github.com/alphagov/govuk-frontend/issues/1350
     config.assets.css_compressor = nil
 
-    config.action_dispatch.rescue_responses['Datafile::DatafileNotFound'] = :not_found
-    config.action_dispatch.rescue_responses['Dataset::DatasetNotFound'] = :not_found
-    config.exceptions_app = self.routes
+    config.action_dispatch.rescue_responses["Datafile::DatafileNotFound"] = :not_found
+    config.action_dispatch.rescue_responses["Dataset::DatasetNotFound"] = :not_found
+    config.exceptions_app = routes
 
-    config.analytics_tracking_id = ENV['GA_TRACKING_ID']
-    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '**', '*.{rb,yml}')]
+    config.analytics_tracking_id = ENV["GA_TRACKING_ID"]
+    config.i18n.load_path += Dir[Rails.root.join("config/locales/**/**/*.{rb,yml}")]
     config.filter_parameters << :password
     config.filter_parameters << :password_confirmation
 
@@ -54,12 +54,12 @@ module FindDataBeta
     config.ssl_options = { hsts: { expires: 1.week } }
 
     config.action_dispatch.default_headers = {
-      'X-Frame-Options' => 'DENY',
-      'X-Content-Type-Options' => 'nosniff',
-      'X-XSS-Protection' => '1; mode=block',
-      'X-Download-Options' => 'noopen',
-      'X-Permitted-Cross-Domain-Policies' => 'none',
-      'Referrer-Policy' => %w(origin-when-cross-origin strict-origin-when-cross-origin)
+      "X-Frame-Options" => "DENY",
+      "X-Content-Type-Options" => "nosniff",
+      "X-XSS-Protection" => "1; mode=block",
+      "X-Download-Options" => "noopen",
+      "X-Permitted-Cross-Domain-Policies" => "none",
+      "Referrer-Policy" => %w[origin-when-cross-origin strict-origin-when-cross-origin],
     }
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,8 +1,17 @@
 require_relative "boot"
 
+require "rails"
+# Pick the frameworks you want:
 require "active_model/railtie"
+require "active_job/railtie"
+# require "active_record/railtie"
+# require "active_storage/engine"
 require "action_controller/railtie"
 require "action_mailer/railtie"
+# require "action_mailbox/engine"
+# require "action_text/engine"
+require "action_view/railtie"
+# require "action_cable/engine"
 require "sprockets/railtie"
 require "rails/test_unit/railtie"
 

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,4 +1,4 @@
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
-require 'bundler/setup' # Set up gems listed in the Gemfile.
-require 'bootsnap/setup' # Speed up boot time by caching expensive operations.
+require "bundler/setup" # Set up gems listed in the Gemfile.
+require "bootsnap/setup" # Speed up boot time by caching expensive operations.

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,5 +1,5 @@
 # Load the Rails application.
-require_relative 'application'
+require_relative "application"
 
 # Initialize the Rails application.
 Rails.application.initialize!

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,8 +1,10 @@
+require "active_support/core_ext/integer/time"
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  # In the development environment your application's code is reloaded on
-  # every request. This slows down response time but is perfect for development
+  # In the development environment your application's code is reloaded any time
+  # it changes. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.
   config.cache_classes = false
 
@@ -36,6 +38,12 @@ Rails.application.configure do
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 
+  # Raise exceptions for disallowed deprecations.
+  config.active_support.disallowed_deprecation = :raise
+
+  # Tell Active Support which deprecation messages to disallow.
+  config.active_support.disallowed_deprecation_warnings = []
+
   # Debug mode disables concatenation and preprocessing of assets.
   # This option may cause significant delays in view rendering with a large
   # number of complex assets.
@@ -45,11 +53,17 @@ Rails.application.configure do
   config.assets.quiet = true
 
   # Raises error for missing translations.
-  config.action_view.raise_on_missing_translations = true
+  config.i18n.raise_on_missing_translations = true
+
+  # Annotate rendered view with file names.
+  # config.action_view.annotate_rendered_view_with_filenames = true
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  # Uncomment if you wish to allow Action Cable access from any origin.
+  # config.action_cable.disable_request_forgery_protection = true
 
   config.zendesk = nil
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -14,13 +14,13 @@ Rails.application.configure do
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
-  if Rails.root.join('tmp', 'caching-dev.txt').exist?
+  if Rails.root.join("tmp/caching-dev.txt").exist?
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
 
     config.cache_store = :memory_store
     config.public_file_server.headers = {
-      'Cache-Control' => "public, max-age=#{2.days.to_i}"
+      "Cache-Control" => "public, max-age=#{2.days.to_i}",
     }
   else
     config.action_controller.perform_caching = false
@@ -53,5 +53,5 @@ Rails.application.configure do
 
   config.zendesk = nil
 
-  config.ckan_redirection_url = ENV['CKAN_REDIRECTION_URL']
+  config.ckan_redirection_url = ENV["CKAN_REDIRECTION_URL"]
 end

--- a/config/environments/integration.rb
+++ b/config/environments/integration.rb
@@ -1,1 +1,1 @@
-require_relative './production'
+require_relative "./production"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,3 +1,5 @@
+require "active_support/core_ext/integer/time"
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -27,7 +29,6 @@ Rails.application.configure do
 
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass
-
   # Rather than use a CSS compressor, use the SASS style to perform compression.
   config.sass.style = :compressed
   config.sass.line_comments = false
@@ -36,7 +37,7 @@ Rails.application.configure do
   config.assets.compile = false
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  # config.action_controller.asset_host = 'http://assets.example.com'
+  # config.asset_host = 'http://assets.example.com'
 
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
@@ -45,8 +46,8 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
-  # Use the lowest log level to ensure availability of diagnostic information
-  # when problems arise.
+  # Include generic and useful information about system operation, but avoid logging too much
+  # information to avoid inadvertent exposure of personally identifiable information (PII).
   config.log_level = :info
 
   # Prepend all log lines with the following tags.
@@ -67,23 +68,29 @@ Rails.application.configure do
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
-  config.i18n.fallbacks = [I18n.default_locale]
+  config.i18n.fallbacks = true
 
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify
 
+  # Log disallowed deprecations.
+  config.active_support.disallowed_deprecation = :log
+
+  # Tell Active Support which deprecation messages to disallow.
+  config.active_support.disallowed_deprecation_warnings = []
+
   # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.lograge.formatter = Lograge::Formatters::Logstash.new
+  config.log_formatter = ::Logger::Formatter.new
 
   # Use a different logger for distributed setups.
-  # require 'syslog/logger'
+  # require "syslog/logger"
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
   if ENV["RAILS_LOG_TO_STDOUT"].present?
-    config.logger = ActiveSupport::Logger.new(STDOUT)
+    logger           = ActiveSupport::Logger.new(STDOUT)
+    logger.formatter = config.log_formatter
+    config.logger    = ActiveSupport::TaggedLogging.new(logger)
   end
-
-  config.ckan_redirection_url = ENV["CKAN_REDIRECTION_URL"]
 
   # Inserts middleware to perform automatic connection switching.
   # The `database_selector` hash is used to pass options to the DatabaseSelector
@@ -105,4 +112,6 @@ Rails.application.configure do
   # config.active_record.database_selector = { delay: 2.seconds }
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+
+  config.ckan_redirection_url = ENV["CKAN_REDIRECTION_URL"]
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -20,7 +20,7 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   # Compress JS using a preprocessor.
   config.assets.js_compressor = :uglifier
@@ -50,7 +50,7 @@ Rails.application.configure do
   config.log_level = :info
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [ :request_id ]
+  config.log_tags = [:request_id]
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
@@ -83,7 +83,7 @@ Rails.application.configure do
     config.logger = ActiveSupport::Logger.new(STDOUT)
   end
 
-  config.ckan_redirection_url = ENV['CKAN_REDIRECTION_URL']
+  config.ckan_redirection_url = ENV["CKAN_REDIRECTION_URL"]
 
   # Inserts middleware to perform automatic connection switching.
   # The `database_selector` hash is used to pass options to the DatabaseSelector

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -1,1 +1,1 @@
-require_relative './production'
+require_relative "./production"

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,3 +1,5 @@
+require "active_support/core_ext/integer/time"
+
 # The test environment is used exclusively to run your application's
 # test suite. You never need to work with it otherwise. Remember that
 # your test database is "scratch space" for the test suite and is wiped
@@ -20,15 +22,15 @@ Rails.application.configure do
     "Cache-Control" => "public, max-age=#{1.hour.to_i}",
   }
 
-  # Handle errors and disable caching.
-  config.consider_all_requests_local = false
+  # Show full error reports and disable caching.
+  config.consider_all_requests_local       = false
   config.action_controller.perform_caching = false
   config.cache_store = :null_store
 
-  # Render exceptions instead of raising them
+  # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = true
 
-  # The support forms require CSRF authentication, this should be checked in the tests
+  # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = true
 
   config.action_mailer.perform_caching = false
@@ -41,6 +43,15 @@ Rails.application.configure do
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 
+  # Raise exceptions for disallowed deprecations.
+  config.active_support.disallowed_deprecation = :raise
+
+  # Tell Active Support which deprecation messages to disallow.
+  config.active_support.disallowed_deprecation_warnings = []
+
   # Raises error for missing translations.
-  config.action_view.raise_on_missing_translations = true
+  # config.i18n.raise_on_missing_translations = true
+
+  # Annotate rendered view with file names.
+  # config.action_view.annotate_rendered_view_with_filenames = true
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -17,7 +17,7 @@ Rails.application.configure do
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = {
-    'Cache-Control' => "public, max-age=#{1.hour.to_i}"
+    "Cache-Control" => "public, max-age=#{1.hour.to_i}",
   }
 
   # Handle errors and disable caching.

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -4,7 +4,7 @@
 Rails.application.config.assets.initialize_on_precompile = false
 
 # Version of your assets, change this if you want to expire all your assets.
-Rails.application.config.assets.version = '1.0'
+Rails.application.config.assets.version = "1.0"
 
 # Compile assets to a location that doesn't conflict with upstream requests
 Rails.application.config.assets.prefix = "/find-assets"
@@ -12,9 +12,9 @@ Rails.application.config.assets.prefix = "/find-assets"
 # Add additional assets to the asset load path.
 # Rails.application.config.assets.paths << Emoji.images_path
 # Add Yarn node_modules folder to the asset load path.
-Rails.application.config.assets.paths << Rails.root.join('node_modules')
+Rails.application.config.assets.paths << Rails.root.join("node_modules")
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
-Rails.application.config.assets.precompile += %w(map-preview.css map-preview.js)
+Rails.application.config.assets.precompile += %w[map-preview.css map-preview.js]

--- a/config/initializers/backtrace_silencers.rb
+++ b/config/initializers/backtrace_silencers.rb
@@ -1,7 +1,8 @@
 # Be sure to restart your server when you modify this file.
 
 # You can add backtrace silencers for libraries that you're using but don't wish to see in your backtraces.
-# Rails.backtrace_cleaner.add_silencer { |line| line =~ /my_noisy_library/ }
+# Rails.backtrace_cleaner.add_silencer { |line| /my_noisy_library/.match?(line) }
 
-# You can also remove all the silencers if you're trying to debug a problem that might stem from framework code.
-# Rails.backtrace_cleaner.remove_silencers!
+# You can also remove all the silencers if you're trying to debug a problem that might stem from framework code
+# by setting BACKTRACE=1 before calling your invocation, like "BACKTRACE=1 ./bin/rails runner 'MyClass.perform'".
+Rails.backtrace_cleaner.remove_silencers! if ENV["BACKTRACE"]

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -1,0 +1,30 @@
+# Be sure to restart your server when you modify this file.
+
+# Define an application-wide content security policy
+# For further information see the following documentation
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
+
+# Rails.application.config.content_security_policy do |policy|
+#   policy.default_src :self, :https
+#   policy.font_src    :self, :https, :data
+#   policy.img_src     :self, :https, :data
+#   policy.object_src  :none
+#   policy.script_src  :self, :https
+#   policy.style_src   :self, :https
+#   # If you are using webpack-dev-server then specify webpack-dev-server host
+#   policy.connect_src :self, :https, "http://localhost:3035", "ws://localhost:3035" if Rails.env.development?
+
+#   # Specify URI for violation reports
+#   # policy.report_uri "/csp-violation-report-endpoint"
+# end
+
+# If you are using UJS then enable automatic nonce generation
+# Rails.application.config.content_security_policy_nonce_generator = -> request { SecureRandom.base64(16) }
+
+# Set the nonce only to specific directives
+# Rails.application.config.content_security_policy_nonce_directives = %w(script-src)
+
+# Report CSP violations to a specified URI
+# For further information see the following documentation:
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only
+# Rails.application.config.content_security_policy_report_only = true

--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -7,7 +7,7 @@ if host.blank?
   host = vcap.dig("elasticsearch", 0, "credentials", "uri")
 end
 
-raise StandardError.new("No elasticsearch environment variables found") if host.blank?
+raise StandardError, "No elasticsearch environment variables found" if host.blank?
 
 Elasticsearch::Model.client = Elasticsearch::Client.new(
   host: host,

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,4 +1,6 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password]
+Rails.application.config.filter_parameters += %i[
+  passw secret token _key crypt salt certificate otp ssn
+]

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -3,7 +3,7 @@ Kaminari.configure do |config|
 end
 
 Kaminari::Hooks.init if defined?(Kaminari::Hooks)
-Elasticsearch::Model::Response::Response.__send__ :include, Elasticsearch::Model::Response::Pagination::Kaminari
+Elasticsearch::Model::Response::Response.include Elasticsearch::Model::Response::Pagination::Kaminari
 
 # This is a workaround suggested by the Kaminari team to fix a security issue:
 #  https://github.com/kaminari/kaminari/security/advisories/GHSA-r5jw-62xg-j433
@@ -11,5 +11,5 @@ Elasticsearch::Model::Response::Response.__send__ :include, Elasticsearch::Model
 # Ideally we would upgrade to Kaminari 1.2, but we can't because:
 #  https://github.com/elastic/elasticsearch-rails/issues/966
 module Kaminari::Helpers
-  PARAM_KEY_EXCEPT_LIST = [:authenticity_token, :commit, :utf8, :_method, :script_name, :original_script_name].freeze
+  PARAM_KEY_EXCEPT_LIST = %i[authenticity_token commit utf8 _method script_name original_script_name].freeze
 end

--- a/config/initializers/new_framework_defaults_6_1.rb
+++ b/config/initializers/new_framework_defaults_6_1.rb
@@ -1,0 +1,67 @@
+# Be sure to restart your server when you modify this file.
+#
+# This file contains migration options to ease your Rails 6.1 upgrade.
+#
+# Once upgraded flip defaults one by one to migrate to the new default.
+#
+# Read the Guide for Upgrading Ruby on Rails for more info on each option.
+
+# Support for inversing belongs_to -> has_many Active Record associations.
+# Rails.application.config.active_record.has_many_inversing = true
+
+# Track Active Storage variants in the database.
+# Rails.application.config.active_storage.track_variants = true
+
+# Apply random variation to the delay when retrying failed jobs.
+# Rails.application.config.active_job.retry_jitter = 0.15
+
+# Stop executing `after_enqueue`/`after_perform` callbacks if
+# `before_enqueue`/`before_perform` respectively halts with `throw :abort`.
+# Rails.application.config.active_job.skip_after_callbacks_if_terminated = true
+
+# Specify cookies SameSite protection level: either :none, :lax, or :strict.
+#
+# This change is not backwards compatible with earlier Rails versions.
+# It's best enabled when your entire app is migrated and stable on 6.1.
+# Rails.application.config.action_dispatch.cookies_same_site_protection = :lax
+
+# Generate CSRF tokens that are encoded in URL-safe Base64.
+#
+# This change is not backwards compatible with earlier Rails versions.
+# It's best enabled when your entire app is migrated and stable on 6.1.
+# Rails.application.config.action_controller.urlsafe_csrf_tokens = true
+
+# Specify whether `ActiveSupport::TimeZone.utc_to_local` returns a time with an
+# UTC offset or a UTC time.
+# ActiveSupport.utc_to_local_returns_utc_offset_times = true
+
+# Change the default HTTP status code to `308` when redirecting non-GET/HEAD
+# requests to HTTPS in `ActionDispatch::SSL` middleware.
+# Rails.application.config.action_dispatch.ssl_default_redirect_status = 308
+
+# Use new connection handling API. For most applications this won't have any
+# effect. For applications using multiple databases, this new API provides
+# support for granular connection swapping.
+# Rails.application.config.active_record.legacy_connection_handling = false
+
+# Make `form_with` generate non-remote forms by default.
+# Rails.application.config.action_view.form_with_generates_remote_forms = false
+
+# Set the default queue name for the analysis job to the queue adapter default.
+# Rails.application.config.active_storage.queues.analysis = nil
+
+# Set the default queue name for the purge job to the queue adapter default.
+# Rails.application.config.active_storage.queues.purge = nil
+
+# Set the default queue name for the incineration job to the queue adapter default.
+# Rails.application.config.action_mailbox.queues.incineration = nil
+
+# Set the default queue name for the routing job to the queue adapter default.
+# Rails.application.config.action_mailbox.queues.routing = nil
+
+# Set the default queue name for the mail deliver job to the queue adapter default.
+# Rails.application.config.action_mailer.deliver_later_queue_name = nil
+
+# Generate a `Link` header that gives a hint to modern browsers about
+# preloading assets when using `javascript_include_tag` and `stylesheet_link_tag`.
+# Rails.application.config.action_view.preload_links_header = true

--- a/config/initializers/permissions_policy.rb
+++ b/config/initializers/permissions_policy.rb
@@ -1,0 +1,11 @@
+# Define an application-wide HTTP permissions policy. For further
+# information see https://developers.google.com/web/updates/2018/06/feature-policy
+#
+# Rails.application.config.permissions_policy do |f|
+#   f.camera      :none
+#   f.gyroscope   :none
+#   f.microphone  :none
+#   f.usb         :none
+#   f.fullscreen  :self
+#   f.payment     :self, "https://secure.example.com"
+# end

--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -1,5 +1,5 @@
 Raven.configure do |config|
-  config.dsn = ENV['SENTRY_DSN'] if ENV['SENTRY_DSN']
+  config.dsn = ENV["SENTRY_DSN"] if ENV["SENTRY_DSN"]
   config.rails_report_rescued_exceptions = false
   config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
 end

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -9,6 +9,6 @@ SecureHeaders::Configuration.default do |config|
     media_src: ["'self'"],
     object_src: ["'self'"],
     script_src: ["'unsafe-inline'", "'self'", "www.google-analytics.com"],
-    style_src: ["'unsafe-inline'", "'self'"]
+    style_src: ["'unsafe-inline'", "'self'"],
   }
 end

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,2 +1,1 @@
 Rails.application.config.session_store :cookie_store, expire_after: 14.days, secure: !(Rails.env.development? || Rails.env.test?), httponly: true
-

--- a/config/initializers/zendesk.rb
+++ b/config/initializers/zendesk.rb
@@ -4,15 +4,15 @@ module Zendesk
     return DummyClient.instance if Rails.env.test?
 
     ZendeskAPI::Client.new do |config|
-      config.username = ENV['ZENDESK_USERNAME']
-      config.token = ENV['ZENDESK_API_KEY']
-      config.url = ENV['ZENDESK_END_POINT']
+      config.username = ENV["ZENDESK_USERNAME"]
+      config.token = ENV["ZENDESK_API_KEY"]
+      config.url = ENV["ZENDESK_END_POINT"]
     end
   end
 
   class DummyClient
     def self.instance
-      @instance ||= self.new
+      @instance ||= new
     end
 
     def tickets
@@ -22,7 +22,7 @@ module Zendesk
 
   class DummyTickets
     def self.instance
-      @instance ||= self.new
+      @instance ||= new
     end
 
     def create!(_arg); end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -8,9 +8,14 @@ max_threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
 min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
 threads min_threads_count, max_threads_count
 
+# Specifies the `worker_timeout` threshold that Puma will use to wait before
+# terminating a worker in development environments.
+#
+worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
+
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port        ENV.fetch("PORT") { 3000 }
+port ENV.fetch("PORT") { 3000 }
 
 # Specifies the `environment` that Puma will run in.
 #

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,63 +1,63 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-  root to: 'pages#home'
+  root to: "pages#home"
 
   get "/sites/default/files/*organogram_path", to: redirect("https://s3-eu-west-1.amazonaws.com/datagovuk-#{Rails.env}-ckan-organogram/legacy/%{organogram_path}"), format: false
 
   if ENV["CKAN_REDIRECTION_URL"].present?
-    get 'dataset/edit/:legacy_name', to: redirect(domain: ENV['CKAN_REDIRECTION_URL'], subdomain: '', path: "/dataset/edit/%{legacy_name}")
+    get "dataset/edit/:legacy_name", to: redirect(domain: ENV["CKAN_REDIRECTION_URL"], subdomain: "", path: "/dataset/edit/%{legacy_name}")
   end
 
-  get 'dataset/:uuid', to: 'datasets#show', uuid: /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/
+  get "dataset/:uuid", to: "datasets#show", uuid: /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/
 
-  scope module: 'legacy' do
-    get 'dataset/:legacy_name',
-        to: 'datasets#available_soon',
+  scope module: "legacy" do
+    get "dataset/:legacy_name",
+        to: "datasets#available_soon",
         constraints: ReferrerConstraint.new
 
-    get 'dataset/:legacy_name',                                 to: 'datasets#redirect'
-    get 'dataset/:legacy_dataset_name/resource/:datafile_uuid', to: 'datafiles#redirect'
+    get "dataset/:legacy_name",                                 to: "datasets#redirect"
+    get "dataset/:legacy_dataset_name/resource/:datafile_uuid", to: "datafiles#redirect"
 
-    get 'data/search', to: 'search#redirect'
+    get "data/search", to: "search#redirect"
   end
 
-  scope module: 'pages' do
-    get 'about'
-    get 'accessibility'
-    get 'cookies'
-    get 'dashboard'
-    get 'privacy'
-    get 'publishers'
-    get 'site-changes', to: :site_changes
-    get 'support'
-    get 'terms'
-    get 'ckan_maintenance'
+  scope module: "pages" do
+    get "about"
+    get "accessibility"
+    get "cookies"
+    get "dashboard"
+    get "privacy"
+    get "publishers"
+    get "site-changes", to: :site_changes
+    get "support"
+    get "terms"
+    get "ckan_maintenance"
   end
 
   match "404", to: "errors#not_found", via: :all
   match "500", to: "errors#internal_server_error", via: :all
 
-  get 'search/', to: 'search#search'
+  get "search/", to: "search#search"
 
   resources :tickets, only: %i[new create]
-  get 'tickets/confirmation', to: 'tickets#confirmation'
+  get "tickets/confirmation", to: "tickets#confirmation"
 
-  get 'data/map-preview', to: 'map_previews#show', as: 'map_preview'
+  get "data/map-preview", to: "map_previews#show", as: "map_preview"
 
   defaults format: :xml do
-    get 'data/preview_proxy', to: 'map_previews#proxy'
-    get 'data/preview_getinfo', to: 'map_previews#getinfo'
+    get "data/preview_proxy", to: "map_previews#proxy"
+    get "data/preview_getinfo", to: "map_previews#getinfo"
   end
 
-  get 'dataset/:uuid/:name', to: 'datasets#show', as: 'dataset'
-  get 'dataset/:dataset_uuid/:name/datafile/:datafile_uuid/preview', to: 'previews#show', as: 'datafile_preview'
+  get "dataset/:uuid/:name", to: "datasets#show", as: "dataset"
+  get "dataset/:dataset_uuid/:name/datafile/:datafile_uuid/preview", to: "previews#show", as: "datafile_preview"
 
-  get 'acknowledge', to: 'messages#acknowledge'
+  get "acknowledge", to: "messages#acknowledge"
 
   # Route everything else to CKAN
   if ENV["CKAN_REDIRECTION_URL"].present?
-    match '*path',
-          to: redirect(domain: ENV['CKAN_REDIRECTION_URL'], subdomain: '', path: "/%{path}"),
+    match "*path",
+          to: redirect(domain: ENV["CKAN_REDIRECTION_URL"], subdomain: "", path: "/%{path}"),
           via: :all,
           constraints: { path: /(?!#{Regexp.quote(Rails.application.config.assets.prefix[1..-1])}).+/ }
   end

--- a/config/spring.rb
+++ b/config/spring.rb
@@ -2,5 +2,5 @@ Spring.watch(
   ".ruby-version",
   ".rbenv-vars",
   "tmp/restart.txt",
-  "tmp/caching-dev.txt"
+  "tmp/caching-dev.txt",
 )

--- a/scripts/set-credential.rb
+++ b/scripts/set-credential.rb
@@ -1,5 +1,5 @@
 #!/usr/local/bin/ruby -w
-require 'json'
+require "json"
 
 app = ARGV[0]
 key = ARGV[1]
@@ -8,7 +8,7 @@ value = ARGV[2]
 puts "Reading env from '#{app}'..."
 app_env = `cf env #{app}`
 
-sys_env = app_env.split('System-Provided:').last.split("{\n \"VCAP_APP").first.delete("\n")
+sys_env = app_env.split("System-Provided:").last.split("{\n \"VCAP_APP").first.delete("\n")
 sys_env = JSON.parse(sys_env)
 
 puts "Got application env, detecting credentials service name..."
@@ -17,7 +17,7 @@ secret_service = sys_env["VCAP_SERVICES"]["user-provided"].select { |s| s["name"
 puts "Using secrets service '#{secret_service['name']}'"
 puts "\nWARNING! This is a potentially destructive operation!"
 puts "Do you wish to continue changing #{key} on #{secret_service['name']}? [yN]"
-unless %w(y yes).include?(STDIN.gets.chomp.downcase)
+unless %w[y yes].include?(STDIN.gets.chomp.downcase)
   puts "Aborting"
   exit
 end


### PR DESCRIPTION
Follow-on from #897. This PR fixes Rubocop issues, adds Rubocop to the default Rake task (to prevent linting issues in future), and then manually upgrades to the 6.1 Rails config.

Trello: https://trello.com/c/nWRFaLO3/2562-manually-bump-apps-to-rails-61