### PR TITLE
Update Format filter

### DIFF
--- a/app/models/solr_datafile.rb
+++ b/app/models/solr_datafile.rb
@@ -7,7 +7,7 @@ class SolrDatafile
     @url = hash["url"]
 
     @created_at = hash["created"] || created_at
-    @format = hash["format"]&.strip&.delete_prefix(".")&.upcase
+    @format = hash["format"]&.strip&.delete_prefix(".")&.delete_suffix(".")&.upcase
     @uuid = hash["id"]
   end
 end

--- a/app/presenters/search_presenter.rb
+++ b/app/presenters/search_presenter.rb
@@ -87,6 +87,7 @@ private
     cleaned_formats = raw_formats.map do |raw_format|
       raw_format.strip.delete_prefix(".").delete_suffix(".")
         .gsub(/\Ahttps:\/\/www\.iana\.org\/assignments\/media-types\/(?:text|application)\//, "")
+        .sub(/\d+\.\d+\Z/, "")
         .delete_prefix("OGC ")
         .upcase
     end

--- a/app/presenters/search_presenter.rb
+++ b/app/presenters/search_presenter.rb
@@ -49,11 +49,14 @@ class SearchPresenter
 
   def format_options
     if search_keywords.empty?
-      Search::Solr::FORMAT_MAPPINGS.keys
+      Search::Solr::FORMAT_MAPPINGS.keys << "Other"
     else
       raw_formats = facet_values("res_format")
 
       main_formats = (cleaned_formats(raw_formats) & Search::Solr::FORMAT_MAPPINGS.keys).sort
+      other_formats = cleaned_formats(raw_formats) - main_formats
+
+      other_formats.present? ? (main_formats << "Other") : main_formats.sort
     end
   end
 

--- a/app/services/search/solr.rb
+++ b/app/services/search/solr.rb
@@ -55,6 +55,8 @@ module Search
     }.freeze
 
     def self.format_filter(format)
+      return other_formats_filter_query if format == "Other"
+
       FORMAT_MAPPINGS[format].map { |f| "res_format:\"#{f}\"" }.join("OR")
     end
 
@@ -138,6 +140,13 @@ module Search
 
     def self.client
       @client ||= RSolr.connect(url: ENV["SOLR_URL"])
+    end
+
+    def self.other_formats_filter_query
+      query_parts = FORMAT_MAPPINGS.values.flatten.map do |format|
+        "-res_format:\"#{format}\""
+      end
+      query_parts.join("")
     end
   end
 end

--- a/app/services/search/solr.rb
+++ b/app/services/search/solr.rb
@@ -42,9 +42,20 @@ module Search
       "extras_theme-primary:\"#{topic.parameterize(separator: '-')}\""
     end
 
