### PR TITLE
Improve search functionality

### DIFF
--- a/app/controllers/solr_search_controller.rb
+++ b/app/controllers/solr_search_controller.rb
@@ -17,6 +17,8 @@ private
   def solr_search_response
     @solr_search_response ||= begin
       Search::Solr.search(params)
+    rescue Search::Solr::NoSearchTermsError
+      no_results_found
     rescue RSolr::Error::Http => e
       handle_solr_http_error(e)
     end

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -1,4 +1,149 @@
 module SearchHelper
+  STOP_WORDS = %w[i
+                  me
+                  my
+                  myself
+                  we
+                  our
+                  ours
+                  ourselves
+                  you
+                  your
+                  yours
+                  yourself
+                  yourselves
+                  he
+                  him
+                  his
+                  himself
+                  she
+                  her
+                  hers
+                  herself
+                  it
+                  its
+                  itself
+                  they
+                  them
+                  their
+                  theirs
+                  themselves
+                  what
+                  which
+                  who
+                  whom
+                  this
+                  that
+                  these
+                  those
+                  am
+                  is
+                  are
+                  was
+                  were
+                  be
+                  been
+                  being
+                  have
+                  has
+                  had
+                  having
+                  do
+                  does
+                  did
+                  doing
+                  a
+                  an
+                  the
+                  and
+                  &
+                  but
+                  if
+                  or
+                  because
+                  as
+                  until
+                  while
+                  of
+                  at
+                  by
+                  for
+                  with
+                  about
+                  against
+                  between
+                  into
+                  through
+                  during
+                  before
+                  after
+                  above
+                  below
+                  to
+                  from
+                  up
+                  down
+                  in
+                  out
+                  on
+                  off
+                  over
+                  under
+                  again
+                  further
+                  then
+                  once
+                  here
+                  there
+                  when
+                  where
+                  why
+                  how
+                  all
+                  any
+                  both
+                  each
+                  few
+                  more
+                  most
+                  other
+                  some
+                  such
+                  no
+                  nor
+                  not
+                  only
+                  own
+                  same
+                  so
+                  than
+                  too
+                  very
+                  s
+                  t
+                  can
+                  will
+                  just
+                  don
+                  should
+                  now].freeze
+
+  def self.process_query(query_string)
+    phrase_regex = /"(.*?)"|\b(\w+)\b/
+
+    matches = query_string.scan(phrase_regex)
+
+    processed_terms = matches.map do |phrase, term|
+      if phrase
+        "\"#{phrase}\""
+      elsif term
+        STOP_WORDS.include?(term.downcase) ? nil : term
+      end
+    end
+
+    processed_terms.compact.join(" ")
+  end
+
   def display_sort(sort)
     sort == "best" ? "Best Match" : "Most Recent"
   end

--- a/app/presenters/search_presenter.rb
+++ b/app/presenters/search_presenter.rb
@@ -83,7 +83,9 @@ class SearchPresenter
 private
 
   def facet_values(facet_name)
-    counts = search_response.dig("facet_counts", "facet_fields", facet_name)
+    return [] if search_response.dig("facet_counts", "facet_fields").nil?
+
+    counts = search_response["facet_counts"]["facet_fields"][facet_name]
     counts.values_at(* counts.each_index.select(&:even?))
   end
 

