### PR TITLE
Don't use GTM from govuk_publishing_components until we can upgrade

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem "elasticsearch-rails", "~> 7.2.1"
 gem "faraday"
 gem "faraday_middleware"
 gem "govuk_elements_rails"
-gem "govuk_publishing_components", "~> 28.7.1"
+gem "govuk_publishing_components", "~> 28.7.1" # TODO: Revert https://github.com/alphagov/datagovuk_find/pull/1286 once 39.2.3+
 gem "htmlentities"
 gem "jbuilder"
 gem "jquery-rails"

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,12 +5,24 @@
 <html class="govuk-template">
   <head>
   <% if ENV["GOOGLE_TAG_MANAGER_ID"] %>
-    <%= render "govuk_publishing_components/components/google_tag_manager_script", {
-      gtm_id: ENV["GOOGLE_TAG_MANAGER_ID"],
-      gtm_auth: ENV["GOOGLE_TAG_MANAGER_AUTH"],
-      gtm_preview: ENV["GOOGLE_TAG_MANAGER_PREVIEW"]
-    } %>
+    <% 
+      gtm_auth = ENV["GOOGLE_TAG_MANAGER_AUTH"]
+      gtm_preview = ENV["GOOGLE_TAG_MANAGER_PREVIEW"]
+    
+      gtm_attributes = []
+        gtm_attributes << "gtm_auth=" + gtm_auth if gtm_auth
+        gtm_attributes << "gtm_preview=#{gtm_preview}&gtm_cookies_win=x" if gtm_preview
+      gtm_attributes = gtm_attributes.join('&')
+    %>
+    <script>
+    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl+'&<%= raw gtm_attributes %>';f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','<%= ENV["GOOGLE_TAG_MANAGER_ID"] %>');
+    </script>
   <% end %>
+
 <script>
 <% if Rails.application.config.analytics_tracking_id.present? %>
   var analyticsInit = function() {


### PR DESCRIPTION
The GTA doesn’t work as expected for DGU.

It appears that `gtm_cookies_win=x` allows GTM Preview to change the environment of a page, which means that they win over gtm_auth and gtm_preview parameters. The fix was added to govuk_publishing_components in v39.2.3: https://github.com/alphagov/govuk_publishing_components/pull/4097

However due to a number of issues with upgrading we are using 28.7.1 version.

This replicates code from https://github.com/alphagov/govuk_publishing_components/blob/a9be4e9f18693e3a2a7dcf87b7b396fbb283d579/app/views/govuk_publishing_components/components/_google_tag_manager_script.html.erb