### PR TITLE
Make the Rails log level configurable.

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,9 +46,7 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
-  # Include generic and useful information about system operation, but avoid logging too much
-  # information to avoid inadvertent exposure of personally identifiable information (PII).
-  config.log_level = :info
+  config.log_level = ENV.fetch("RAILS_LOG_LEVEL", :info)
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]


### PR DESCRIPTION
Honour the `RAILS_LOG_LEVEL` env var, same as other GOV.UK apps.

Default remains INFO.