### PR TITLE
Remove Google site verification files

### DIFF
--- a/public/googlea6393a390aadfbaa.html
+++ b/public/googlea6393a390aadfbaa.html
@@ -1,1 +1,0 @@
-google-site-verification: googlea6393a390aadfbaa.html

--- a/public/googlea8e9d553783278d4.html
+++ b/public/googlea8e9d553783278d4.html
@@ -1,1 +1,0 @@
-google-site-verification: googlea8e9d553783278d4.html

--- a/public/googleb8f2fff41622c68a.html
+++ b/public/googleb8f2fff41622c68a.html
@@ -1,1 +1,0 @@
-google-site-verification: googleb8f2fff41622c68a.html


### PR DESCRIPTION
We are now using DNS-based verification[^1] to prove domain ownership in order to access Google Search Console, so these are no longer needed.

[^1]: https://github.com/alphagov/govuk-dns-tf/commit/36debb10484a7fa98139879e999e362f0f09e82f