### PR TITLE
Update build image tag to run against v prefix

### DIFF
--- a/.github/workflows/build-image-on-tags.yaml
+++ b/.github/workflows/build-image-on-tags.yaml
@@ -3,7 +3,7 @@ name: Build and push images on tags
 on:
   push:
     tags:
-      - 'k[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   build_and_push:

--- a/.github/workflows/create-pr-on-tags.yaml
+++ b/.github/workflows/create-pr-on-tags.yaml
@@ -14,8 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set GH_REF
-        # Change back to git tag once we no longer need the k versions
-        run: echo "GH_REF=`echo $(git fetch -t -q && git tag -l "k*" | sort --version-sort | tail -n1)`" >> $GITHUB_ENV
+        run: echo "GH_REF=`echo $(git fetch -t -q | sort --version-sort | tail -n1)`" >> $GITHUB_ENV
       - run: bash ./docker/create-pr.sh
         env:
           GH_TOKEN: ${{ secrets.PR_GITHUB_TOKEN }}


### PR DESCRIPTION
This will trigger deployments to the kubernetes cluster when tagged releases are prefix with v

## Reference

https://trello.com/c/2qXYzZYb/1239-switchover-paas-apps-to-k8s-cluster