### PR TITLE
Remove feedback survey link

### DIFF
--- a/app/views/layouts/_feedback_survey_banner.html.erb
+++ b/app/views/layouts/_feedback_survey_banner.html.erb
@@ -1,7 +1,5 @@
 <div id="dgu-phase-banner" class="phase-banner">
   <p>
     <strong class="phase-tag">BETA</strong>
-    <span><%= t(".beta_survey_message_html", :href => link_to(t('.href'), t('.survey_url'), class: 'govuk-link'))%>
-    </span>
   </p>
 </div>

--- a/config/locales/views/layouts/en.yml
+++ b/config/locales/views/layouts/en.yml
@@ -1,9 +1,5 @@
 en:
   layouts:
-    feedback_survey_banner:
-      beta_survey_message_html: "This is a new service – your %{href} will help us to improve it"
-      href: "feedback"
-      survey_url: "http://www.smartsurvey.co.uk/s/3SEXD/"
     proposition_header:
       menu: "Menu"
       publishers: "Publish your data"


### PR DESCRIPTION
We don’t regularly look at responses to that survey. There's no team working on actively improving the product. We shouldn't set expectations that we're looking at feedback and potentially acting on it.

https://trello.com/c/k4MFlnIA/3546-remove-feedback-link-from-datagovuk-2