### PR TITLE
Update organogram js files to handle office region

### DIFF
--- a/app/assets/javascripts/organograms/org-data-loader.js
+++ b/app/assets/javascripts/organograms/org-data-loader.js
@@ -99,7 +99,8 @@ var OrgDataLoader = {
                     'profession' : post['Professional/Occupational Group'],
                     'email' : post['Contact E-mail'],
                     'phone' : post['Contact Phone'],
-                    'notes' : post['Notes']
+                    'notes' : post['Notes'],
+                    'office_region': post['Office Region']
                 }
             }
 
@@ -150,7 +151,8 @@ var OrgDataLoader = {
                     'profession_group': post['Professional/Occupational Group'],
                     'junior': true,
                     'nodeType': 'jp_child',
-                    'type': 'junior_posts'
+                    'type': 'junior_posts',
+                    'office_region': post['Office Region']
                 }
             };
         }

--- a/app/assets/javascripts/organograms/orgvis.js
+++ b/app/assets/javascripts/organograms/orgvis.js
@@ -322,6 +322,9 @@ var Orgvis = {
             if(typeof nd.phone != 'undefined'){
                 html += '<p class="phone"><span>Phone</span><span class="value">' + nd.phone + '</span></p>';
             }
+            if(typeof nd.office_region != 'undefined'){
+                html += '<p class="office_region"><span>Office Region</span><span class="value">' + nd.office_region + '</span></p>';
+            }
             if(typeof nd.notes != 'undefined'){
                 html += '<p class="notes"><span>Notes</span><span class="value">' + nd.notes + '</span></p>';
             }
@@ -400,6 +403,7 @@ var Orgvis = {
         html += '<p class="paybandRange"><span>Payband Salary Range</span><span class="value">'+nd.salaryrange+'</span></p>';
         html += '<p class="reportsTo"><span>Reports To</span><span class="value">'+nd.reportsto+'</span></p>';
         html += '<p class="unit"><span>Unit</span><span class="value">'+nd.unit+'</span></p>';
+        html += '<p class="officeRegion"><span>Office Region</span><span class="value">'+nd.office_region+'</span></p>';
         html += '</div>'; // end content
         html += '</div>'; // end panel
         html += '<a class="close">x</a>';


### PR DESCRIPTION
## What 

Update the javascript which handles organograms to correctly show the office region metadata.

This code has been tested locally in a full end to end and appears to show the office region metadata correctly -

![image](https://user-images.githubusercontent.com/22152807/146379558-d480251c-c4a6-4193-a37d-e41b5e6985c1.png)

## Reference 

https://trello.com/c/VKwyN1MA/724-work-on-dgu-organogram-things-coming-from-cabinet-office-transparency-team