### PR TITLE
Stricter numeric checks with ability to handle nil values

### DIFF
--- a/app/helpers/previews_helper.rb
+++ b/app/helpers/previews_helper.rb
@@ -7,7 +7,9 @@ module PreviewsHelper
     end
   end
 
-  def is_numeric(string)
-    string.match?(/\d/)
+  def is_numeric(value)
+    return false unless value.respond_to?(:match?)
+
+    value.match?(/\d/)
   end
 end

--- a/app/helpers/previews_helper.rb
+++ b/app/helpers/previews_helper.rb
@@ -7,7 +7,7 @@ module PreviewsHelper
     end
   end
 
-  def is_numeric(value)
+  def numeric?(value)
     return false unless value.respond_to?(:match?)
 
     value.match?(/\d/)

--- a/app/helpers/previews_helper.rb
+++ b/app/helpers/previews_helper.rb
@@ -8,8 +8,13 @@ module PreviewsHelper
   end
 
   def numeric?(value)
-    return false unless value.respond_to?(:match?)
-
-    value.match?(/\d/)
+    value.to_s.match?(/\A
+                      \-? # may be negative
+                      (
+                        \d+(\.\d+)? # digits, potential followed by decimal
+                        |
+                        \.\d+ # decimal point followed by digits
+                      )
+                      \Z/x)
   end
 end

--- a/app/views/previews/show.html.erb
+++ b/app/views/previews/show.html.erb
@@ -23,7 +23,7 @@
               row.each do |col|
                 table_row << {
                   text: col,
-                  format: is_numeric(col) ? "numeric" : false
+                  format: numeric?(col) ? "numeric" : false
                 }
               end
               table_rows <<  table_row
@@ -39,7 +39,7 @@
             end
           end
         %>
-        
+
         <p class="govuk-body"><%= t('.preview_line', line_count: @datafile.preview.line_count) %></p>
         <%= link_to download_text(@dataset, @datafile), @datafile.url,
           class: "govuk-button",

--- a/spec/helpers/previews_helper_spec.rb
+++ b/spec/helpers/previews_helper_spec.rb
@@ -6,8 +6,28 @@ RSpec.describe PreviewsHelper do
       expect(helper.numeric?("123")).to be true
     end
 
-    it "returns false when given a text string" do
-      expect(helper.numeric?("some text")).to be false
+    it "returns true when given a negative number" do
+      expect(helper.numeric?("-123")).to be true
+    end
+
+    it "returns true when given a number with a decimal" do
+      expect(helper.numeric?("123.45")).to be true
+    end
+
+    it "returns true when given a number prefixed with a decimal point" do
+      expect(helper.numeric?(".45")).to be true
+    end
+
+    it "returns false when given text" do
+      expect(helper.numeric?("some text with 1 number")).to be false
+    end
+
+    it "returns false when given number in a formatted presentation" do
+      expect(helper.numeric?("020 123 12345")).to be false
+    end
+
+    it "returns false when given a number with multiple decimal points" do
+      expect(helper.numeric?("100.34.45")).to be false
     end
 
     it "returns false when given a non-string object" do

--- a/spec/helpers/previews_helper_spec.rb
+++ b/spec/helpers/previews_helper_spec.rb
@@ -1,17 +1,17 @@
 require "rails_helper"
 
 RSpec.describe PreviewsHelper do
-  describe "#is_numeric" do
+  describe "#numeric?" do
     it "returns true when given an integer as a string" do
-      expect(helper.is_numeric("123")).to be true
+      expect(helper.numeric?("123")).to be true
     end
 
     it "returns false when given a text string" do
-      expect(helper.is_numeric("some text")).to be false
+      expect(helper.numeric?("some text")).to be false
     end
 
     it "returns false when given a non-string object" do
-      expect(helper.is_numeric(nil)).to be false
+      expect(helper.numeric?(nil)).to be false
     end
   end
 end

--- a/spec/helpers/previews_helper_spec.rb
+++ b/spec/helpers/previews_helper_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe PreviewsHelper do
+  describe "#is_numeric" do
+    it "returns true when given an integer as a string" do
+      expect(helper.is_numeric("123")).to be true
+    end
+
+    it "returns false when given a text string" do
+      expect(helper.is_numeric("some text")).to be false
+    end
+
+    it "returns false when given a non-string object" do
+      expect(helper.is_numeric(nil)).to be false
+    end
+  end
+end


### PR DESCRIPTION
The primary purpose of this PR is to fix a production bug where the preview rendering of a CSV fails for any CSV files that have a nil entry.

When looking at this I discovered the check for whether data was numeric was a little optimistic so I've made that more robust and re-named it to embrace common Ruby idioms.