### PR TITLE
Handle missing params

### DIFF
--- a/app/presenters/search_presenter.rb
+++ b/app/presenters/search_presenter.rb
@@ -24,7 +24,7 @@ class SearchPresenter
   end
 
   def organisations
-    if search_keywords.empty?
+    if search_keywords.blank?
       Search::Solr.get_organisations.keys
     else
       slugs = facet_values("organization")
@@ -39,7 +39,7 @@ class SearchPresenter
   end
 
   def topic_options
-    if search_keywords.empty?
+    if search_keywords.blank?
       TOPIC_MAPPINGS.keys
     else
       tokenized_topics = facet_values("extras_theme-primary")
@@ -49,7 +49,7 @@ class SearchPresenter
   end
 
   def format_options
-    if search_keywords.empty?
+    if search_keywords.blank?
       Search::Solr::FORMAT_MAPPINGS.keys << "Other"
     else
       raw_formats = facet_values("res_format")

--- a/app/services/search/solr.rb
+++ b/app/services/search/solr.rb
@@ -14,14 +14,14 @@ module Search
       @sort_query = sort_param == "recent" ? "metadata_modified desc" : nil
       build_filter_query(params)
 
-      query_param.empty? ? query_solr : query_solr_with_facets
+      query_param.blank? ? query_solr : query_solr_with_facets
     end
 
     def self.build_term_query(query_param)
       return @query = "*:*" if query_param.blank?
 
       processed_query = SearchHelper.process_query(query_param)
-      raise NoSearchTermsError, "Query string is empty after processing" if processed_query.empty?
+      raise NoSearchTermsError, "Query string is empty after processing" if processed_query.blank?
 
       @query = "(title:(#{processed_query})^2 OR notes:(#{processed_query})) AND NOT site_id:dgu_organisations"
     end

--- a/app/services/search/solr.rb
+++ b/app/services/search/solr.rb
@@ -3,7 +3,7 @@ module Search
     RESULTS_PER_PAGE = 20
 
     def self.search(params)
-      query_param = params.fetch("q", "").squish
+      query_param = (params["q"] || "").to_s.squish
       @page = params["page"]
       sort_param = params["sort"]
       @page && @page.to_i.positive? ? @page.to_i : 1

--- a/spec/services/search/solr_spec.rb
+++ b/spec/services/search/solr_spec.rb
@@ -26,6 +26,10 @@ RSpec.describe Search::Solr do
       allow_any_instance_of(RSolr::Client).to receive(:get).and_return(JSON.parse(response))
     end
 
+    it "returns a response if q param is missing" do
+      expect { described_class.search({}) }.not_to raise_error
+    end
+
     it "returns a JSON response" do
       expect(results).to be_a(Hash)
     end


### PR DESCRIPTION
Error occurred because the `params.fetch("q", "")` returns `nil` if q param is missing in the query, and calling squish on nil raises the NoMethodError. params["q"] will return nil if the key doesn't exist, and || will fall back to "" (an empty string) if that's the case.

Also switches to use `.blank?`, which  is more flexible, returning true for objects that are nil, empty, or consist only of whitespace.

https://govuk.sentry.io/issues/6194636580/?project=1461892
```
NoMethodError
undefined method `squish' for nil:NilClass (NoMethodError)

      query_param = params.fetch("q", "").squish
```