### PR TITLE
Disable session store in order to allow fastly to cache

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -30,9 +30,6 @@ Rails.application.configure do
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = true
 
-  # Disable request forgery protection in test environment.
-  config.action_controller.allow_forgery_protection = true
-
   config.action_mailer.perform_caching = false
 
   # Tell Action Mailer not to deliver emails to the real world.

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,1 +1,1 @@
-Rails.application.config.session_store :cookie_store, expire_after: 14.days, secure: !(Rails.env.development? || Rails.env.test?), httponly: true
+Rails.application.config.session_store :disabled


### PR DESCRIPTION
Also CSRF no longer needed as support forms have been disabled.