### PR TITLE
Paginate solr search results

### DIFF
--- a/app/controllers/solr_search_controller.rb
+++ b/app/controllers/solr_search_controller.rb
@@ -3,8 +3,13 @@ class SolrSearchController < ApplicationController
     @sort = params["sort"]
 
     @presenter = SearchPresenter.new(solr_search_response, params)
-    @datasets = solr_search_response["response"]["docs"]
+
     @num_results = solr_search_response["response"]["numFound"]
+    @datasets = Kaminari.paginate_array(
+      solr_search_response["response"]["docs"],
+      total_count: @num_results,
+    ).page(params[:page])
+     .per(Search::Solr::RESULTS_PER_PAGE)
   end
 
 private

--- a/app/services/search/solr.rb
+++ b/app/services/search/solr.rb
@@ -1,5 +1,7 @@
 module Search
   class Solr
+    RESULTS_PER_PAGE = 20
+
     def self.search(params)
       query_param = params.fetch("q", "").squish
       @page = params["page"]
@@ -116,7 +118,7 @@ module Search
         q: @query,
         fq: @filter_query,
         start: @page,
-        rows: 20,
+        rows: RESULTS_PER_PAGE,
         fl: field_list,
         sort: @sort_query,
       }
@@ -127,7 +129,7 @@ module Search
         q: @query,
         fq: @filter_query,
         start: @page,
-        rows: 20,
+        rows: RESULTS_PER_PAGE,
         fl: field_list,
         sort: @sort_query,
         facet: "true",

--- a/app/views/solr_search/search.html.erb
+++ b/app/views/solr_search/search.html.erb
@@ -53,6 +53,12 @@
               <p><%= truncate(strip_tags(dataset["notes"]), length: 200, separator: ' ') %></p>
             </div>
           <% end %>
+          <div class="dgu-pagination">
+            <nav>
+              <%= dgu_page_entries_info @datasets, entry_name: 'dataset' %>
+              <span class="dgu-pagination__numbers"><%= paginate @datasets, window: 2 %></span>
+            </nav>
+          </div>
         </div>
       </div>
     </div>

--- a/spec/features/solr_search_page_spec.rb
+++ b/spec/features/solr_search_page_spec.rb
@@ -25,6 +25,8 @@ RSpec.feature "Solr Search page" do
 
     when_i_sort_results_by_most_recent
     then_i_can_see_results_sorted_by_most_recent
+
+    then_i_can_see_pagination_info
   end
 
   def given_i_am_on_the_solr_search_page
@@ -121,5 +123,11 @@ RSpec.feature "Solr Search page" do
 
   def then_i_can_see_results_sorted_by_most_recent
     expect(page).to have_select("sort", selected: "Most recent")
+  end
+
+  def then_i_can_see_pagination_info
+    within(".dgu-pagination") do
+      expect(page).to have_content("Displaying all 2 datasets")
+    end
   end
 end


### PR DESCRIPTION
Uses Kaminari's `paginate_array` method:https://www.rubydoc.info/gems/kaminari-core/Kaminari.paginate_array and existing helper.

- first page
<kbd><img width="643" alt="Screenshot 2024-12-03 at 11 27 42" src="https://github.com/user-attachments/assets/f1fb0a93-49ef-4954-b199-cde9787e719e"></kbd>

- subsequent pages
<kbd><img width="648" alt="Screenshot 2024-12-03 at 11 27 57" src="https://github.com/user-attachments/assets/6de90e25-98a1-4adf-b7af-8023992a607d"></kbd>

- last page
<kbd><img width="655" alt="Screenshot 2024-12-03 at 11 30 41" src="https://github.com/user-attachments/assets/e738b157-21be-4140-b7fa-baee0a93e47f"></kbd>

- 1 result
<kbd><img width="201" alt="Screenshot 2024-12-03 at 11 26 54" src="https://github.com/user-attachments/assets/ff474c23-fd84-43da-970f-0cb03e28d6cf"></kbd>

- less than 20 results
<kbd><img width="237" alt="Screenshot 2024-12-03 at 11 26 35" src="https://github.com/user-attachments/assets/04cc8027-54c6-4a06-aed0-1edf826ddc4a"></kbd>

Closes https://github.com/alphagov/datagovuk_find/issues/1339
