### PR TITLE
Get organisations contact and FOI details

### DIFF
--- a/app/services/search/solr.rb
+++ b/app/services/search/solr.rb
@@ -107,7 +107,7 @@ module Search
           "site_id:dgu_organisations",
           "name:#{name}",
         ],
-        fl: %w[title name],
+        fl: %w[title name extras_contact-email extras_foi-email extras_foi-web extras_foi-name],
       }
     end
 


### PR DESCRIPTION
When Publisher contact details are not defined in the dataset response, we want to get them form the get_organisations query. They are used in `app/helpers/datasets_helper.rb` as a fallback for Publishers contact details or FOI details.

Example datasets:
- /dataset/3441999e-03d2-40f9-a30b-85fa8a5a88ca/contracts-finder-notices-07-2023
- /dataset/28b2ce3b-9cfb-45b3-9543-c258e3751267/academy-school-catchments

| Before    | After |
| -------- | ------- |
|<img width="519" alt="Screenshot 2025-01-03 at 15 05 35" src="https://github.com/user-attachments/assets/a441a762-9be9-4f6b-9bfa-30e712f8bc58" />|<img width="695" alt="Screenshot 2025-01-03 at 15 05 55" src="https://github.com/user-attachments/assets/234655d9-ba4d-427c-beec-93e5a4453128" />|
