### PR TITLE
Configure gtm in secure headers...

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,26 +4,19 @@
 # For further information see the following documentation
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
-GOOGLE_ANALYTICS_DOMAINS = %w[www.google-analytics.com
-                              ssl.google-analytics.com
-                              stats.g.doubleclick.net
-                              www.googletagmanager.com
-                              www.region1.google-analytics.com
-                              region1.google-analytics.com].freeze
+# Rails.application.config.content_security_policy do |policy|
+#   policy.default_src :self, :https
+#   policy.font_src    :self, :https, :data
+#   policy.img_src     :self, :https, :data
+#   policy.object_src  :none
+#   policy.script_src  :self, :https
+#   policy.style_src   :self, :https
+#   # If you are using webpack-dev-server then specify webpack-dev-server host
+#   policy.connect_src :self, :https, "http://localhost:3035", "ws://localhost:3035" if Rails.env.development?
 
-Rails.application.config.content_security_policy do |policy|
-  #   policy.default_src :self, :https
-  #   policy.font_src    :self, :https, :data
-  #   policy.img_src     :self, :https, :data
-  #   policy.object_src  :none
-  policy.script_src :self, *GOOGLE_ANALYTICS_DOMAINS
-  #   policy.style_src   :self, :https
-  #   # If you are using webpack-dev-server then specify webpack-dev-server host
-  #   policy.connect_src :self, :https, "http://localhost:3035", "ws://localhost:3035" if Rails.env.development?
-
-  #   # Specify URI for violation reports
-  #   # policy.report_uri "/csp-violation-report-endpoint"
-end
+#   # Specify URI for violation reports
+#   # policy.report_uri "/csp-violation-report-endpoint"
+# end
 
 # If you are using UJS then enable automatic nonce generation
 # Rails.application.config.content_security_policy_nonce_generator = -> request { SecureRandom.base64(16) }

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -8,7 +8,7 @@ SecureHeaders::Configuration.default do |config|
     manifest_src: ["'self'"],
     media_src: ["'self'"],
     object_src: ["'self'"],
-    script_src: ["'unsafe-inline'", "'self'", "www.google-analytics.com"],
+    script_src: ["'unsafe-inline'", "'self'", "www.google-analytics.com", "www.googletagmanager.com"],
     style_src: ["'unsafe-inline'", "'self'"],
   }
 end


### PR DESCRIPTION
...so that the script is allowed to run.

Related to https://github.com/alphagov/datagovuk_find/pull/1259

Moving the config to Secure Headers initialiser, as due to alphabetical execution, the Secure Headers settings
overwrite any changes to Content Security Policy.

Trello Card: https://trello.com/c/VdzhWk09/3456-migrate-datagovuk-page-views-tracking-from-ua-to-ga4-3