### PR TITLE
Remove /dashboard page

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,11 +1,6 @@
 class PagesController < ApplicationController
   def dashboard
-    @datasets_count = get_datasets_count
-    @publishers_count = Dataset.publishers.count
-    @datafiles_count = Dataset.datafiles["doc_count"]
-    @datasets_published_with_datafiles_count = Dataset.datafiles["datasets_with_datafiles"]["doc_count"]
-    @datasets_published_with_no_datafiles_count = @datasets_count - @datasets_published_with_datafiles_count
-    @datafiles_count_by_format = Dataset.datafiles["formats"]["buckets"]
+    render "errors/not_found", status: :gone
   end
 
   def ckan_maintenance
@@ -14,12 +9,5 @@ class PagesController < ApplicationController
 
   def home
     expires_in 30.minutes, public: true
-  end
-
-private
-
-  def get_datasets_count
-    query = Search::Query.search(q: "", track_total_hits: true)
-    Dataset.search(query).total_count
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,7 +25,7 @@ Rails.application.routes.draw do
     get "about"
     get "accessibility"
     get "cookies"
-    get "dashboard"
+    get "dashboard" # 410 Gone
     get "privacy"
     get "publishers"
     get "site-changes", to: :site_changes


### PR DESCRIPTION
The dashboard is not used for anything and it was showing incorrect information. If we ever need stats we can get them directly from CKAN.

It's not worth the time porting it from OpenSearch to Solr.

### Before
<kbd><img width="794" alt="Screenshot 2025-01-07 at 15 54 23" src="https://github.com/user-attachments/assets/caea44f7-dbc3-463e-80b5-ebc0da152c8c" /></kbd>

### After

<kbd><img width="790" alt="Screenshot 2025-01-07 at 15 59 35" src="https://github.com/user-attachments/assets/c9523aba-ad2a-448f-8b86-5ff16851a47a" /></kbd>
