### PR TITLE
Point user to an alternative way to get urgent support

### DIFF
--- a/app/views/pages/support.html.erb
+++ b/app/views/pages/support.html.erb
@@ -5,11 +5,68 @@
 <% end%>
 
 <main role="main" id="main-content" class="govuk-main-wrapper">
-  <div class="grid-row">
-    <div class="column-two-thirds">
-      <h1 class="heading-large">Service unavailable</h1>
-      <p>Sorry you can't use this service because of a technical problem.</p>
-      <p>We're working on a fix. Please try again later.</p>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Support",
+        margin_bottom: 6,
+        heading_level: 1,
+        font_size: "l",
+      } %>
+
+      <p class="govuk-body">The Government Digital Service (GDS) maintains the technical service behind data.gov.uk
+         and helps government publishers to manage and update their data.</p>
+
+      <p class="govuk-body">It cannot</p>
+      <ul class="list list-bullet">
+        <li>help you find or research datasets</li>
+        <li>provide personal information or medical records</li>
+        <li>combine data from multiple datasets</li>
+      </ul>
+
+      <p class="govuk-body">For questions about GOV.UK check the <%= link_to "GOV.UK help pages", "https://www.gov.uk/help", class: "govuk-link" %> or <%= link_to "contact GOV.UK", "https://www.gov.uk/contact/govuk", class: "govuk-link" %>.</p>
+      <p class="govuk-body">The NHS <%= link_to "publishes its own data.", "https://digital.nhs.uk/data-and-information/data-collections-and-data-sets/data-sets", class: "govuk-link" %></p>
+
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "If you have a question about a dataset",
+        margin_bottom: 4,
+        heading_level: 2,
+        font_size: "m",
+      } %>
+      <p class="govuk-body">If you have a question about a specific dataset, contact the publisher directly.</p>
+
+      <form action="tickets/new" method="get">
+        <%= render "govuk_publishing_components/components/radio", {
+          name: "support",
+          heading: "How can we help you?",
+          items: [
+            {
+              value: "feedback",
+              text: "I want to report a problem"
+            },
+            {
+              value: "data",
+              text: "I want government to publish new data"
+            },
+            {
+              value: "publish",
+              text: "I want to publish for an organisation"
+            },
+            {
+              value: "accessibility",
+              text: "I want to report an accessibility issue"
+            },
+          ]
+        } %>
+
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Continue",
+          margin_bottom: true,
+        } %>
+      </form>
+
+      <p class="govuk-body">Please give us your feedback about the site using <%= link_to "our survey", "http://www.smartsurvey.co.uk/s/3SEXD/", class: "govuk-link" %>.</p>
     </div>
   </div>
 </main>

--- a/app/views/pages/support.html.erb
+++ b/app/views/pages/support.html.erb
@@ -34,7 +34,7 @@
         heading_level: 2,
         font_size: "m",
       } %>
-      <p class="govuk-body">If you have a question about a specific dataset, contact the publisher directly.</p>
+      <p class="govuk-body">If you have a question about a specific dataset, contact the publisher directly using the contact details on the dataset page.</p>
 
       <%= render "govuk_publishing_components/components/heading", {
         text: "Other urgent requests",

--- a/app/views/pages/support.html.erb
+++ b/app/views/pages/support.html.erb
@@ -36,35 +36,13 @@
       } %>
       <p class="govuk-body">If you have a question about a specific dataset, contact the publisher directly.</p>
 
-      <form action="tickets/new" method="get">
-        <%= render "govuk_publishing_components/components/radio", {
-          name: "support",
-          heading: "How can we help you?",
-          items: [
-            {
-              value: "feedback",
-              text: "I want to report a problem"
-            },
-            {
-              value: "data",
-              text: "I want government to publish new data"
-            },
-            {
-              value: "publish",
-              text: "I want to publish for an organisation"
-            },
-            {
-              value: "accessibility",
-              text: "I want to report an accessibility issue"
-            },
-          ]
-        } %>
-
-        <%= render "govuk_publishing_components/components/button", {
-          text: "Continue",
-          margin_bottom: true,
-        } %>
-      </form>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Other urgent requests",
+        margin_bottom: 4,
+        heading_level: 2,
+        font_size: "m",
+      } %>
+      <p class="govuk-body">If your request is urgent, please use <%= link_to "the form", "https://www.gov.uk/contact/govuk", class: "govuk-link" %> and mention that it's about data.gov.uk.</p>
 
       <p class="govuk-body">Please give us your feedback about the site using <%= link_to "our survey", "http://www.smartsurvey.co.uk/s/3SEXD/", class: "govuk-link" %>.</p>
     </div>

--- a/app/views/tickets/new.html.erb
+++ b/app/views/tickets/new.html.erb
@@ -5,11 +5,77 @@
 <% end%>
 
 <main role="main" id="main-content" class="govuk-main-wrapper">
