### PR TITLE
Add redirect of support/new to /support

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,7 @@ Rails.application.routes.draw do
     get "publishers"
     get "site-changes", to: :site_changes
     get "support"
+    get "support/new", to: redirect("/support")
     get "terms"
     get "ckan_maintenance"
   end
@@ -39,8 +40,7 @@ Rails.application.routes.draw do
 
   get "search/", to: "search#search"
 
-  resources :tickets, only: %i[new create]
-  get "tickets/confirmation", to: "tickets#confirmation"
+  get "tickets/new", to: redirect("/support")
 
   get "data/map-preview", to: "map_previews#show", as: "map_preview"
 


### PR DESCRIPTION
To stop bots from being able to raise spam tickets.

[Trello card] (https://trello.com/c/TrY9IEND/2300-dgu-form-spam)