### PR TITLE
Revert "Restore support form"

### DIFF
--- a/app/views/pages/support.html.erb
+++ b/app/views/pages/support.html.erb
@@ -5,68 +5,11 @@
 <% end%>
 
 <main role="main" id="main-content" class="govuk-main-wrapper">
-
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <%= render "govuk_publishing_components/components/heading", {
-        text: "Support",
-        margin_bottom: 6,
-        heading_level: 1,
-        font_size: "l",
-      } %>
-
-      <p class="govuk-body">The Government Digital Service (GDS) maintains the technical service behind data.gov.uk
-         and helps government publishers to manage and update their data.</p>
-
-      <p class="govuk-body">It cannot</p>
-      <ul class="list list-bullet">
-        <li>help you find or research datasets</li>
-        <li>provide personal information or medical records</li>
-        <li>combine data from multiple datasets</li>
-      </ul>
-
-      <p class="govuk-body">For questions about GOV.UK check the <%= link_to "GOV.UK help pages", "https://www.gov.uk/help", class: "govuk-link" %> or <%= link_to "contact GOV.UK", "https://www.gov.uk/contact/govuk", class: "govuk-link" %>.</p>
-      <p class="govuk-body">The NHS <%= link_to "publishes its own data.", "https://digital.nhs.uk/data-and-information/data-collections-and-data-sets/data-sets", class: "govuk-link" %></p>
-
-      <%= render "govuk_publishing_components/components/heading", {
-        text: "If you have a question about a dataset",
-        margin_bottom: 4,
-        heading_level: 2,
-        font_size: "m",
-      } %>
-      <p class="govuk-body">If you have a question about a specific dataset, contact the publisher directly.</p>
-
-      <form action="tickets/new" method="get">
-        <%= render "govuk_publishing_components/components/radio", {
-          name: "support",
-          heading: "How can we help you?",
-          items: [
-            {
-              value: "feedback",
-              text: "I want to report a problem"
-            },
-            {
-              value: "data",
-              text: "I want government to publish new data"
-            },
-            {
-              value: "publish",
-              text: "I want to publish for an organisation"
-            },
-            {
-              value: "accessibility",
-              text: "I want to report an accessibility issue"
-            },
-          ]
-        } %>
-
-        <%= render "govuk_publishing_components/components/button", {
-          text: "Continue",
-          margin_bottom: true,
-        } %>
-      </form>
-
-      <p class="govuk-body">Please give us your feedback about the site using <%= link_to "our survey", "http://www.smartsurvey.co.uk/s/3SEXD/", class: "govuk-link" %>.</p>
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <h1 class="heading-large">Service unavailable</h1>
+      <p>Sorry you can't use this service because of a technical problem.</p>
+      <p>We're working on a fix. Please try again later.</p>
     </div>
   </div>
 </main>

--- a/app/views/tickets/new.html.erb
+++ b/app/views/tickets/new.html.erb
@@ -5,77 +5,11 @@
 <% end%>
 
 <main role="main" id="main-content" class="govuk-main-wrapper">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <% if @ticket.errors.any? %>
