### PR TITLE
Fix Style/RedundantRegexpEscape linting offence

### DIFF
--- a/app/helpers/previews_helper.rb
+++ b/app/helpers/previews_helper.rb
@@ -9,7 +9,7 @@ module PreviewsHelper
 
   def numeric?(value)
     value.to_s.match?(/\A
-                      \-? # may be negative
+                      -? # may be negative
                       (
                         \d+(\.\d+)? # digits, potential followed by decimal
                         |


### PR DESCRIPTION
This is auto-corrected by Rubocop. The dash character does not need
escaping.

This is to fix the main branch after I snookered myself by merging in
a PR before rebasing it against the main branch with updated linting
rules.