### PR TITLE
Explicitly set Solr query operator to OR

### DIFF
--- a/app/services/search/solr.rb
+++ b/app/services/search/solr.rb
@@ -114,7 +114,7 @@ module Search
     def self.query_solr
       client.get "select", params: {
         q: @query,
-        # "q.op": "OR",
+        "q.op": "OR",
         sow: true,
         fq: @filter_query,
         start: @page,
@@ -128,7 +128,7 @@ module Search
       Rails.logger.debug @query
       client.get "select", params: {
         q: @query,
-        # "q.op": "OR",
+        "q.op": "OR",
         sow: true,
         fq: @filter_query,
         start: @page,


### PR DESCRIPTION
This was commented out for testing and merged by mistake.  OR is the default value so it's not going to change the behaviour of the search.

We don't have solrconfig.xml defined. We're using one defined on the image: https://github.com/alphagov/ckanext-datagovuk/blob/main/docker/solr/2.10.Dockerfile#L1 We want to define in the query in case there's an unexpected change in the config.