-  <div class="grid-row">
-    <div class="column-two-thirds">
-      <h1 class="heading-large">Service unavailable</h1>
-      <p>Sorry you can't use this service because of a technical problem.</p>
-      <p>We're working on a fix. Please try again later.</p>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <% if @ticket.errors.any? %>
+        <%
+          errors = @ticket.errors.messages.map do |attr, error|
+            {
+              text: error[0],
+              href: "#error-#{attr.to_s}"
+            }
+          end
+        %>
+        
+        <%= render "govuk_publishing_components/components/error_summary", {
+          title: t('.problem'),
+          items: errors
+        } %>
+      <% end %>
+
+      <%= render "govuk_publishing_components/components/heading", {
+        text: t(".#{@ticket.support}_request"),
+        margin_bottom: 4,
+        heading_level: 1,
+        font_size: "l",
+      } %>
+
+      <%= form_for @ticket, url: { action: "create", controller: "tickets" } do |f| %>
+        <%
+          content_error = t('.enter_a_message') if @ticket.errors[:content].any?
+          content_error_id = "error-content" if @ticket.errors[:content].any?
+          name_error = t('.enter_a_name') if @ticket.errors[:name].any?
+          name_error_id = "error-name" if @ticket.errors[:name].any?
+          email_error = t('.enter_an_email') if @ticket.errors[:email].any?
+          email_error_id = "error-email" if @ticket.errors[:email].any?
+        %>
+
+        <%= render "govuk_publishing_components/components/textarea", {
+          label: {
+            text: t('.your_message'),
+          },
+          name: "ticket[content]",
+          error_message: content_error,
+          id: content_error_id,
+          rows: 8,
+        } %>
+
+        <%= render "govuk_publishing_components/components/input", {
+          label: {
+            text: t('.name'),
+          },
+          name: "ticket[name]",
+          error_message: name_error,
+          id: name_error_id,
+          autocomplete: "name",
+        } %>
+
+        <%= render "govuk_publishing_components/components/input", {
+          label: {
+            text: t('.email_address'),
+          },
+          name: "ticket[email]",
+          error_message: email_error,
+          id: email_error_id,
+          hint: t('.use_this_to_reply'),
+          autocomplete: "email",
+        } %>
+
+        <%= f.hidden_field(:support, :value => @ticket.support) %>
+        <%= render "govuk_publishing_components/components/button", {
+          text: t('.submit'),
+        } %>      
+      <% end %>
     </div>
   </div>
 </main>

--- a/app/views/tickets/new.html.erb
+++ b/app/views/tickets/new.html.erb
@@ -7,75 +7,15 @@
 <main role="main" id="main-content" class="govuk-main-wrapper">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <% if @ticket.errors.any? %>
-        <%
-          errors = @ticket.errors.messages.map do |attr, error|
-            {
-              text: error[0],
-              href: "#error-#{attr.to_s}"
-            }
-          end
-        %>
-        
-        <%= render "govuk_publishing_components/components/error_summary", {
-          title: t('.problem'),
-          items: errors
-        } %>
-      <% end %>
 
       <%= render "govuk_publishing_components/components/heading", {
-        text: t(".#{@ticket.support}_request"),
+        text: "Other urgent requests",
         margin_bottom: 4,
         heading_level: 1,
         font_size: "l",
       } %>
 
-      <%= form_for @ticket, url: { action: "create", controller: "tickets" } do |f| %>
-        <%
-          content_error = t('.enter_a_message') if @ticket.errors[:content].any?
-          content_error_id = "error-content" if @ticket.errors[:content].any?
-          name_error = t('.enter_a_name') if @ticket.errors[:name].any?
-          name_error_id = "error-name" if @ticket.errors[:name].any?
-          email_error = t('.enter_an_email') if @ticket.errors[:email].any?
-          email_error_id = "error-email" if @ticket.errors[:email].any?
-        %>
-
-        <%= render "govuk_publishing_components/components/textarea", {
-          label: {
-            text: t('.your_message'),
-          },
-          name: "ticket[content]",
-          error_message: content_error,
-          id: content_error_id,
-          rows: 8,
-        } %>
-
-        <%= render "govuk_publishing_components/components/input", {
-          label: {
-            text: t('.name'),
-          },
-          name: "ticket[name]",
-          error_message: name_error,
-          id: name_error_id,
-          autocomplete: "name",
-        } %>
-
-        <%= render "govuk_publishing_components/components/input", {
-          label: {
-            text: t('.email_address'),
-          },
-          name: "ticket[email]",
-          error_message: email_error,
-          id: email_error_id,
-          hint: t('.use_this_to_reply'),
-          autocomplete: "email",
-        } %>
-
-        <%= f.hidden_field(:support, :value => @ticket.support) %>
-        <%= render "govuk_publishing_components/components/button", {
-          text: t('.submit'),
-        } %>      
-      <% end %>
+      <p class="govuk-body">If your request is urgent, please use <%= link_to 'the form', 'https://www.gov.uk/contact/govuk', class: 'govuk-link' %> and mention that it's about data.gov.uk.</p>
     </div>
   </div>
 </main>


### PR DESCRIPTION
The support form was removed but we need a way for legitimate users (eg those asking to become data publishers) to contact us.