### PR TITLE
Disallow `/search` in `robots.txt`

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,9 @@
 User-agent: *
 Crawl-delay: 10
+
+Disallow: /search
+
+# The following rules were copied from the old site
 # CSS, JS, Images
 Allow: /misc/*.css$
 Allow: /misc/*.css?
@@ -58,7 +62,6 @@ Disallow: /admin/
 Disallow: /comment/reply/
 Disallow: /filter/tips/
 Disallow: /node/add/
-Disallow: /search
 Disallow: /user/register/
 Disallow: /user/password/
 Disallow: /user/login/

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -58,7 +58,7 @@ Disallow: /admin/
 Disallow: /comment/reply/
 Disallow: /filter/tips/
 Disallow: /node/add/
-Disallow: /search/
+Disallow: /search
 Disallow: /user/register/
 Disallow: /user/password/
 Disallow: /user/login/


### PR DESCRIPTION
[Trello card](https://trello.com/c/9Y1k5t6J/3271-noindex-datagovuk-search-result-pages-2)

Removing the trailing slash, as our search URLs (e.g. https://www.data.gov.uk/search?q=test+registration) do not include this slash.