+    FORMAT_MAPPINGS = {
+      "CSV" => ["CSV", ".csv", "csv", "CSV ", "csv.", ".CSV", "https://www.iana.org/assignments/media-types/text/csv"],
+      "GEOJSON" => %w[GeoJSON geojson],
+      "HTML" => %w[HTML html .html],
+      "KML" => %w[KML kml],
+      "PDF" => %w[PDF .pdf pdf],
+      "WMS" => ["WMS", "OGC WMS", "ogc wfs", "wms"],
+      "XLS" => %w[XLS xls .xls],
+      "XML" => %w[XML],
+      "ZIP" => %w[ZIP Zip https://www.iana.org/assignments/media-types/application/zip zip .zip],
+    }.freeze
+
     def self.format_filter(format)
-      format = "GeoJSON" if format == "GEOJSON"
-      "res_format:#{format}"
+      FORMAT_MAPPINGS[format].map { |f| "res_format:\"#{f}\"" }.join("OR")
     end
 
     def self.licence_filter(licence)

--- a/app/services/search/solr.rb
+++ b/app/services/search/solr.rb
@@ -44,10 +44,14 @@ module Search
 
     FORMAT_MAPPINGS = {
       "CSV" => ["CSV", ".csv", "csv", "CSV ", "csv.", ".CSV", "https://www.iana.org/assignments/media-types/text/csv"],
+      "ESRI REST" => ["Esri REST", "ESRI REST API"],
       "GEOJSON" => %w[GeoJSON geojson],
       "HTML" => %w[HTML html .html],
+      "JSON" => ["JSON", "json1.0", "json2.0", "https://www.iana.org/assignments/media-types/application/json"],
       "KML" => %w[KML kml],
       "PDF" => %w[PDF .pdf pdf],
+      "SHP" => %w[SHP],
+      "WFS" => ["WFS", "OGC WFS", "ogc wfs", "wfs"],
       "WMS" => ["WMS", "OGC WMS", "ogc wfs", "wms"],
       "XLS" => %w[XLS xls .xls],
       "XML" => %w[XML],

--- a/app/services/search/solr.rb
+++ b/app/services/search/solr.rb
@@ -103,7 +103,7 @@ module Search
         fl: field_list,
         sort: @sort_query,
         facet: "true",
-        "facet.field": %w[organization extras_theme-primary],
+        "facet.field": %w[organization extras_theme-primary res_format],
         "facet.sort": "count",
         "facet.mincount": 1,
       }
@@ -119,6 +119,7 @@ module Search
         metadata_modified
         metadata_created
         extras_theme-primary
+        res_format
         validated_data_dict
         extras_licence
       ].freeze

--- a/spec/fixtures/solr_response.json
+++ b/spec/fixtures/solr_response.json
@@ -37,6 +37,10 @@
       "extras_theme-primary":[
         "govern",
         2
+      ],
+      "res_format": [
+        "CSV", 4, 
+        "ZIP", 2
       ]
     }
   }

--- a/spec/fixtures/solr_response_with_facets.json
+++ b/spec/fixtures/solr_response_with_facets.json
@@ -35,6 +35,10 @@
       "extras_theme-primary": [
         "societi", 18, 
         "health", 9
+      ],
+      "res_format": [
+        "CSV", 4, 
+        "ZIP", 2
       ]
     }
   }

--- a/spec/presenters/search_presenter_spec.rb
+++ b/spec/presenters/search_presenter_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe SearchPresenter do
       } }
       presenter = described_class.new(query_response, {})
 
-      expect(presenter.format_options).to eql(Search::Solr::FORMAT_MAPPINGS.keys)
+      expect(presenter.format_options).to eql(Search::Solr::FORMAT_MAPPINGS.keys << "Other")
     end
 
     it "returns only datafiles' formats included in returned datasets" do
@@ -65,6 +65,41 @@ RSpec.describe SearchPresenter do
         GEOJSON
         HTML
       ])
+    end
+
+    it "returns includes Other option for non-standard formats" do
+      query_response =
+        { "responseHeader" => {
+            "params" => { "q" => "title:\"dogs\" OR notes:\"dogs\" AND NOT site_id:dgu_organisations" },
+          },
+          "facet_counts" => {
+            "facet_fields" => {
+              "res_format" => ["CSV", 10, "some-weird-format", 1],
+            },
+          } }
+
+      presenter = described_class.new(query_response, { "q" => "dogs" })
+
+      expect(presenter.format_options).to eql(%w[
+        CSV
+        Other
+      ])
+    end
+
+    it "doesn't include Other if no results are returned" do
+      query_response =
+        { "responseHeader" => {
+            "params" => { "q" => "title:\"dogs\" OR notes:\"dogs\" AND NOT site_id:dgu_organisations" },
+          },
+          "facet_counts" => {
+            "facet_fields" => {
+              "res_format" => [],
+            },
+          } }
+
+      presenter = described_class.new(query_response, { "q" => "dogs" })
+
+      expect(presenter.format_options).to eql(%w[])
     end
   end
 end

--- a/spec/presenters/search_presenter_spec.rb
+++ b/spec/presenters/search_presenter_spec.rb
@@ -42,19 +42,28 @@ RSpec.describe SearchPresenter do
         "status" => 0,
         "params" => { "q" => "*:*", "wt" => "json" },
       } }
