### PR TITLE
Update Licence details on dataset page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,7 +148,7 @@ GEM
     google-protobuf (3.25.5)
     googleapis-common-protos-types (1.12.0)
       google-protobuf (~> 3.18)
-    govuk_app_config (9.9.1)
+    govuk_app_config (9.8.2)
       logstasher (~> 2.1)
       opentelemetry-exporter-otlp (>= 0.25, < 0.27)
       opentelemetry-instrumentation-all (>= 0.39.1, < 0.57.0)

--- a/app/services/search/solr.rb
+++ b/app/services/search/solr.rb
@@ -64,8 +64,10 @@ module Search
       FORMAT_MAPPINGS[format].map { |f| "res_format:\"#{f}\"" }.join("OR")
     end
 
+    OGL_IDS = ["uk-ogl", /OGL-UK-*/, "ogl"].freeze
+
     def self.licence_filter(licence)
-      return "license_id:(uk-ogl OGL-UK-* ogl)" if licence == "uk-ogl"
+      return "license_id:(#{OGL_IDS.map { |id| id.is_a?(Regexp) ? id.source : id }.join(' ')})" if licence == "uk-ogl"
 
       "license_id:\"#{licence}\""
     end

--- a/app/views/solr_datasets/_meta_data.html.erb
+++ b/app/views/solr_datasets/_meta_data.html.erb
@@ -45,18 +45,16 @@
 
           <dt><%= t('.licence') %>:</dt>
           <dd property="dc:rights">
-            <% if @dataset.licence_url.present? %>
-              <% if @dataset.licence_code == "uk-ogl" %>
-                <%= link_to t('.uk_ogl'),
-                            t('.uk_ogl_url'),
-                              rel: 'dc:rights',
-                              class: 'govuk-link' %>
-              <% else %>
-                <%= link_to @dataset.licence_title,
-                            @dataset.licence_url.html_safe,
-                              rel: 'dc:rights',
-                              class: 'govuk-link' %>
-              <% end %>
+            <% if Search::Solr::OGL_IDS.any? { |id| id === @dataset.licence_code } %>
+              <%= link_to t('.uk_ogl'),
+                          t('.uk_ogl_url'),
+                            rel: 'dc:rights',
+                            class: 'govuk-link' %>
+            <% elsif @dataset.licence_url.present? %>
+              <%= link_to @dataset.licence_title,
+                          @dataset.licence_url.html_safe,
+                            rel: 'dc:rights',
+                            class: 'govuk-link' %>
             <% elsif @dataset.licence_title.present? %>
               <%= @dataset.licence_title %>
             <% else %>

--- a/app/views/solr_datasets/_meta_data.html.erb
+++ b/app/views/solr_datasets/_meta_data.html.erb
@@ -57,8 +57,17 @@
                             class: 'govuk-link' %>
             <% elsif @dataset.licence_title.present? %>
               <%= @dataset.licence_title %>
+            <% elsif @dataset.licence_custom.present? %>
+              <%= t('.other_licence') %>
             <% else %>
               <%= t('.no_licence') %>
+            <% end %>
+
+            <% if @dataset.licence_custom.present? %>
+              <br>
+              <%= link_to t('.view_licence_information'),
+                            '#licence-info',
+                            class: 'govuk-link' %>
             <% end %>
           </dd>
         </dl>

--- a/spec/features/solr_dataset_edge_cases_spec.rb
+++ b/spec/features/solr_dataset_edge_cases_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.feature "Solr Dataset page edge cases", type: :feature do
+  scenario "User views a dataset page without datafiles" do
+    given_an_organisation_exists
+    given_a_dataset_without_datafiles_exists
+    when_i_visit_solr_dataset_page(@response_no_datafiles, @dataset_no_datafiles)
+
+    then_a_message_indicates_no_data_links_are_available
+    and_a_not_released_label_is_displayed
+  end
+
+  def given_a_dataset_without_datafiles_exists
+    @response_no_datafiles = JSON.parse(File.read(Rails.root.join("spec/fixtures/solr_dataset_without_datafiles.json").to_s))
+    params = @response_no_datafiles["response"]["docs"].first
+    @dataset_no_datafiles = SolrDataset.new(params)
+  end
+
+  def given_an_organisation_exists
+    org_response = JSON.parse(File.read(Rails.root.join("spec/fixtures/solr_organisation.json").to_s))
+    allow(Search::Solr).to receive(:get_organisation).and_return(org_response)
+  end
+
+  def when_i_visit_solr_dataset_page(response, dataset)
+    allow(Search::Solr).to receive(:get_by_uuid).and_return(response)
+    visit solr_dataset_path(dataset.id, dataset.name)
+  end
+
+  def then_a_message_indicates_no_data_links_are_available
+    expect(page).to have_css("h2", text: "Data links")
+    expect(page).to have_content("This data hasn’t been released by the publisher.")
+  end
+
+  def and_a_not_released_label_is_displayed
+    expect(page).to have_content("Availability: Not released")
+  end
+end