--- a/app/services/search/solr.rb
+++ b/app/services/search/solr.rb
@@ -119,6 +119,7 @@ module Search
     def self.query_solr
       client.get "select", params: {
         q: @query,
+        sow: true,
         fq: @filter_query,
         start: @page,
         rows: RESULTS_PER_PAGE,
@@ -130,6 +131,7 @@ module Search
     def self.query_solr_with_facets
       client.get "select", params: {
         q: @query,
+        sow: true,
         fq: @filter_query,
         start: @page,
         rows: RESULTS_PER_PAGE,

--- a/app/services/search/solr.rb
+++ b/app/services/search/solr.rb
@@ -28,7 +28,7 @@ module Search
     end
 
     def self.build_term_query(query_param)
-      @query = query_param.present? ? "title:\"#{query_param}\" OR notes:\"#{query_param}\" AND NOT site_id:dgu_organisations" : "*:*"
+      @query = query_param.present? ? "title:(#{query_param}) OR notes:(#{query_param}) AND NOT site_id:dgu_organisations" : "*:*"
     end
 
     def self.build_filter_query(params)

--- a/app/services/search/solr.rb
+++ b/app/services/search/solr.rb
@@ -9,9 +9,8 @@ module Search
       @page && @page.to_i.positive? ? @page.to_i : 1
 
       get_organisations
-
-      @query = query_param.present? ? "title:\"#{query_param}\" OR notes:\"#{query_param}\" AND NOT site_id:dgu_organisations" : "*:*"
-
+      
+      build_term_query(query_param)
       @sort_query = "metadata_modified desc" if sort_param == "recent"
       build_filter_query(params)
 
@@ -26,6 +25,10 @@ module Search
         fq: "id:#{uuid}",
         fl: field_list,
       }
+    end
+
+    def self.build_term_query(query_param)
+      @query = query_param.present? ? "title:\"#{query_param}\" OR notes:\"#{query_param}\" AND NOT site_id:dgu_organisations" : "*:*"
     end
 
     def self.build_filter_query(params)

--- a/app/services/search/solr.rb
+++ b/app/services/search/solr.rb
@@ -9,7 +9,7 @@ module Search
       @page && @page.to_i.positive? ? @page.to_i : 1
 
       get_organisations
-      
+
       build_term_query(query_param)
       @sort_query = "metadata_modified desc" if sort_param == "recent"
       build_filter_query(params)
@@ -119,6 +119,7 @@ module Search
     def self.query_solr
       client.get "select", params: {
         q: @query,
+        "q.op": "OR",
         sow: true,
         fq: @filter_query,
         start: @page,
@@ -131,6 +132,7 @@ module Search
     def self.query_solr_with_facets
       client.get "select", params: {
         q: @query,
+        "q.op": "OR",
         sow: true,
         fq: @filter_query,
         start: @page,

--- a/app/services/search/solr.rb
+++ b/app/services/search/solr.rb
@@ -33,7 +33,7 @@ module Search
       processed_query = SearchHelper.process_query(query_param)
       raise NoSearchTermsError, "Query string is empty after processing" if processed_query.empty?
 
-      @query = "(title:(#{processed_query}) OR notes:(#{processed_query})) AND NOT site_id:dgu_organisations"
+      @query = "(title:(#{processed_query})^2 OR notes:(#{processed_query})) AND NOT site_id:dgu_organisations"
     end
 
     def self.build_filter_query(params)

--- a/app/services/search/solr.rb
+++ b/app/services/search/solr.rb
@@ -28,7 +28,7 @@ module Search
     end
 
     def self.build_term_query(query_param)
-      @query = query_param.present? ? "title:(#{query_param}) OR notes:(#{query_param}) AND NOT site_id:dgu_organisations" : "*:*"
+      @query = query_param.present? ? "(title:(#{query_param}) OR notes:(#{query_param})) AND NOT site_id:dgu_organisations" : "*:*"
     end
 
     def self.build_filter_query(params)

--- a/spec/controllers/solr_search_controller_spec.rb
+++ b/spec/controllers/solr_search_controller_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+
+RSpec.describe SolrSearchController, type: :controller do
+  let(:valid_params) { { q: "test search", page: 1, sort: "asc" } }
+  let(:solr_response_with_results) do
+    {
+      "response" => {
+        "numFound" => 2,
+        "docs" => [
+          { "id" => "1", "title" => "Test Result 1" },
+          { "id" => "2", "title" => "Test Result 2" },
+        ],
+      },
+    }
+  end
+  let(:solr_response_no_results) do
+    { "response" => { "numFound" => 0, "docs" => [] } }
+  end
+
+  describe "GET #search" do
+    context "when there are search results" do
+      before do
+        allow(Search::Solr).to receive(:search).and_return(solr_response_with_results)
+        get :search, params: valid_params
+      end
+
+      it "returns a successful response" do
+        expect(response).to be_successful
+      end
+
+      it "sets sort" do
+        expect(controller.instance_variable_get(:@sort)).to eq("asc")
+      end
+
+      it "sets number of results" do
+        expect(controller.instance_variable_get(:@num_results)).to eq(2)
+      end
+
+      it "sets datasets" do
+        datasets = controller.instance_variable_get(:@datasets)
+        expect(datasets.size).to eq(2)
+      end
+    end
+
+    context "when there are no search results" do
+      before do
+        allow(Search::Solr).to receive(:search).and_return(solr_response_no_results)
+        get :search, params: valid_params
+      end
+
+      it "returns a successful response" do
+        expect(response).to be_successful
+      end
+
+      it "sets number of results as 0" do
+        expect(controller.instance_variable_get(:@num_results)).to eq(0)
+      end
+
+      it "sets datasets as an empty array" do
+        expect(controller.instance_variable_get(:@datasets)).to be_empty
+      end
+    end
+  end
+end

--- a/spec/controllers/solr_search_controller_spec.rb
+++ b/spec/controllers/solr_search_controller_spec.rb
@@ -80,6 +80,25 @@ RSpec.describe SolrSearchController, type: :controller do
       end
     end
 
+    context "when query string is empty after processing" do
+      before do
+        allow(Search::Solr).to receive(:search).and_raise(Search::Solr::NoSearchTermsError)
+        get :search, params: { q: "the" }
+      end
+
+      it "returns a successful response" do
+        expect(response).to be_successful
+      end
+
+      it "sets number of results as 0" do
+        expect(controller.instance_variable_get(:@num_results)).to eq(0)
+      end
+
+      it "sets datasets as an empty array" do
+        expect(controller.instance_variable_get(:@datasets)).to be_empty
+      end
+    end
+
     context "when there is an unexpected error" do
       it "raises an error for an unexpected Solr error" do
         mock_solr_http_error(status: 500)

--- a/spec/helpers/search_helper_spec.rb
+++ b/spec/helpers/search_helper_spec.rb
@@ -1,6 +1,53 @@
 require "rails_helper"
 
 RSpec.describe SearchHelper do
+  describe "#process_query" do
+    it "removes stop words from terms but keeps phrases intact" do
+      query_params = '"quick brown" fox jumps over "lazy dog" in the forest'
+      expected_result = '"quick brown" fox jumps "lazy dog" forest'
+
+      result = SearchHelper.process_query(query_params)
+
+      expect(result).to eq(expected_result)
+    end
+
+    it "handles input with only terms" do
+      query_params = "fox jumps over the lazy dog"
+      expected_result = "fox jumps lazy dog"
+
+      result = SearchHelper.process_query(query_params)
+
+      expect(result).to eq(expected_result)
+    end
+
+    it "handles input with only phrases" do
+      query_params = '"quick brown" "lazy dog"'
+      expected_result = '"quick brown" "lazy dog"'
+
+      result = SearchHelper.process_query(query_params)
+
+      expect(result).to eq(expected_result)
+    end
+
+    it "removes multiple stop words while preserving meaningful terms" do
+      query_params = "a quick and simple test of the analyzer"
+      expected_result = "quick simple test analyzer"
+
+      result = SearchHelper.process_query(query_params)
+
+      expect(result).to eq(expected_result)
+    end
+
+    it "handles empty input gracefully" do
+      query_params = ""
+      expected_result = ""
+
+      result = SearchHelper.process_query(query_params)
+
+      expect(result).to eq(expected_result)
+    end
+  end
+
   describe "#datafile_formats_for_select" do
     let(:dataset1) do
       build :dataset, datafiles: [build(:datafile, :raw, format: "foo"),

--- a/spec/presenters/search_presenter_spec.rb
+++ b/spec/presenters/search_presenter_spec.rb
@@ -34,6 +34,13 @@ RSpec.describe SearchPresenter do
         "Towns and cities",
       ])
     end
+
+    it "returns empty array if facet_fields are not present in the response" do
+      query_response = { "facet_counts" => {} }
+      presenter = described_class.new(query_response, { "q" => "the" })
+
+      expect(presenter.topic_options).to eql([])
+    end
   end
 
   describe "#format_options" do
@@ -101,6 +108,13 @@ RSpec.describe SearchPresenter do
       presenter = described_class.new(query_response, { "q" => "dogs" })
 
       expect(presenter.format_options).to eql(%w[])
+    end
+
+    it "returns empty array if facet_fields are not present in the response" do
+      query_response = { "facet_counts" => {} }
+      presenter = described_class.new(query_response, { "q" => "the" })
+
+      expect(presenter.format_options).to eql([])
     end
   end
 end

--- a/spec/services/search/solr_spec.rb
+++ b/spec/services/search/solr_spec.rb
@@ -296,7 +296,7 @@ RSpec.describe Search::Solr do
       )
 
       expect(term_query).to eq(
-        "(title:(animal health) OR notes:(animal health)) AND NOT site_id:dgu_organisations",
+        "(title:(animal health)^2 OR notes:(animal health)) AND NOT site_id:dgu_organisations",
       )
     end
 
@@ -306,7 +306,7 @@ RSpec.describe Search::Solr do
       )
 
       expect(term_query).to eq(
-        "(title:(\"animal health\") OR notes:(\"animal health\")) AND NOT site_id:dgu_organisations",
+        "(title:(\"animal health\")^2 OR notes:(\"animal health\")) AND NOT site_id:dgu_organisations",
       )
     end
 
