### PR TITLE
Fix previews when some data rows are nil

### DIFF
--- a/app/views/previews/show.html.erb
+++ b/app/views/previews/show.html.erb
@@ -35,7 +35,7 @@
             @datafile.preview.headers.each_with_index do |col, index|
               table_headings << {
                 text: col,
-                format: (table_rows.select {|row| row[index][:format] == "numeric"}).length > 0 ? "numeric" : false
+                format: (table_rows.select {|row| row[index].try(:[], :format) == "numeric" }).length > 0 ? "numeric" : false
               }
             end
           end


### PR DESCRIPTION
> **Unrelated to Solr DB migration**. Sentry wasn't configured before.

We were seeing an error when `row[index]` is nil.

`row[index].try(:[], :format)` won’t raise an error and return nil. Otherwise it will safely check the :format key.

https://govuk.sentry.io/issues/6195895254/?project=1461892 
```
  NoMethodError
undefined method `[]' for nil:NilClass (NoMethodError)
```
Preview for `/dataset/09de00b3-9a3f-453a-b52d-9b7008db2add/special-advisers-gifts-and-hospitality-in-wales-office/datafile/940bbf71-8b44-4743-ac1a-565ba6dd5df1/preview` now renders correctly

<kbd><img width="745" alt="Screenshot 2025-01-06 at 14 03 22" src="https://github.com/user-attachments/assets/29746116-e111-4d46-bfd9-7ad4811adfed" /></kbd>


