### PR TITLE
Update `govuk_test` to v3.0.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       - uses: nanasess/setup-chromedriver@master
         with:
           # Optional: do not specify to match Chrome's version
-          chromedriver-version: '77.0.3865.40'
+          chromedriver-version: '115.0.5790.102'
       - run: |
           export DISPLAY=:99
           chromedriver --url-base=/wd/hub &

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,7 +77,7 @@ GEM
     browser (5.3.1)
     builder (3.2.4)
     byebug (11.1.3)
-    capybara (3.36.0)
+    capybara (3.39.2)
       addressable
       matrix
       mini_mime (>= 0.1.3)
@@ -86,7 +86,6 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    childprocess (4.1.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
     crack (0.4.5)
@@ -170,12 +169,11 @@ GEM
       rails (>= 6)
       rouge
       sprockets (< 4)
-    govuk_test (2.3.0)
+    govuk_test (3.0.1)
       brakeman (>= 5.0.2)
-      capybara
+      capybara (>= 3.36)
       puma
-      selenium-webdriver (>= 3.142)
-      webdrivers (>= 4)
+      selenium-webdriver (>= 4.0)
     hashdiff (1.0.1)
     hashie (5.0.0)
     htmlentities (4.3.4)
@@ -391,10 +389,10 @@ GEM
       sprockets-rails
       tilt
     secure_headers (6.3.3)
-    selenium-webdriver (4.1.0)
-      childprocess (>= 0.5, < 5.0)
+    selenium-webdriver (4.11.0)
       rexml (~> 3.2, >= 3.2.5)
-      rubyzip (>= 1.2.2)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
     sentry-rails (5.9.0)
       railties (>= 5.0)
       sentry-ruby (~> 5.9.0)
@@ -433,15 +431,12 @@ GEM
       unf_ext
     unf_ext (0.0.8)
     unicode-display_width (2.2.0)
-    webdrivers (5.0.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     webmock (3.14.0)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
+    websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)


### PR DESCRIPTION
This removes the dependency on the `webdrivers` gem, which was causing test failures on CI (and in Docker).

Also updates the Chrome WebDriver to the latest version (the latest version of Chrome does not yet have a corresponding WebDriver, so we have to hardcode a slightly older point release)