--- a/spec/features/solr_dataset_edge_cases_spec.rb
+++ b/spec/features/solr_dataset_edge_cases_spec.rb
@@ -28,6 +28,23 @@ RSpec.feature "Solr Dataset page edge cases", type: :feature do
                         href: "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/")
       end
     end
+
+    scenario "Link to licence with additional info" do
+      modifed_json_fixture = modified_dataset_json(
+        "extras_licence", "Fair Usage"
+      )
+      given_a_dataset_exists_and_i_visit_the_page(modifed_json_fixture)
+
+      within("section.meta-data") do
+        expect(page)
+          .to have_link("View licence information",
+                        href: "#licence-info")
+      end
+
+      within("section.dgu-licence-info") do
+        expect(page).to have_content("Fair Usage")
+      end
+    end
   end
 
   def given_a_dataset_without_datafiles_exists

--- a/spec/features/solr_inspire_dataset_show_page_spec.rb
+++ b/spec/features/solr_inspire_dataset_show_page_spec.rb
@@ -1,0 +1,130 @@
+require "rails_helper"
+
+RSpec.feature "Solr Inspire dataset", type: :feature do
+  scenario "User views Inspire dataset page" do
+    given_an_organisation_exists
+    given_an_inspire_dataset_exists
+    when_i_visit_solr_dataset_page(@response_inspire, @dataset_inspire)
+
+    # Custom Licence
+    then_the_custom_licence_title_is_displayed
+    then_the_custom_licence_information_is_displayed
+
+    # Additional Information
+    then_the_additional_information_title_is_displayed
+    then_the_additional_metadata_summary_is_displayed
+    then_the_date_added_to_data_gov_uk_is_displayed
+    then_the_access_constraints_are_displayed
+    then_the_harvest_guid_is_displayed
+    then_the_extent_is_displayed
+    then_the_spatial_reference_is_displayed
+    then_the_dataset_reference_date_is_displayed
+    then_the_frequency_of_update_is_displayed
+    then_the_responsible_party_is_displayed
+    then_the_iso_19139_resource_type_is_displayed
+    then_the_metadata_language_is_displayed
+    then_the_inspire_xml_link_is_displayed
+    then_the_inspire_html_link_is_displayed
+
+    then_the_publisher_edit_link_is_not_displayed
+  end
+
+  def given_an_inspire_dataset_exists
+    @response_inspire = JSON.parse(File.read(Rails.root.join("spec/fixtures/solr_inspire_dataset.json").to_s))
+    params = @response_inspire["response"]["docs"].first
+    @dataset_inspire = SolrDataset.new(params)
+  end
+
+  def given_an_organisation_exists
+    org_response = JSON.parse(File.read(Rails.root.join("spec/fixtures/solr_organisation.json").to_s))
+    allow(Search::Solr).to receive(:get_organisation).and_return(org_response)
+  end
+
+  def when_i_visit_solr_dataset_page(response, dataset)
+    allow(Search::Solr).to receive(:get_by_uuid).and_return(response)
+    visit solr_dataset_path(dataset.id, dataset.name)
+  end
+
+  def then_the_custom_licence_title_is_displayed
+    expect(page).to have_css("section.dgu-licence-info h2", text: "Licence information")
+  end
+
+  def then_the_custom_licence_information_is_displayed
+    expect(page).to have_css(
+      "section.dgu-licence-info",
+      text: "Licence information\nUnder the OGL, Land Registry permits you to use the data for commercial or non-commercial purposes. \\n(a) use the polygons (including the associated geometry, namely x,y co-ordinates); or\\Ordnance Survey Public Sector End User Licence - INSPIRE (http://www.ordnancesurvey.co.uk/business-and-government/public-sector/mapping-agreements/inspire-licence.html)",
+    )
+  end
+
+  def then_the_additional_information_title_is_displayed
+    expect(page).to have_css(".dgu-additional-info h2", text: "Additional information")
+  end
+
+  def then_the_additional_metadata_summary_is_displayed
+    expect(page).to have_css(".dgu-additional-info .summary", text: "View additional metadata")
+  end
+
+  def then_the_date_added_to_data_gov_uk_is_displayed
+    expect(page).to have_css(".dgu-additional-info", text: "Added to data.gov.uk")
+    expect(page).to have_css(".dgu-additional-info", text: "2020-12-14")
+  end
+
+  def then_the_access_constraints_are_displayed
+    expect(page).to have_css(".dgu-additional-info", text: "Access contraints")
+    expect(page).to have_css(".dgu-additional-info", text: "Not specified")
+  end
+
+  def then_the_harvest_guid_is_displayed
+    expect(page).to have_css(".dgu-additional-info", text: "Harvest GUID")
+    expect(page).to have_css(".dgu-additional-info", text: "3df58f2f-a13e-46e9-a657-f532f7ad2fc1")
+  end
+
+  def then_the_extent_is_displayed
+    expect(page).to have_css(".dgu-additional-info", text: "Extent")
+    expect(page).to have_css(".dgu-additional-info", text: "Latitude: 55.80° to ° Longitude: -6.33° to 1.78°")
+  end
+
+  def then_the_spatial_reference_is_displayed
+    expect(page).to have_css(".dgu-additional-info", text: "Spatial reference")
+    expect(page).to have_css(".dgu-additional-info", text: "http://www.opengis.net/def/crs/EPSG/0/27700")
+  end
+
+  def then_the_dataset_reference_date_is_displayed
+    expect(page).to have_css(".dgu-additional-info", text: "Dataset reference date")
+    expect(page).to have_css(".dgu-additional-info", text: "2020-12-29 (publication)")
+  end
+
+  def then_the_frequency_of_update_is_displayed
+    expect(page).to have_css(".dgu-additional-info", text: "Frequency of update")
+    expect(page).to have_css(".dgu-additional-info", text: "monthly")
+  end
+
+  def then_the_responsible_party_is_displayed
+    expect(page).to have_css(".dgu-additional-info", text: "Responsible party")
+    expect(page).to have_css(".dgu-additional-info", text: "HM Land Registry (pointOfContact)")
+  end
+
+  def then_the_iso_19139_resource_type_is_displayed
+    expect(page).to have_css(".dgu-additional-info", text: "ISO 19139 resource type")
+    expect(page).to have_css(".dgu-additional-info", text: "dataset")
+  end
+
+  def then_the_metadata_language_is_displayed
+    expect(page).to have_css(".dgu-additional-info", text: "Metadata language")
+    expect(page).to have_css(".dgu-additional-info", text: "eng")
+  end
+
+  def then_the_inspire_xml_link_is_displayed
+    expect(page).to have_xpath("//a[@href='/api/2/rest/harvestobject/d35b1574-9823-4fbc-80c0-cd1cc3b84bea/xml']", visible: :all)
+  end
+
+  def then_the_inspire_html_link_is_displayed
+    expect(page).to have_xpath("//a[@href='/api/2/rest/harvestobject/d35b1574-9823-4fbc-80c0-cd1cc3b84bea/html']", visible: :all)
+  end
+
+  def then_the_publisher_edit_link_is_not_displayed
+    expect(page).to_not have_css("h2", text: "Edit this dataset")
+    expect(page).to_not have_css("p", text: "You must have an account for this publisher on data.gov.uk to make any changes to a dataset.")
+    expect(page).to_not have_link("Sign in", href: "/dataset/edit/performance-related-pay-department-for-communities-and-local-government")
+  end
+end

