### PR TITLE
Declare Ruby version in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source "https://rubygems.org"
 
+ruby File.read(".ruby-version").strip
+
 gem "rails", "6.1.6.1"
 
 gem "addressable"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -491,5 +491,8 @@ DEPENDENCIES
   webmock
   zendesk_api
 
+RUBY VERSION
+   ruby 3.2.0p0
+
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
If the Ruby version is left unspecified then the Cloud Foundry buildpack will use Ruby 2.7.1 by default, but we've just upgraded this app to Ruby 3.2.0.