### PR TITLE
Remove dot (.) prefix from formats

### DIFF
--- a/app/models/datafile.rb
+++ b/app/models/datafile.rb
@@ -10,7 +10,7 @@ class Datafile
     @start_date = hash["start_date"]
     @created_at = hash["created_at"]
     @updated_at = hash["updated_at"]
-    @format = hash["format"]&.strip&.upcase
+    @format = hash["format"]&.strip&.delete_prefix(".")&.upcase
     @size = hash["size"]
     @uuid = hash["uuid"]
   end

--- a/spec/models/datafile_spec.rb
+++ b/spec/models/datafile_spec.rb
@@ -27,5 +27,12 @@ RSpec.describe Datafile do
         expect(datafile.csv?).to be true
       end
     end
+
+    describe "#csv?" do
+      it 'returns true if datafile is ".csv "' do
+        datafile = build :datafile, format: ".csv "
+        expect(datafile.csv?).to be true
+      end
+    end
   end
 end


### PR DESCRIPTION
## What

Some resources were set with the . prefix, e.g. .csv, this would cause csv prefix links to not show. 
So removing the `.` from the format will enable previews again, this has been tested on a local dev stack