### PR TITLE
Update CKAN maintenance page for database upgrade

### DIFF
--- a/app/views/pages/ckan_maintenance.html.erb
+++ b/app/views/pages/ckan_maintenance.html.erb
@@ -9,13 +9,12 @@
      Data.gov.uk publishing freeze
    </h1>
 
-  <p>data.gov.uk publishing freeze – 6:30am on Thursday 5 August to 11:59pm on Friday 6 August 2021</p>
+  <p>data.gov.uk publishing freeze – 6:30am on Friday 17 December to 11:59pm on Monday 20 December 2021</p>
   <p>We’re making some improvements to your data.gov.uk publishing account.</p>
-  <p>You will not be able to publish, edit or delete datasets while we upgrade the data publishing tool.</p>
+  <p>You will not be able to publish, edit, delete or view datasets on the publishing tool during the upgrade.</p>
   <p>There will not be any downtime for visitors to data.gov.uk – only publishing will be affected.</p>
   <h2 class="heading-medium">Why we need to upgrade</h2>
-  <p>We’re upgrading to CKAN 2.9. This will make data.gov.uk more stable for users and publishers. It will also allow us to make further improvements to the publishing tool later this year.</p>
-  <p>You can see a detailed list of the CKAN 2.9 changes at: <a href="https://github.com/ckan/ckan/blob/2.9/CHANGELOG.rst#v293-2021-05-19">https://github.com/ckan/ckan/blob/2.9/CHANGELOG.rst#v293-2021-05-19</a></p>
+  <p>We’re upgrading the database CKAN uses. This will make data.gov.uk more stable for users and publishers.</p>
 
   <p>If you have any questions or concerns about the upgrade, please let us know: <a href="https://data.gov.uk/support">https://data.gov.uk/support</a></p>
   </div>


### PR DESCRIPTION
## What

Update the maintenance webpage with the provisional dates for publishing downtime.

## Reference 

https://trello.com/c/lipeZ92R/50-prepare-comms-for-ckan-downtime