### PR TITLE
Force HTML request format

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,14 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception, prepend: true
+  before_action :restrict_request_format
   rescue_from SolrDataset::NotFound, with: :render_not_found
   rescue_from SolrDatafile::NotFound, with: :render_not_found
 
   def render_not_found
     render "errors/not_found", status: :not_found
+  end
+
+  def restrict_request_format
+    request.format = :html
   end
 end

--- a/spec/requests/error_handling_spec.rb
+++ b/spec/requests/error_handling_spec.rb
@@ -31,4 +31,11 @@ RSpec.describe "Error handling", type: :request do
     get "/dataset/#{dataset.name}/resource/#{SecureRandom.uuid}"
     expect(response).to have_http_status(:not_found)
   end
+
+  it "handles JSON requests" do
+    mock_solr_http_error(status: 404)
+
+    get "/dataset/something.json"
+    expect(response).to have_http_status(:not_found)
+  end
 end


### PR DESCRIPTION
We were seeing the following errors caused by request being in the JSON format ActionView::MissingTemplate
Missing template errors/not_found with {:locale=>[:en], :formats=>[:json], :variants=>[], :handlers=>[:raw, :erb, :html, :builder, :ruby, :jbuilder]}. (ActionView::MissingTemplate) https://govuk.sentry.io/issues/6194268690/?project=1461892

Example request data.gov.uk/dataset/tunbridge-wells-open-data-local-plan-2006-rural-exception-housing-h8/datapackage.json

We don't want to support JSON requests.
This a similar behaviour to gov.uk