-        <%
-          errors = @ticket.errors.messages.map do |attr, error|
-            {
-              text: error[0],
-              href: "#error-#{attr.to_s}"
-            }
-          end
-        %>
-        
-        <%= render "govuk_publishing_components/components/error_summary", {
-          title: t('.problem'),
-          items: errors
-        } %>
-      <% end %>
-
-      <%= render "govuk_publishing_components/components/heading", {
-        text: t(".#{@ticket.support}_request"),
-        margin_bottom: 4,
-        heading_level: 1,
-        font_size: "l",
-      } %>
-
-      <%= form_for @ticket, url: { action: "create", controller: "tickets" } do |f| %>
-        <%
-          content_error = t('.enter_a_message') if @ticket.errors[:content].any?
-          content_error_id = "error-content" if @ticket.errors[:content].any?
-          name_error = t('.enter_a_name') if @ticket.errors[:name].any?
-          name_error_id = "error-name" if @ticket.errors[:name].any?
-          email_error = t('.enter_an_email') if @ticket.errors[:email].any?
-          email_error_id = "error-email" if @ticket.errors[:email].any?
-        %>
-
-        <%= render "govuk_publishing_components/components/textarea", {
-          label: {
-            text: t('.your_message'),
-          },
-          name: "ticket[content]",
-          error_message: content_error,
-          id: content_error_id,
-          rows: 8,
-        } %>
-
-        <%= render "govuk_publishing_components/components/input", {
-          label: {
-            text: t('.name'),
-          },
-          name: "ticket[name]",
-          error_message: name_error,
-          id: name_error_id,
-          autocomplete: "name",
-        } %>
-
-        <%= render "govuk_publishing_components/components/input", {
-          label: {
-            text: t('.email_address'),
-          },
-          name: "ticket[email]",
-          error_message: email_error,
-          id: email_error_id,
-          hint: t('.use_this_to_reply'),
-          autocomplete: "email",
-        } %>
-
-        <%= f.hidden_field(:support, :value => @ticket.support) %>
-        <%= render "govuk_publishing_components/components/button", {
-          text: t('.submit'),
-        } %>      
-      <% end %>
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <h1 class="heading-large">Service unavailable</h1>
+      <p>Sorry you can't use this service because of a technical problem.</p>
+      <p>We're working on a fix. Please try again later.</p>
     </div>
   </div>
 </main>

--- a/spec/features/support_spec.rb
+++ b/spec/features/support_spec.rb
@@ -1,106 +1,106 @@
 require "rails_helper"
 
-RSpec.feature "Support tickets", type: :feature do
-  before do
-    visit support_path
-  end
+# RSpec.feature "Support tickets", type: :feature do
+#   before do
+#     visit support_path
+#   end
 
-  feature "Reporting a problem" do
-    let(:ticket) { build :ticket, support: "feedback" }
+#   feature "Reporting a problem" do
+#     let(:ticket) { build :ticket, support: "feedback" }
 
-    scenario "Send a support ticket to Zendesk" do
-      choose "I want to report a problem"
-      click_on "Continue"
-      expect(page).to have_content "Report a problem"
+#     scenario "Send a support ticket to Zendesk" do
+#       choose "I want to report a problem"
+#       click_on "Continue"
+#       expect(page).to have_content "Report a problem"
 
-      fill_in "Your message", with: ticket.content
-      fill_in "Name", with: ticket.name
-      fill_in "Email address", with: ticket.email
+#       fill_in "Your message", with: ticket.content
+#       fill_in "Name", with: ticket.name
+#       fill_in "Email address", with: ticket.email
 
-      expect(Zendesk.client)
-        .to receive_message_chain("tickets.create!")
-        .with(ticket.to_json)
+#       expect(Zendesk.client)
+#         .to receive_message_chain("tickets.create!")
+#         .with(ticket.to_json)
 
-      click_on "Submit"
-      expect(page).to have_content "Thanks for contacting data.gov.uk"
-    end
-  end
+#       click_on "Submit"
+#       expect(page).to have_content "Thanks for contacting data.gov.uk"
+#     end
+#   end
 
-  feature "Asking government to publish new data" do
-    let(:ticket) { build :ticket, support: "data" }
+#   feature "Asking government to publish new data" do
+#     let(:ticket) { build :ticket, support: "data" }
 
-    scenario "Send a support ticket to Zendesk" do
-      choose "I want government to publish new data"
-      click_on "Continue"
-      expect(page).to have_content "Ask the government to publish new data"
+#     scenario "Send a support ticket to Zendesk" do
+#       choose "I want government to publish new data"
+#       click_on "Continue"
+#       expect(page).to have_content "Ask the government to publish new data"
 
-      fill_in "Your message", with: ticket.content
-      fill_in "Name", with: ticket.name
-      fill_in "Email address", with: ticket.email
+#       fill_in "Your message", with: ticket.content
+#       fill_in "Name", with: ticket.name
+#       fill_in "Email address", with: ticket.email
 
-      expect(Zendesk.client)
-        .to receive_message_chain("tickets.create!")
-        .with(ticket.to_json)
+#       expect(Zendesk.client)
+#         .to receive_message_chain("tickets.create!")
+#         .with(ticket.to_json)
 
