### PR TITLE
Cache homepage for 30 minutes

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -12,6 +12,10 @@ class PagesController < ApplicationController
     render "ckan_maintenance", status: :service_unavailable
   end
 
+  def home
+    expires_in 30.minutes, public: true
+  end
+
 private
 
   def get_datasets_count

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe PagesController, type: :controller do
+  render_views
+
+  describe "Homepage" do
+    it "caches for 30 minutes" do
+      get :home
+
+      expect(response.headers["Cache-Control"]).to eq("max-age=1800, public")
+    end
+  end
+end


### PR DESCRIPTION
Configure the data.gov.uk homepage to cache for half an hour.
It is expected that this will reduce the risk of serving 404 to
users, which is what the PaaS does if Origin happens to be down
at the time of the request.

The `max-age` value of the `Cache-Control` header is one of the
values supported by Fastly: https://docs.fastly.com/en/guides/caching-best-practices#cache-control-headers

The cache is set to `public` rather than `private` as we need the
cache to be applied at the CDN (cache proxy server) level, not just
the client. There is no user session state that affects the homepage
(e.g. "Signed in as SOME_USER") so it should be safe to cache the
homepage at the CDN level.

Trello: https://trello.com/c/cZQ0bNLL/3031-cache-datagovuk-homepage-5