### PR TITLE
Add search tips for no results found page

### DIFF
--- a/app/views/solr_search/_no_results.html.erb
+++ b/app/views/solr_search/_no_results.html.erb
@@ -1,0 +1,14 @@
+<div class="dgu-results__zero">
+  <%= render "govuk_publishing_components/components/heading", {
+    text: "#{t(".try")}:",
+    margin_bottom: 4,
+    heading_level: 2,
+    font_size: "m",
+  } %>
+  <ul class="govuk-list govuk-list--bullet">
+    <li><%= t('.remove_filters') %></li>
+    <li><%= t('.check_spelling') %></li>
+    <li><%= t('.fewer_words') %></li>
+    <li><%= t('.less_specific') %></li>
+  </ul>
+</div>

--- a/app/views/solr_search/search.html.erb
+++ b/app/views/solr_search/search.html.erb
@@ -35,30 +35,34 @@
             <%= t('.result').pluralize(@num_results) %> <%= t('.found') %>
           </span>
 
-          <% @datasets.each do |dataset| %>
-            <div class="dgu-results__result">
-              <h2 class="govuk-heading-m">
-                <%= link_to dataset["title"], solr_dataset_path(dataset["id"], dataset["name"]), class: 'govuk-link' %>
-              </h2>
-              <dl class="dgu-metadata__box">
-                <dt><%= t('.meta_data_box.published_by') %>:</dt>
-                <dd class="published_by"><%= JSON.parse(dataset["validated_data_dict"])["organization"]["title"] %></dd>
-                <dt><%= t('.meta_data_box.last_updated') %>:</dt>
-                <% if dataset["metadata_modified"].present? %>
-                  <dd><%= format_timestamp(dataset["metadata_modified"]) %></dd>
-                <% else %>
-                  <dd class="dgu-secondary-text"> <%= t('.meta_data_box.not_applicable') %></dd>
-                <% end %>
-              </dl>
-              <p><%= truncate(strip_tags(dataset["notes"]), length: 200, separator: ' ') %></p>
+          <% if @num_results.zero? %>
+            <%= render "no_results" %>
+          <% else %>
+            <% @datasets.each do |dataset| %>
+              <div class="dgu-results__result">
+                <h2 class="govuk-heading-m">
+                  <%= link_to dataset["title"], solr_dataset_path(dataset["id"], dataset["name"]), class: 'govuk-link' %>
+                </h2>
+                <dl class="dgu-metadata__box">
+                  <dt><%= t('.meta_data_box.published_by') %>:</dt>
+                  <dd class="published_by"><%= JSON.parse(dataset["validated_data_dict"])["organization"]["title"] %></dd>
+                  <dt><%= t('.meta_data_box.last_updated') %>:</dt>
+                  <% if dataset["metadata_modified"].present? %>
+                    <dd><%= format_timestamp(dataset["metadata_modified"]) %></dd>
+                  <% else %>
+                    <dd class="dgu-secondary-text"> <%= t('.meta_data_box.not_applicable') %></dd>
+                  <% end %>
+                </dl>
+                <p><%= truncate(strip_tags(dataset["notes"]), length: 200, separator: ' ') %></p>
+              </div>
+            <% end %>
+            <div class="dgu-pagination">
+              <nav>
+                <%= dgu_page_entries_info @datasets, entry_name: 'dataset' %>
+                <span class="dgu-pagination__numbers"><%= paginate @datasets, window: 2 %></span>
+              </nav>
             </div>
           <% end %>
-          <div class="dgu-pagination">
-            <nav>
-              <%= dgu_page_entries_info @datasets, entry_name: 'dataset' %>
-              <span class="dgu-pagination__numbers"><%= paginate @datasets, window: 2 %></span>
-            </nav>
-          </div>
         </div>
       </div>
     </div>

--- a/config/locales/views/search/en.yml
+++ b/config/locales/views/search/en.yml
@@ -64,3 +64,9 @@ en:
       accessibility:
         submit_button: "Apply filters"
       remove_filters: "Remove filters"
+    no_results:
+      try: "Improve your search results by"
+      remove_filters: "removing filters"
+      check_spelling: "double-checking your spelling"
+      fewer_words: "using fewer keywords"
+      less_specific: "searching for something less specific"


### PR DESCRIPTION
To help users use the website.

Examples taken from the GOV.UK Search:
https://github.com/alphagov/finder-frontend/blob/1c34ddc0fc74d6f4070a35b80b1a4f5819621bfe/app/views/finders/_search_results.html.erb#L20-L29

- **Solr before:**  <kbd><img width="400" alt="Screenshot 2024-12-17 at 11 44 38" src="https://github.com/user-attachments/assets/3ae1d223-53bb-4ab6-899d-339c2a738d37" /></kbd>


| **Solr after** | **OpenSearch** |
| :---- | :---- |
| <img width="500" alt="Screenshot 2024-12-17 at 11 51 06" src="https://github.com/user-attachments/assets/436f6486-df17-459c-beae-7e3c665df0d1" /> | <img width="500" alt="Screenshot 2024-12-17 at 11 55 51" src="https://github.com/user-attachments/assets/7c0e8fa2-e2ce-433a-a9f3-a5163271bbb8" /> |