### PR TITLE
Remove redundant RuboCop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,28 +9,6 @@ inherit_mode:
 
 AllCops:
   TargetRubyVersion: 2.5
-  Exclude:
-    - bin/**/*
-    - config.ru
-    - db/schema.rb
-    - vendor/**/*
-    - vendor/bundle/**/*
-
-Metrics/BlockLength:
-  Exclude:
-    - 'config/routes.rb'
-    - 'lib/tasks/**/*.rake'
-    - 'spec/**/*.rb'
-
-Style/FormatStringToken:
-  Exclude:
-    - "config/routes.rb"
-
-Rails/OutputSafety:
-  Enabled: false
-
-Rails/FilePath:
-  EnforcedStyle: slashes
 
 Rails/SaveBang:
   AllowedReceivers:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,9 +7,6 @@ inherit_mode:
   merge:
     - Exclude
 
-AllCops:
-  TargetRubyVersion: 2.5
-
 Rails/SaveBang:
   AllowedReceivers:
     - Elasticsearch::Model.client.indices

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,16 @@ inherit_mode:
   merge:
     - Exclude
 
+# **************************************************************
+# TRY NOT TO ADD OVERRIDES IN THIS FILE
+#
+# This repo is configured to follow the RuboCop GOV.UK styleguide.
+# Any rules you override here will cause this repo to diverge from
+# the way we write code in all other GOV.UK repos.
+#
+# See https://github.com/alphagov/rubocop-govuk/blob/main/CONTRIBUTING.md
+# **************************************************************
+
 Rails/SaveBang:
   AllowedReceivers:
     - Elasticsearch::Model.client.indices

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,6 @@ Rails.application.routes.draw do
     match "*path",
           to: redirect(domain: ENV["CKAN_DOMAIN"], subdomain: "", path: "/%{path}"),
           via: :all,
-          constraints: { path: /(?!#{Regexp.quote(Rails.application.config.assets.prefix[1..-1])}).+/ }
+          constraints: { path: /(?!#{Regexp.quote(Rails.application.config.assets.prefix[1..])}).+/ }
   end
 end


### PR DESCRIPTION
https://trello.com/c/Cr2TnMtI/193-make-it-easier-to-agree-with-rubocop-govuk

This also adds a standard header to avoid more special config creeping
in in the future. Please see the commits for more details.