### PR TITLE
Only return active datasets

### DIFF
--- a/app/helpers/datasets_helper.rb
+++ b/app/helpers/datasets_helper.rb
@@ -9,6 +9,8 @@ module DatasetsHelper
   }.freeze
 
   def to_markdown(content)
+    return "Not provided" if content.nil?
+
     markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML, autolink: true, tables: false)
     markdown.render(content).html_safe
   end

--- a/app/models/solr_dataset.rb
+++ b/app/models/solr_dataset.rb
@@ -40,8 +40,8 @@ class SolrDataset
 
     response = begin
       solr_client.get "select", params: {
-        q: "*:*",
-        fq: "id:#{uuid}",
+        q: "id:#{uuid}",
+        fq: "state:active",
         fl: Search::Solr.field_list,
       }
     rescue RSolr::Error::Http => e

--- a/spec/helpers/datasets_helper_spec.rb
+++ b/spec/helpers/datasets_helper_spec.rb
@@ -11,6 +11,12 @@ RSpec.describe DatasetsHelper do
     end
   end
 
+  describe "to_markdown" do
+    it "returns 'Not provided' if the input is nil" do
+      expect(helper.to_markdown(nil)).to eq("Not provided")
+    end
+  end
+
   describe "#contact_email_is_email?" do
     it "returns true when email string is 'valid' (contains '@')" do
       dataset = build :dataset, contact_email: "foo@bar.com"


### PR DESCRIPTION
We are seeing errors when trying to render draft datasets: https://govuk.sentry.io/issues/6188276899/?project=1461892

It filters query by active datasets and switches to use `q` parameter for the query. Otherwise Solr returns all results.
Majority of draft dataets return Not found in Open search.

Examples of draft datasets:
- /41600666-30dc-4243-9b64-4be3e8f5c65f/spend-over-25-000-in-gloucestershire-health-and-care-nhsft
- /ac45e29d-4692-471a-a977-01c6f27fe48a/crown-prosecution-service-organogram-march-2016
- /a7d30a03-100d-4544-9715-ab4b8fb69e33/gc-data-catalogue-coal-authority
- /4e789532-c53c-43f7-8909-995a4b7ba65b/hee-organogram
- /24cd6864-1dfa-47ef-86bd-62ef9e5b765e/https-www-hacw-nhs-uk-download-cfm-doc-docm93jijm4n9979-xlsx-ver-17995