-
       presenter = described_class.new(query_response, {})
+
+      expect(presenter.format_options).to eql(Search::Solr::FORMAT_MAPPINGS.keys)
+    end
+
+    it "returns only datafiles' formats included in returned datasets" do
+      query_response =
+        { "responseHeader" => {
+            "params" => { "q" => "title:\"dogs\" OR notes:\"dogs\" AND NOT site_id:dgu_organisations" },
+          },
+          "facet_counts" => {
+            "facet_fields" => {
+              "res_format" => ["CSV", 10, "GEOJSON", 5, "csv.", 2, ".html"],
+            },
+          } }
+
+      presenter = described_class.new(query_response, { "q" => "dogs" })
 
       expect(presenter.format_options).to eql(%w[
         CSV
         GEOJSON
         HTML
-        KML
-        PDF
-        WMS
-        XLS
-        XML
-        ZIP
       ])
     end
   end

--- a/spec/presenters/search_presenter_spec.rb
+++ b/spec/presenters/search_presenter_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe SearchPresenter do
           },
           "facet_counts" => {
             "facet_fields" => {
-              "res_format" => ["CSV", 10, "GEOJSON", 5, "csv.", 2, ".html"],
+              "res_format" => ["CSV", 10, "GEOJSON", 5, "csv.", 2, ".html", 1, "json2.0", 1],
             },
           } }
 
@@ -64,6 +64,7 @@ RSpec.describe SearchPresenter do
         CSV
         GEOJSON
         HTML
+        JSON
       ])
     end
 

--- a/spec/services/search/solr_spec.rb
+++ b/spec/services/search/solr_spec.rb
@@ -291,13 +291,18 @@ RSpec.describe Search::Solr do
     it "returns negative solr filter query for Other formats" do
       query_string =
         "-res_format:\"CSV\"-res_format:\".csv\"-res_format:\"csv\"-res_format:\"CSV \"-res_format:\"csv.\"-res_format:\".CSV\"-res_format:\"https://www.iana.org/assignments/media-types/text/csv\"" \
+        "-res_format:\"Esri REST\"-res_format:\"ESRI REST API\"" \
         "-res_format:\"GeoJSON\"-res_format:\"geojson\"" \
         "-res_format:\"HTML\"-res_format:\"html\"-res_format:\".html\"" \
+        "-res_format:\"JSON\"-res_format:\"json1.0\"-res_format:\"json2.0\"-res_format:\"https://www.iana.org/assignments/media-types/application/json\"" \
         "-res_format:\"KML\"-res_format:\"kml\"" \
         "-res_format:\"PDF\"-res_format:\".pdf\"-res_format:\"pdf\"" \
-        "-res_format:\"WMS\"-res_format:\"wms\"-res_format:\"OGC WMS\"" \
-        "-res_format:\"XLS\"-res_format:\"xls\"-res_format:\".xls\"-res_format:\"XML\"" \
-        "-res_format:\"ZIP\"-res_format:\"Zip\"-res_format:\"https://www.iana.org/assignments/media-types/application/zip\"-res_format:\"zip\"-res_format:\".zip\"" \
+        "-res_format:\"SHP\"" \
+        "-res_format:\"WFS\"-res_format:\"OGC WFS\"-res_format:\"ogc wfs\"-res_format:\"wfs\"" \
+        "-res_format:\"WMS\"-res_format:\"OGC WMS\"-res_format:\"ogc wfs\"-res_format:\"wms\"" \
+        "-res_format:\"XLS\"-res_format:\"xls\"-res_format:\".xls\"" \
+        "-res_format:\"XML\"" \
+        "-res_format:\"ZIP\"-res_format:\"Zip\"-res_format:\"https://www.iana.org/assignments/media-types/application/zip\"-res_format:\"zip\"-res_format:\".zip\""
 
       expect(described_class.format_filter("Other")).to eq(query_string)
     end

