### PR TITLE
Update production manifest for www

### DIFF
--- a/production-manifest.yml
+++ b/production-manifest.yml
@@ -8,6 +8,7 @@ applications:
   routes:
   - route: find-data-beta.cloudapps.digital
   - route: data.gov.uk
+  - route: www.data.gov.uk
   env:
     RAILS_ENV: production
     RACK_ENV: production


### PR DESCRIPTION
This is a follow up due to redirection to www domain to improve handling of cookies, without this update www domain fails.