### PR TITLE
Fix organogram CSP error

### DIFF
--- a/app/controllers/previews_controller.rb
+++ b/app/controllers/previews_controller.rb
@@ -1,7 +1,7 @@
 class PreviewsController < ApplicationController
   def show
     append_content_security_policy_directives(
-      connect_src: %w[s3-eu-west-1.amazonaws.com],
+      connect_src: ["s3-eu-west-1.amazonaws.com", ENV["CKAN_DOMAIN"]].compact,
     )
 
     @dataset = Dataset.get_by_uuid(uuid: params[:dataset_uuid])

--- a/bin/setup-docker-test.sh
+++ b/bin/setup-docker-test.sh
@@ -2,7 +2,7 @@
 # source this script before running tests in docker ckan to set the correct env vars
 export RAILS_ENV=test
 export ES_INDEX=datasets-test
-export CKAN_REDIRECTION_URL=testdomain
+export CKAN_DOMAIN=testdomain
 
 # install chrome for tests
 wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -66,6 +66,4 @@ Rails.application.configure do
   # config.action_cable.disable_request_forgery_protection = true
 
   config.zendesk = nil
-
-  config.ckan_redirection_url = ENV["CKAN_REDIRECTION_URL"]
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -112,6 +112,4 @@ Rails.application.configure do
   # config.active_record.database_selector = { delay: 2.seconds }
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
-
-  config.ckan_redirection_url = ENV["CKAN_REDIRECTION_URL"]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,8 +4,8 @@ Rails.application.routes.draw do
 
   get "/sites/default/files/*organogram_path", to: redirect("https://s3-eu-west-1.amazonaws.com/datagovuk-#{Rails.env}-ckan-organogram/legacy/%{organogram_path}"), format: false
 
-  if ENV["CKAN_REDIRECTION_URL"].present?
-    get "dataset/edit/:legacy_name", to: redirect(domain: ENV["CKAN_REDIRECTION_URL"], subdomain: "", path: "/dataset/edit/%{legacy_name}")
+  if ENV["CKAN_DOMAIN"].present?
+    get "dataset/edit/:legacy_name", to: redirect(domain: ENV["CKAN_DOMAIN"], subdomain: "", path: "/dataset/edit/%{legacy_name}")
   end
 
   get "dataset/:uuid", to: "datasets#show", uuid: /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/
@@ -55,9 +55,9 @@ Rails.application.routes.draw do
   get "acknowledge", to: "messages#acknowledge"
 
   # Route everything else to CKAN
-  if ENV["CKAN_REDIRECTION_URL"].present?
+  if ENV["CKAN_DOMAIN"].present?
     match "*path",
-          to: redirect(domain: ENV["CKAN_REDIRECTION_URL"], subdomain: "", path: "/%{path}"),
+          to: redirect(domain: ENV["CKAN_DOMAIN"], subdomain: "", path: "/%{path}"),
           via: :all,
           constraints: { path: /(?!#{Regexp.quote(Rails.application.config.assets.prefix[1..-1])}).+/ }
   end

--- a/production-manifest.yml
+++ b/production-manifest.yml
@@ -11,7 +11,7 @@ applications:
   env:
     RAILS_ENV: production
     RACK_ENV: production
-    CKAN_REDIRECTION_URL: ckan.publishing.service.gov.uk
+    CKAN_DOMAIN: ckan.publishing.service.gov.uk
     GOVUK_APP_DOMAIN: www.gov.uk
     GOVUK_WEBSITE_ROOT: https://www.gov.uk
   services:

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,7 +4,7 @@ SimpleCov.start
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require "spec_helper"
 ENV["RAILS_ENV"] ||= "test"
-ENV["CKAN_REDIRECTION_URL"] ||= "testdomain"
+ENV["CKAN_DOMAIN"] ||= "testdomain"
 require File.expand_path("../config/environment", __dir__)
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?

--- a/staging-manifest.yml
+++ b/staging-manifest.yml
@@ -11,7 +11,7 @@ applications:
   env:
     RAILS_ENV: staging
     RACK_ENV: staging
-    CKAN_REDIRECTION_URL: ckan.staging.publishing.service.gov.uk
+    CKAN_DOMAIN: ckan.staging.publishing.service.gov.uk
     GOVUK_APP_DOMAIN: www.gov.uk
     GOVUK_WEBSITE_ROOT: https://www.gov.uk
   services:


### PR DESCRIPTION
Some organograms are hosted on ckan.publishing.service.gov.uk, instead
of s3-eu-west-1.amazonaws.com.

The previews for these organograms are currently broken because the
content security policy prevents the JavaScript from dowloading the
files from the CKAN domain.

I confirmed that the CSP was the only issue by disabling CSP in my
brower (using a plugin) and confirming that the broken previews worked
correctly.

Since the CSP already permits all of S3 eu-west-1 in the connect_src,
adding CKAN to the CSP feels like a very small piece of extra security
attack surface. And it should be a quick way to fix the bug where some
organogram previews don't show up.

I tried to add a test for this, but rails controller tests don't execute
enough of the stack for the SecureHeaders gem to do its thing and set
the CSP header. It might be possible to test with a feature test, but
that feels like overkill.

I also renamed `CKAN_REDIRECTION_URL` to `CKAN_DOMAIN` to
make it clear how it's being used (the CSP needs it to be a domain, not
a full URL, which fortunately it already is).