@@ -316,7 +316,7 @@ RSpec.describe Search::Solr do
       )
 
       expect(term_query).to eq(
-        "(title:(\"animal health\" dogs) OR notes:(\"animal health\" dogs)) AND NOT site_id:dgu_organisations",
+        "(title:(\"animal health\" dogs)^2 OR notes:(\"animal health\" dogs)) AND NOT site_id:dgu_organisations",
       )
     end
 
@@ -326,7 +326,7 @@ RSpec.describe Search::Solr do
       )
 
       expect(term_query).to eq(
-        "(title:(organogram staff roles salaries) OR notes:(organogram staff roles salaries)) AND NOT site_id:dgu_organisations",
+        "(title:(organogram staff roles salaries)^2 OR notes:(organogram staff roles salaries)) AND NOT site_id:dgu_organisations",
       )
     end
 
@@ -336,7 +336,7 @@ RSpec.describe Search::Solr do
       )
 
       expect(term_query).to eq(
-        "(title:(\"organogram of staff roles & salaries\") OR notes:(\"organogram of staff roles & salaries\")) AND NOT site_id:dgu_organisations",
+        "(title:(\"organogram of staff roles & salaries\")^2 OR notes:(\"organogram of staff roles & salaries\")) AND NOT site_id:dgu_organisations",
       )
     end
 

