### PR TITLE
Setting up Google Tag Manager in Content Security Policy

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,19 +4,26 @@
 # For further information see the following documentation
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
-# Rails.application.config.content_security_policy do |policy|
-#   policy.default_src :self, :https
-#   policy.font_src    :self, :https, :data
-#   policy.img_src     :self, :https, :data
-#   policy.object_src  :none
-#   policy.script_src  :self, :https
-#   policy.style_src   :self, :https
-#   # If you are using webpack-dev-server then specify webpack-dev-server host
-#   policy.connect_src :self, :https, "http://localhost:3035", "ws://localhost:3035" if Rails.env.development?
+GOOGLE_ANALYTICS_DOMAINS = %w[www.google-analytics.com
+                              ssl.google-analytics.com
+                              stats.g.doubleclick.net
+                              www.googletagmanager.com
+                              www.region1.google-analytics.com
+                              region1.google-analytics.com].freeze
 
-#   # Specify URI for violation reports
-#   # policy.report_uri "/csp-violation-report-endpoint"
-# end
+Rails.application.config.content_security_policy do |policy|
+  #   policy.default_src :self, :https
+  #   policy.font_src    :self, :https, :data
+  #   policy.img_src     :self, :https, :data
+  #   policy.object_src  :none
+  policy.script_src :self, *GOOGLE_ANALYTICS_DOMAINS
+  #   policy.style_src   :self, :https
+  #   # If you are using webpack-dev-server then specify webpack-dev-server host
+  #   policy.connect_src :self, :https, "http://localhost:3035", "ws://localhost:3035" if Rails.env.development?
+
+  #   # Specify URI for violation reports
+  #   # policy.report_uri "/csp-violation-report-endpoint"
+end
 
 # If you are using UJS then enable automatic nonce generation
 # Rails.application.config.content_security_policy_nonce_generator = -> request { SecureRandom.base64(16) }


### PR DESCRIPTION
Setting up Google Tag Manager in Content Security Policy, so that the script is allowed to be run.

As it can see below, this is currently being prevented by content policy in Find, as it is in its Rails default state:
<img width="961" alt="GTM" src="https://github.com/alphagov/datagovuk_find/assets/99875822/59e82730-8738-4db9-bcff-2c4cd152f3cb">
It is visible that Google Tag Manager is present
<img width="1710" alt="Issue" src="https://github.com/alphagov/datagovuk_find/assets/99875822/53748240-6e9c-4b30-93a7-ed2d73c85f94">
But the script is prevented to run by default policy.


Related to PR: https://github.com/alphagov/datagovuk_find/pull/1256

Trello card: https://trello.com/c/VdzhWk09/3456-migrate-datagovuk-page-views-tracking-from-ua-to-ga4-3