### PR TITLE
Mark search results pages as `noindex`

### DIFF
--- a/app/views/search/search.html.erb
+++ b/app/views/search/search.html.erb
@@ -2,6 +2,10 @@
     t('.results_page_title', query: search_term) :
     t('.search_results') %><% end %>
 
+<% content_for :head do %>
+  <meta name="robots" content="noindex">
+<% end %>
+
 <form action="/search" method="GET">
   <main role="main" id="main-content" class="govuk-main-wrapper">
     <div class="govuk-width-container">


### PR DESCRIPTION
[Trello card](https://trello.com/c/9Y1k5t6J/3271-noindex-datagovuk-search-result-pages-2)

Supersedes #1172 

We set `noindex` to prevent search engines from indexing the search results pages themselves, but we do not set `nofollow`, as we want search engines to be able to use the search results pages to discover other pages on DGU. This is important because DGU doesn't have a sitemap.