--- a/spec/services/search/solr_spec.rb
+++ b/spec/services/search/solr_spec.rb
@@ -319,6 +319,34 @@ RSpec.describe Search::Solr do
         "(title:(\"animal health\" dogs) OR notes:(\"animal health\" dogs)) AND NOT site_id:dgu_organisations",
       )
     end
+
+    it "returns a solr query for search terms without stop words" do
+      term_query = described_class.build_term_query(
+        "organogram of staff roles & salaries",
+      )
+
+      expect(term_query).to eq(
+        "(title:(organogram staff roles salaries) OR notes:(organogram staff roles salaries)) AND NOT site_id:dgu_organisations",
+      )
+    end
+
+    it "returns a solr query for search phrases including stop words" do
+      term_query = described_class.build_term_query(
+        "\"organogram of staff roles & salaries\"",
+      )
+
+      expect(term_query).to eq(
+        "(title:(\"organogram of staff roles & salaries\") OR notes:(\"organogram of staff roles & salaries\")) AND NOT site_id:dgu_organisations",
+      )
+    end
+
+    it "raises an error if query is empty after processing" do
+      expect {
+        described_class.build_term_query(
+          "the or",
+        )
+      }.to raise_error(Search::Solr::NoSearchTermsError)
+    end
   end
 
   describe ".build_filter_query" do

