### PR TITLE
Tidy up Solr dataset page

### DIFF
--- a/app/models/solr_datafile.rb
+++ b/app/models/solr_datafile.rb
@@ -1,6 +1,6 @@
 class SolrDatafile
   attr_reader :name, :url, :created_at,
-              :format, :size, :uuid
+              :format, :uuid
 
   def initialize(hash, created_at)
     @name = hash["name"] || hash["description"]
@@ -8,7 +8,6 @@ class SolrDatafile
 
     @created_at = hash["created"] || created_at
     @format = hash["format"]&.strip&.delete_prefix(".")&.upcase
-    @size = hash["size"]
     @uuid = hash["id"]
   end
 end

--- a/app/models/solr_dataset.rb
+++ b/app/models/solr_dataset.rb
@@ -3,7 +3,7 @@ class SolrDataset
 
   DatasetNotFound = Class.new(StandardError)
 
-  attr_reader :id, :name, :title, :summary, :public_updated_at, :topic, :licence_title, :licence_url, :organisation, :datafiles, :contact_email, :contact_name, :foi_name, :foi_email, :foi_web, :docs, :licence_custom, :inspire_dataset, :harvested
+  attr_reader :id, :name, :title, :summary, :public_updated_at, :topic, :licence_title, :licence_url, :organisation, :datafiles, :contact_email, :contact_name, :foi_name, :foi_email, :foi_web, :docs, :licence_custom, :inspire_dataset, :harvested, :licence_code
 
   def initialize(dataset)
     @id = dataset["id"]
@@ -16,6 +16,7 @@ class SolrDataset
     dataset_dict = JSON.parse(dataset["validated_data_dict"])
     @licence_title = dataset_dict["license_title"]
     @licence_url = dataset_dict["license_url"]
+    @licence_code = dataset_dict["license_id"]
     @licence_custom = dataset["extras_licence"].gsub(/"|\[|\]/, "") if dataset["extras_licence"].present?
 
     @organisation = Organisation.new(get_organisation(dataset_dict["organization"]["name"]))

--- a/app/views/solr_datasets/_datafile_table.html.erb
+++ b/app/views/solr_datasets/_datafile_table.html.erb
@@ -28,9 +28,6 @@
             <span class="dgu-secondary-text">N/A</span>
           <% else %>
             <%= datafile.format.upcase %>
-            <% if datafile.size %>
-              (<%= datafile.size.number_to_human_size %>)
-            <% end %>
           <% end %>
         </td>
         <td class="govuk-table__cell">

--- a/app/views/solr_datasets/_meta_data.html.erb
+++ b/app/views/solr_datasets/_meta_data.html.erb
@@ -46,10 +46,17 @@
           <dt><%= t('.licence') %>:</dt>
           <dd property="dc:rights">
             <% if @dataset.licence_url.present? %>
-              <%= link_to @dataset.licence_title,
-                          @dataset.licence_url.html_safe,
-                            rel: 'dc:rights',
-                            class: 'govuk-link' %>
+              <% if @dataset.licence_code == "uk-ogl" %>
+                <%= link_to t('.uk_ogl'),
+                            t('.uk_ogl_url'),
+                              rel: 'dc:rights',
+                              class: 'govuk-link' %>
+              <% else %>
+                <%= link_to @dataset.licence_title,
+                            @dataset.licence_url.html_safe,
+                              rel: 'dc:rights',
+                              class: 'govuk-link' %>
+              <% end %>
             <% elsif @dataset.licence_title.present? %>
               <%= @dataset.licence_title %>
             <% else %>

--- a/config/locales/views/datasets/en.yml
+++ b/config/locales/views/datasets/en.yml
@@ -97,6 +97,8 @@ en:
         licence: "Licence"
         no_licence: "None"
         other_licence: "Other Licence"
+        uk_ogl: "Open Government Licence"
+        uk_ogl_url: "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
         publisher_datasets: "More from this publisher"
         search_gov_data: "Search"
         accessibility:


### PR DESCRIPTION
This PR removes an unused field and fixes an issue with the OGL licence information shown in the metadata box on the dataset page.

This has been tested on Integration.

Before:
![Screenshot 2024-10-23 at 17 13 26](https://github.com/user-attachments/assets/0d6cca3d-d759-482b-9fca-0eca6141590d)

After:
![Screenshot 2024-10-23 at 17 34 43](https://github.com/user-attachments/assets/4bfcc1a3-6cbc-4327-8c05-ca43a721bc1b)
