### PR TITLE
Add dev.Dockerfile to enable running on local dev cluster

### DIFF
--- a/docker/dev.Dockerfile
+++ b/docker/dev.Dockerfile
@@ -1,0 +1,11 @@
+FROM ghcr.io/alphagov/datagovuk_find:v2.41.0
+
+USER root
+ENV BUNDLE_WITHOUT=""
+ENV RAILS_ENV=development
+RUN install_packages \
+    g++ git gpg libc-dev libcurl4-openssl-dev libgdbm-dev libssl-dev \
+    libmariadb-dev-compat libpq-dev libyaml-dev make xz-utils
+RUN bundle install
+
+USER app


### PR DESCRIPTION
dev.Dockerfile extends the production Dockerfile to include development environment dependencies that would be useful to use in a local cluster to aid running tests and debugging issues.