### PR TITLE
Fix rubocop invocation in default task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,4 +5,9 @@ require_relative "config/application"
 
 Rails.application.load_tasks
 
-task default: %i[brakeman rubocop spec]
+desc "lint Ruby"
+task lint: :environment do
+  sh "bundle exec rubocop"
+end
+
+task default: %i[brakeman lint spec]


### PR DESCRIPTION
This follows the same approach as Content Publisher.
Without this, the default task fails with "Don't know how
to build task 'rubocop'"