--- a/spec/services/search/solr_spec.rb
+++ b/spec/services/search/solr_spec.rb
@@ -290,13 +290,33 @@ RSpec.describe Search::Solr do
       expect(term_query).to eq("*:*")
     end
 
-    it "returns a solr query for the search term" do
+    it "returns a solr query for multiple search terms" do
       term_query = described_class.build_term_query(
         "animal health",
       )
 
       expect(term_query).to eq(
-        "title:\"animal health\" OR notes:\"animal health\" AND NOT site_id:dgu_organisations",
+        "title:(animal health) OR notes:(animal health) AND NOT site_id:dgu_organisations",
+      )
+    end
+
+    it "returns a solr query for exact phrase search (in quotes)" do
+      term_query = described_class.build_term_query(
+        "\"animal health\"",
+      )
+
+      expect(term_query).to eq(
+        "title:(\"animal health\") OR notes:(\"animal health\") AND NOT site_id:dgu_organisations",
+      )
+    end
+
+    it "returns a solr query for multiple search terms including exact phrase search (in quotes)" do
+      term_query = described_class.build_term_query(
+        "\"animal health\" dogs",
+      )
+
+      expect(term_query).to eq(
+        "title:(\"animal health\" dogs) OR notes:(\"animal health\" dogs) AND NOT site_id:dgu_organisations",
       )
     end
   end

--- a/spec/services/search/solr_spec.rb
+++ b/spec/services/search/solr_spec.rb
@@ -296,7 +296,7 @@ RSpec.describe Search::Solr do
       )
 
       expect(term_query).to eq(
-        "title:(animal health) OR notes:(animal health) AND NOT site_id:dgu_organisations",
+        "(title:(animal health) OR notes:(animal health)) AND NOT site_id:dgu_organisations",
       )
     end
 
@@ -306,7 +306,7 @@ RSpec.describe Search::Solr do
       )
 
       expect(term_query).to eq(
-        "title:(\"animal health\") OR notes:(\"animal health\") AND NOT site_id:dgu_organisations",
+        "(title:(\"animal health\") OR notes:(\"animal health\")) AND NOT site_id:dgu_organisations",
       )
     end
 
@@ -316,7 +316,7 @@ RSpec.describe Search::Solr do
       )
 
       expect(term_query).to eq(
-        "title:(\"animal health\" dogs) OR notes:(\"animal health\" dogs) AND NOT site_id:dgu_organisations",
+        "(title:(\"animal health\" dogs) OR notes:(\"animal health\" dogs)) AND NOT site_id:dgu_organisations",
       )
     end
   end

--- a/spec/services/search/solr_spec.rb
+++ b/spec/services/search/solr_spec.rb
@@ -281,6 +281,26 @@ RSpec.describe Search::Solr do
     end
   end
 
+  describe ".build_term_query" do
+    it "returns special syntax that requests all documents in the index, if q param is missing" do
+      term_query = described_class.build_term_query(
+        "",
+      )
+
+      expect(term_query).to eq("*:*")
+    end
+
+    it "returns a solr query for the search term" do
+      term_query = described_class.build_term_query(
+        "animal health",
+      )
+
+      expect(term_query).to eq(
+        "title:\"animal health\" OR notes:\"animal health\" AND NOT site_id:dgu_organisations",
+      )
+    end
+  end
+
   describe ".build_filter_query" do
     it "includes active datasets filter" do
       filter_query = described_class.build_filter_query({ filters: {} })


