### PR TITLE
Ensure OGL Licence filter returns all relevant results

### DIFF
--- a/app/presenters/search_presenter.rb
+++ b/app/presenters/search_presenter.rb
@@ -76,6 +76,10 @@ class SearchPresenter
     search_params.dig(:filters, :format)
   end
 
+  def selected_licence
+    search_params&.dig(:filters, :licence_code)
+  end
+
 private
 
   def facet_values(facet_name)

--- a/app/services/search/solr.rb
+++ b/app/services/search/solr.rb
@@ -65,7 +65,9 @@ module Search
     end
 
     def self.licence_filter(licence)
-      "license_id:#{licence}"
+      return "license_id:(uk-ogl OGL-UK-* ogl)" if licence == "uk-ogl"
+
+      "license_id:\"#{licence}\""
     end
 
     def self.get_organisations

--- a/app/views/solr_search/_filters.html.erb
+++ b/app/views/solr_search/_filters.html.erb
@@ -19,7 +19,8 @@
   items: [
     {
       label: t(".filter_by_ogl"),
-      value: "uk-ogl"
+      value: "uk-ogl",
+      checked: @presenter.selected_licence == "uk-ogl",
     }
   ]
 } %>

--- a/spec/services/search/solr_spec.rb
+++ b/spec/services/search/solr_spec.rb
@@ -281,7 +281,7 @@ RSpec.describe Search::Solr do
     end
   end
 
-  describe ".topic_filter" do
+  describe ".format_filter" do
     it "returns solr filter query with all format variations for a main format" do
       expect(described_class.format_filter("CSV")).to eq(
         "res_format:\"CSV\"ORres_format:\".csv\"ORres_format:\"csv\"ORres_format:\"CSV \"ORres_format:\"csv.\"ORres_format:\".CSV\"ORres_format:\"https://www.iana.org/assignments/media-types/text/csv\"",
@@ -305,6 +305,20 @@ RSpec.describe Search::Solr do
         "-res_format:\"ZIP\"-res_format:\"Zip\"-res_format:\"https://www.iana.org/assignments/media-types/application/zip\"-res_format:\"zip\"-res_format:\".zip\""
 
       expect(described_class.format_filter("Other")).to eq(query_string)
+    end
+  end
+
+  describe ".licence_filter" do
+    it "returns solr filter query with all variations of Open Government Licence" do
+      expect(described_class.licence_filter("uk-ogl")).to eq(
+        "license_id:(uk-ogl OGL-UK-* ogl)",
+      )
+    end
+
+    it "returns solr filter query for other licences" do
+      expect(described_class.licence_filter("other-nc")).to eq(
+        "license_id:\"other-nc\"",
+      )
     end
   end
 end


### PR DESCRIPTION
We used `uk-ogl` id to filter datasets that use the standard OGL licence. Datasets with `OGL-UK-3.0` and `ogl` should also be returned.

Available to test in integration https://www.integration.data.gov.uk/search/solr?q= (VPN required)

### Before
<kbd><img width="1178" alt="Screenshot 2024-11-20 at 16 54 07" src="https://github.com/user-attachments/assets/d03dd67f-89f7-40c6-b802-cec8ad930854"></kbd>


### After
<kbd><img width="1183" alt="Screenshot 2024-11-20 at 16 50 17" src="https://github.com/user-attachments/assets/9dfc0c1f-36c7-45be-84ad-74b1a385c052"></kbd>

Closes https://github.com/alphagov/datagovuk_find/issues/1354
