### PR TITLE
Implement Google Tag Manager

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,7 +4,13 @@
 <!--[if gt IE 8]><!--><html lang="<%= content_for?(:html_lang) ? yield(:html_lang) : "en" %>"><!--<![endif]-->
 <html class="govuk-template">
   <head>
-
+  <% if ENV["GOOGLE_TAG_MANAGER_ID"] %>
+    <%= render "govuk_publishing_components/components/google_tag_manager_script", {
+      gtm_id: ENV["GOOGLE_TAG_MANAGER_ID"],
+      gtm_auth: ENV["GOOGLE_TAG_MANAGER_AUTH"],
+      gtm_preview: ENV["GOOGLE_TAG_MANAGER_PREVIEW"]
+    } %>
+  <% end %>
 <script>
 <% if Rails.application.config.analytics_tracking_id.present? %>
   var analyticsInit = function() {


### PR DESCRIPTION
This adds GA4 tracking to DGU Find. It is configured with the below environment variables:
- GOOGLE_TAG_MANAGER_ID
- GOOGLE_TAG_MANAGER_AUTH (integration only)
- GOOGLE_TAG_MANAGER_PREVIEW (integration only)

Values are defined in https://github.com/alphagov/govuk-dgu-charts/pull/179

Trello card: https://trello.com/c/VdzhWk09/3456-migrate-datagovuk-page-views-tracking-from-ua-to-ga4-3