### PR TITLE
Add sort filters to search page

### DIFF
--- a/app/controllers/solr_search_controller.rb
+++ b/app/controllers/solr_search_controller.rb
@@ -1,7 +1,9 @@
 class SolrSearchController < ApplicationController
   before_action :search_for_dataset, only: [:search]
 
-  def search; end
+  def search
+    @sort = params["sort"]
+  end
 
 private
 

--- a/app/services/search/solr.rb
+++ b/app/services/search/solr.rb
@@ -3,17 +3,21 @@ module Search
     def self.search(params)
       query_param = params.fetch("q", "").squish
       page = params["page"]
+      sort_param = params["sort"]
       page && page.to_i.positive? ? page.to_i : 1
 
       solr_client = client
 
       query = "*:*" if query_param.empty?
 
+      sort_query = "metadata_modified desc" if sort_param == "recent"
+
       solr_client.get "select", params: {
         q: query,
         start: page,
         rows: 20,
         fl: field_list,
+        sort: sort_query,
       }
     end
 

--- a/app/views/solr_search/search.html.erb
+++ b/app/views/solr_search/search.html.erb
@@ -25,6 +25,7 @@
 
       <div class="govuk-grid-row dgu-filters">
         <div class="govuk-grid-column-two-thirds dgu-results">
+          <%= render '/search/sort' if @num_results > 1 %>
           <span class="dgu-results__summary">
             <span class="govuk-body-s govuk-!-font-weight-bold"><%= number_with_delimiter(@num_results) %></span>
             <%= t('.result').pluralize(@num_results) %> <%= t('.found') %>

--- a/spec/features/solr_search_page_spec.rb
+++ b/spec/features/solr_search_page_spec.rb
@@ -3,43 +3,66 @@ require "rails_helper"
 RSpec.describe "Solr Search page", type: :feature do
   let(:results) { File.read(Rails.root.join("spec/fixtures/solr_response.json").to_s) }
 
-  before do
-    allow(Search::Solr).to receive(:search).and_return(JSON.parse(results))
+  describe "Default search page behaviour" do
+    before do
+      allow(Search::Solr).to receive(:search).and_return(JSON.parse(results))
+    end
+
+    scenario "Displays search heading" do
+      visit "/search/solr"
+      expect(page).to have_css("h1", text: "Search results")
+    end
+
+    scenario "Displays search box" do
+      visit "/search/solr"
+      expect(page).to have_content("Search data.gov.uk")
+    end
+
+    scenario "Displays search results" do
+      visit "/search/solr"
+      expect(page).to have_content("2 results found")
+    end
+
+    scenario "Displays the title for each search result" do
+      visit "/search/solr"
+      expect(page).to have_css("h2", text: "A very interesting dataset")
+      expect(page).to have_css("h2", text: "A dataset with additional inspire metadata")
+    end
+
+    scenario "Displays the publisher for each search result" do
+      visit "/search/solr"
+      results = all(".published_by")
+      expect(results.length).to be(2)
+      expect(results[0]).to have_content "Ministry of Housing, Communities and Local Government"
+      expect(results[1]).to have_content "Mole Valley District Council"
+    end
+
+    scenario "Displays the last updated for each search result" do
+      visit "/search/solr"
+      expect(page).to have_content("Last updated", count: 2)
+      expect(page).to have_content("30 June 2017")
+      expect(page).to have_content("17 August 2018")
+    end
+
+    scenario "Results are sorted by best match" do
+      visit "/search/solr"
+      expect(page).to have_select("sort", selected: "Best match")
+    end
   end
 
-  scenario "Displays search heading" do
-    visit "/search/solr"
-    expect(page).to have_css("h1", text: "Search results")
-  end
+  describe "When a user filters the results" do
+    before do
+      allow(Search::Solr).to receive(:search).and_return(JSON.parse(results))
+    end
 
-  scenario "Displays search box" do
-    visit "/search/solr"
-    expect(page).to have_content("Search data.gov.uk")
-  end
+    scenario "Results are sorted by best match" do
+      filtered_solr_search_for("Best match")
+      expect(page).to have_select("sort", selected: "Best match")
+    end
 
-  scenario "Displays search results" do
-    visit "/search/solr"
-    expect(page).to have_content("2 results found")
-  end
-
-  scenario "Displays the title for each search result" do
-    visit "/search/solr"
-    expect(page).to have_css("h2", text: "A very interesting dataset")
-    expect(page).to have_css("h2", text: "A dataset with additional inspire metadata")
-  end
-
-  scenario "Displays the publisher for each search result" do
-    visit "/search/solr"
-    results = all(".published_by")
-    expect(results.length).to be(2)
-    expect(results[0]).to have_content "Ministry of Housing, Communities and Local Government"
-    expect(results[1]).to have_content "Mole Valley District Council"
-  end
-
-  scenario "Displays the last updated for each search result" do
-    visit "/search/solr"
-    expect(page).to have_content("Last updated", count: 2)
-    expect(page).to have_content("30 June 2017")
-    expect(page).to have_content("17 August 2018")
+    scenario "Results are sorted by most recent" do
+      filtered_solr_search_for("Most recent")
+      expect(page).to have_select("sort", selected: "Most recent")
+    end
   end
 end

--- a/spec/support/solr_dataset_helper.rb
+++ b/spec/support/solr_dataset_helper.rb
@@ -1,0 +1,7 @@
+def filtered_solr_search_for(sort_method)
+  visit "/search/solr"
+  within "#main-content" do
+    select sort_method, from: "Sort by"
+    find(".gem-c-search__submit").click
+  end
+end


### PR DESCRIPTION
By default the results returned are "best match" and the sort option in the filter is automatically selected.

When the results are sorted by "most recent" we want to sort using the `public_updated_at` (the equivalent field in Solr is `metadata_modified`) and ordered by desc. This is passed as the `sort` parameter in the Solr query.

This has been tested in Integration.

Sorted by "Best match":
![Screenshot 2024-10-07 at 12 17 58](https://github.com/user-attachments/assets/e3f9b909-12e4-4bbe-8984-a89de2b65711)

Sorted by "Most recent":
![Screenshot 2024-10-07 at 12 18 09](https://github.com/user-attachments/assets/6a9e2919-b0f2-45d6-bb0d-a2ba442e50e3)

