### PR TITLE
Link to deployment docs elsewhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,24 +33,7 @@ First run `bin/setup` to bundle, etc. Then run `rails s`.
 
 ## Deployment
 
-Continuous Integration has been setup using Github Actions. 
-  - Tests are run on pull requests.
-  - Deployments to Integration happen automatically when marging branches into the `main` branch.
-  - In order to carry out a release to production a developer in the govuk team will need to create a release tag with a  leading `v` and [approve](https://docs.github.com/en/actions/managing-workflow-runs/reviewing-deployments) of the deployment in Github Actions.
-
-### Integration
-
-To deploy to integration merge a PR into `main`.
-
-### Staging & Production
-
-To deploy to staging/production you need to tag the release, the tag needs to be in this format - `v9.9.9` where 9 is a number and the leading `v` is required. E.g. `v0.1.11` is valid, `0.1.11` is not.
-
-This will create a PR on [govuk-dgu-charts](https://github.com/alphagov/govuk-dgu-charts/pulls) which you should be able to approve and merge into main for testing.
-
-Test that your changes are working in staging - https://staging.data.gov.uk before releasing to Production.
-
-Then merge in the production release PR.
+See [the developer docs on data.gov.uk deployment](https://docs.publishing.service.gov.uk/manual/data-gov-uk-deployment.html)
 
 ## Example application URLs
 


### PR DESCRIPTION
The deployment guidance was duplicated (and more comprehensive) elsewhere, so this removes it from here and provides a link instead.