--- a/spec/fixtures/solr_dataset.json
+++ b/spec/fixtures/solr_dataset.json
@@ -8,7 +8,7 @@
         "id":"420932c7-e6f8-43ea-adc5-3141f757b5cb",
         "name":"a-very-interesting-dataset",
         "title":"A very interesting dataset",
-        "notes":"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec euismod mauris in augue laoreet congue. Phasellus bibendum leo vel magna lacinia eleifend. Nam vitae lectus quis nulla varius faucibus id quis nibh. Nullam auctor ipsum non nunc efficitur bibendum Sed vitae ex nisi. Suspendisse posuere purus ac dui posuere, in interdum risus ornare. \n\nThe following files can be found on the website here:\n\nhttps://www.gov.uk/",
+        "notes":"Lorem ipsum dolor sit amet.",
         "metadata_modified":"2017-06-30T09:08:37.040Z",
         "metadata_created":"2011-10-27T13:29:52.056Z",
         "organization":"department-for-communities-and-local-government",

--- a/spec/services/search/solr_spec.rb
+++ b/spec/services/search/solr_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe Search::Solr do
       end
 
       it "includes the notes" do
-        expect(dataset["notes"]).to eq("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec euismod mauris in augue laoreet congue. Phasellus bibendum leo vel magna lacinia eleifend. Nam vitae lectus quis nulla varius faucibus id quis nibh. Nullam auctor ipsum non nunc efficitur bibendum Sed vitae ex nisi. Suspendisse posuere purus ac dui posuere, in interdum risus ornare. \n\nThe following files can be found on the website here:\n\nhttps://www.gov.uk/")
+        expect(dataset["notes"]).to eq("Lorem ipsum dolor sit amet.")
       end
 
       it "includes the last updated date" do