-      click_on "Submit"
-      expect(page).to have_content "Thanks for contacting data.gov.uk"
-    end
-  end
+#       click_on "Submit"
+#       expect(page).to have_content "Thanks for contacting data.gov.uk"
+#     end
+#   end
 
-  feature "Becoming a publisher" do
-    let(:ticket) { build :ticket, support: "publish" }
+#   feature "Becoming a publisher" do
+#     let(:ticket) { build :ticket, support: "publish" }
 
-    scenario "Send a support ticket to Zendesk" do
-      choose "I want to publish for an organisation"
-      click_on "Continue"
-      expect(page).to have_content "Publish for an organisation"
+#     scenario "Send a support ticket to Zendesk" do
+#       choose "I want to publish for an organisation"
+#       click_on "Continue"
+#       expect(page).to have_content "Publish for an organisation"
 
-      fill_in "Your message", with: ticket.content
-      fill_in "Name", with: ticket.name
-      fill_in "Email address", with: ticket.email
+#       fill_in "Your message", with: ticket.content
+#       fill_in "Name", with: ticket.name
+#       fill_in "Email address", with: ticket.email
 
-      expect(Zendesk.client)
-        .to receive_message_chain("tickets.create!")
-        .with(ticket.to_json)
+#       expect(Zendesk.client)
+#         .to receive_message_chain("tickets.create!")
+#         .with(ticket.to_json)
 
-      click_on "Submit"
-      expect(page).to have_content "Thanks for contacting data.gov.uk"
-    end
-  end
+#       click_on "Submit"
+#       expect(page).to have_content "Thanks for contacting data.gov.uk"
+#     end
+#   end
 
-  feature "Recover from invalid data" do
-    let(:ticket) { build :ticket, email: "foo" }
+#   feature "Recover from invalid data" do
+#     let(:ticket) { build :ticket, email: "foo" }
 
-    scenario "Show the errors in the ticket form" do
-      choose "I want government to publish new data"
-      click_on "Continue"
-      fill_in "Email address", with: ticket.email
+#     scenario "Show the errors in the ticket form" do
+#       choose "I want government to publish new data"
+#       click_on "Continue"
+#       fill_in "Email address", with: ticket.email
 
-      click_on "Submit"
-      expect(page).to have_content "Enter a valid email address"
-      expect(page).to have_content "Enter a name"
-      expect(page).to have_content "Enter a message"
-    end
-  end
+#       click_on "Submit"
+#       expect(page).to have_content "Enter a valid email address"
+#       expect(page).to have_content "Enter a name"
+#       expect(page).to have_content "Enter a message"
+#     end
+#   end
 
-  feature "Reporting an accessibility issue" do
-    let(:ticket) { build :ticket, support: "accessibility" }
+#   feature "Reporting an accessibility issue" do
+#     let(:ticket) { build :ticket, support: "accessibility" }
 
-    scenario "Send a support ticket to Zendesk" do
-      choose "I want to report an accessibility issue"
-      click_on "Continue"
-      expect(page).to have_content "Report an accessibility issue"
+#     scenario "Send a support ticket to Zendesk" do
+#       choose "I want to report an accessibility issue"
+#       click_on "Continue"
+#       expect(page).to have_content "Report an accessibility issue"
 
-      fill_in "Your message", with: ticket.content
-      fill_in "Name", with: ticket.name
-      fill_in "Email address", with: ticket.email
+#       fill_in "Your message", with: ticket.content
+#       fill_in "Name", with: ticket.name
+#       fill_in "Email address", with: ticket.email
 
-      expect(Zendesk.client)
-        .to receive_message_chain("tickets.create!")
-        .with(ticket.to_json)
+#       expect(Zendesk.client)
+#         .to receive_message_chain("tickets.create!")
+#         .with(ticket.to_json)
 
-      click_on "Submit"
-      expect(page).to have_content "Thanks for contacting data.gov.uk"
-    end
-  end
-end
+#       click_on "Submit"
+#       expect(page).to have_content "Thanks for contacting data.gov.uk"
+#     end
+#   end
+# end


### PR DESCRIPTION
Reverts alphagov/datagovuk_find#1248

User support do not want us to put the form back up just yet, as they want platform to implement some form of rate limiting on the form first. 