--- a/spec/services/search/solr_spec.rb
+++ b/spec/services/search/solr_spec.rb
@@ -287,5 +287,19 @@ RSpec.describe Search::Solr do
         "res_format:\"CSV\"ORres_format:\".csv\"ORres_format:\"csv\"ORres_format:\"CSV \"ORres_format:\"csv.\"ORres_format:\".CSV\"ORres_format:\"https://www.iana.org/assignments/media-types/text/csv\"",
       )
     end
+
+    it "returns negative solr filter query for Other formats" do
+      query_string =
+        "-res_format:\"CSV\"-res_format:\".csv\"-res_format:\"csv\"-res_format:\"CSV \"-res_format:\"csv.\"-res_format:\".CSV\"-res_format:\"https://www.iana.org/assignments/media-types/text/csv\"" \
+        "-res_format:\"GeoJSON\"-res_format:\"geojson\"" \
+        "-res_format:\"HTML\"-res_format:\"html\"-res_format:\".html\"" \
+        "-res_format:\"KML\"-res_format:\"kml\"" \
+        "-res_format:\"PDF\"-res_format:\".pdf\"-res_format:\"pdf\"" \
+        "-res_format:\"WMS\"-res_format:\"wms\"-res_format:\"OGC WMS\"" \
+        "-res_format:\"XLS\"-res_format:\"xls\"-res_format:\".xls\"-res_format:\"XML\"" \
+        "-res_format:\"ZIP\"-res_format:\"Zip\"-res_format:\"https://www.iana.org/assignments/media-types/application/zip\"-res_format:\"zip\"-res_format:\".zip\"" \
+
+      expect(described_class.format_filter("Other")).to eq(query_string)
+    end
   end
 end

--- a/spec/services/search/solr_spec.rb
+++ b/spec/services/search/solr_spec.rb
@@ -280,4 +280,12 @@ RSpec.describe Search::Solr do
       expect(topic_facets[3]).to eq(2)
     end
   end
+
+  describe ".topic_filter" do
+    it "returns solr filter query with all format variations for a main format" do
+      expect(described_class.format_filter("CSV")).to eq(
+        "res_format:\"CSV\"ORres_format:\".csv\"ORres_format:\"csv\"ORres_format:\"CSV \"ORres_format:\"csv.\"ORres_format:\".CSV\"ORres_format:\"https://www.iana.org/assignments/media-types/text/csv\"",
+      )
+    end
+  end
 end

--- a/spec/services/search/solr_spec.rb
+++ b/spec/services/search/solr_spec.rb
@@ -271,5 +271,13 @@ RSpec.describe Search::Solr do
       expect(topic_facets[2]).to eq("health")
       expect(topic_facets[3]).to eq(9)
     end
+
+    it "includes the datasets' formats" do
+      topic_facets = results["facet_counts"]["facet_fields"]["res_format"]
+      expect(topic_facets[0]).to eq("CSV")
+      expect(topic_facets[1]).to eq(4)
+      expect(topic_facets[2]).to eq("ZIP")
+      expect(topic_facets[3]).to eq(2)
+    end
   end
 end


### PR DESCRIPTION
## Changes

- Format filter only includes main formats of returned datasets

<kbd>![narrows-filter-list](https://github.com/user-attachments/assets/bebb943d-eac5-4e5b-b8cd-e61bbc82fbbc)</kbd>

- Users can filter datasets by "Other" formats

<kbd>![other-search](https://github.com/user-attachments/assets/05e25977-329b-4f58-b782-60b22d24a551)</kbd>

- New popular formats added: "Esri REST", "JSON", "SHP", "WFS", "XML"

- Remove tailing . from datafiles' formats

  - Before
<kbd><img width="741" alt="Screenshot 2024-11-11 at 19 21 46" src="https://github.com/user-attachments/assets/f7694057-ba12-48f7-905e-ac0c7eac97f1"></kbd>

  - After
<kbd><img width="748" alt="Screenshot 2024-11-11 at 19 37 35" src="https://github.com/user-attachments/assets/64a8829a-44ca-4b2a-818a-ad487f8fae50"></kbd>

Closes https://github.com/alphagov/datagovuk_find/issues/1336