--- a/spec/support/solr_dataset_helper.rb
+++ b/spec/support/solr_dataset_helper.rb
@@ -6,3 +6,16 @@ def sorted_solr_search_for(sort_method)
     find(".gem-c-search__submit").click
   end
 end
+
+def modified_dataset_validated_data_dict_json(property, new_value)
+  parsed_json = JSON.parse(File.read(Rails.root.join("spec/fixtures/solr_dataset.json").to_s))
+  first_doc = parsed_json["response"]["docs"].first
+  validated_data = JSON.parse(first_doc["validated_data_dict"])
+
+  validated_data[property] = new_value
+
+  # Manually format the JSON string with one space after each colon
+  first_doc["validated_data_dict"] = validated_data.to_json.gsub(/":\s?/, '": ')
+
+  parsed_json
+end

--- a/spec/support/solr_dataset_helper.rb
+++ b/spec/support/solr_dataset_helper.rb
@@ -19,3 +19,13 @@ def modified_dataset_validated_data_dict_json(property, new_value)
 
   parsed_json
 end
+
+def modified_dataset_json(property, new_value)
+  parsed_json = JSON.parse(File.read(Rails.root.join("spec/fixtures/solr_dataset.json").to_s))
+  first_doc = parsed_json["response"]["docs"].first
+
+  # Update the value if the property exists, or add it if it doesn't
+  first_doc[property] = new_value
+
+  parsed_json
+end


### PR DESCRIPTION
To make it consistent for the users how we present it on the dataset page.

Introduction of the OGL_IDS constant will ensure that filter query and licence display on the dataset page stay in sync in case the codes/ids change.

Datasets to test:
- OGL with `OGL-UK-3.0` code `/6449d8f5-76e7-4aff-bfb1-46d46542a56c/footfall`
- OGL with `ogl` code `/zdc37c693-d910-457a-bbee-70a4037715bb/business-rates1`
- Creative Commons Attribution (with a link) `/9eae6898-f45e-4c86-86ac-90c5abd54342/waverley-brownfield-land-register1`
- Creative Commons CCZero (with a link) `/091feb1c-aea6-45c9-82bf-768a15c65307/open-postcode-geo2`
- Other (Non-Commercial) `/4673fcd9-3207-4244-9f7b-ca0ea873d65b/fareham-local-plan-2037-policies-map-adopted-april-2023`
- Other (Open) `/d7e875c5-ea02-4d33-ba53-c4d9b74ae824/tree-preservation-order-points`
- License not specified `/fe764aec-ee2f-47ae-a92c-f2ae30f571c9/dtp-number-reverse-engineering`
- Custom licence `/8f25053a-bc44-4efc-a142-ae6ba3705498/uk-climate-averages`

### Show link to licence details for all OGL codes

| Before   | After |
| -------- | ------- |
| <img width="654" alt="Screenshot 2024-11-21 at 15 56 51" src="https://github.com/user-attachments/assets/ed01e7cf-7adf-4d57-afa4-6d60d29d2668"> | <img width="646" alt="Screenshot 2024-11-21 at 15 57 03" src="https://github.com/user-attachments/assets/e0ac14e7-b7dc-41e8-850d-1b1574ec4fc3"> |

### Show custom licence information

| Before   | After |
| -------- | ------- |
| <img width="656" alt="Screenshot 2024-11-21 at 16 42 22" src="https://github.com/user-attachments/assets/4a06d070-3de5-4f45-9378-62e812af0e7e"> | <img width="656" alt="Screenshot 2024-11-21 at 16 47 59" src="https://github.com/user-attachments/assets/c99b4138-1952-4000-aa9c-64b0e043f44b"> |