### PR DESCRIPTION
### Changes

- Split search terms on whitespaces
- Allow exact phrase search
- Remove stop words from query
- Boost `title` field in query
- Add error handling (incl. `RSolr::Error::Http` error when invalid term is entered)
- _(enhancement)_ Allow advanced search operators (a.k.a special Solr search characters/operators): `+` `-` `&&` `||` `!` `( )` `{ }` `[ ]` `^` `"` `~` `*` `?` `:` `/`. Note: Decided not to escape individual special characters. Searching for special characters. Those also return 'No results found' in OpenSearch.

### Multiple terms
- **Solr before:**  <kbd><img width="500" alt="after" src="https://github.com/user-attachments/assets/748e5b79-2d70-4895-91c7-8d25a35a8e67" /></kbd>

| **Solr after** | **OpenSearch** |
| :---- | :---- |
| <img width="400" alt="after" src="https://github.com/user-attachments/assets/8cad2cd5-2dd5-4a93-a574-61b808fd7730" /> | <img width="400" alt="after" src="https://github.com/user-attachments/assets/9e1ab8fa-9922-449f-819b-7a34c32f13e4" /> |

### Exact phrase search
- **Solr before:**  <kbd><img width="500" alt="os" src="https://github.com/user-attachments/assets/9feb15ec-e215-48da-8f92-fa14b5905e1e" /></kbd>

| **Solr after** | **OpenSearch** |
| :---- | :---- |
| <kbd><img width="400" alt="after" src="https://github.com/user-attachments/assets/3cfb5d10-e176-4273-a5b2-17bd45797240" /></kbd> | <kbd><img width="500" alt="os" src="https://github.com/user-attachments/assets/0e94748c-2d02-4973-bf7c-1efd306cd4b2" /></kbd> |


### Multiple terms incl. exact phrase
- **Solr before:**  <kbd><img width="400" alt="after" src="https://github.com/user-attachments/assets/c4b98066-598e-4c92-9912-bd310ca9f319" /></kbd>

| **Solr after** | **OpenSearch** |
| :---- | :---- |
| searches for "animal health" `OR` dogs | appears to search for "animal health" `AND` dogs |
| <img width="400" alt="after" src="https://github.com/user-attachments/assets/85cb4d0a-690e-4cbe-a5ea-12f84b42dd27" /></kbd> | <kbd><img width="400" alt="OS" src="https://github.com/user-attachments/assets/514f566e-0a10-4394-9456-8cb9891ff4ac" /></kbd> |

The same effect can be achieved in Solr when searching for `+"animal health" +dogs` or `"animal health" AND dogs` or `"animal health" && dogs`. Switching Solr to use `AND` operator results in search results being very insistent with OpenSearch. For example `animal health` search results only 220 datasets (instead of over 2000).
 OpenSearch is retuning way less results as it appears to search for "animal health" AND dogs, whereas normally the OR operator is used. After analysing what OpenSearch does I think it’s an odd behaviour as a result of how we process a combination of “phrase” and “term” search, which ends up as and AND query. The standard “term” search (multi_match query) uses the "OR" operator so this seems like an inconsistency in OpenSearch. Users don’t seem to use phase searches anyway so I’d say this is an unlikely scenario and they can also use filters to refine the search. Product decision has been made to accept this difference.

### Testing

Tested with a few popular searches from the [Analytics dashboard](https://lookerstudio.google.com/u/0/reporting/1dLIysu5Ie131ZL3gGT7zyWBhffNgTSX2/page/cduv):
- `organogram of staff roles & salaries` 
  - 1,625 results in Solr (was 41,329 prior to removing stop words)
  - 1,587 results in OpenSearch

- `"organogram of staff roles & salaries”`
  - 273 result in Solr
  - 261 results in OpenSearch

- `ukas certificate`
  - 282 results in Solr
  - 268 results in OpenSearch

- `check numerous`
  - 849 results in Solr
  - 843 results in OpenSearch