### PR TITLE
Increase the limit on organization facet

### DIFF
--- a/app/services/search/solr.rb
+++ b/app/services/search/solr.rb
@@ -1,7 +1,7 @@
 module Search
   class Solr
     RESULTS_PER_PAGE = 20
-    ORGANISATIONS_LIMIT = 1600 # Arbitrary large number
+    ORGANISATIONS_LIMIT = 3000 # Should match `rows` in https://github.com/alphagov/ckanext-datagovuk/blob/4cfb397/ckanext/datagovuk/lib/cli.py#L398
 
     def self.search(params)
       query_param = (params["q"] || "").to_s.squish

--- a/app/services/search/solr.rb
+++ b/app/services/search/solr.rb
@@ -1,6 +1,7 @@
 module Search
   class Solr
     RESULTS_PER_PAGE = 20
+    ORGANISATIONS_LIMIT = 1600 # Arbitrary large number
 
     def self.search(params)
       query_param = (params["q"] || "").to_s.squish
@@ -91,7 +92,7 @@ module Search
           "site_id:dgu_organisations",
         ],
         fl: %w[title name],
-        rows: 1600,
+        rows: ORGANISATIONS_LIMIT,
       }
       query["response"]["docs"].each do |org|
         @organisations_list.store(org["title"], org["name"])
@@ -139,6 +140,7 @@ module Search
         sort: @sort_query,
         facet: "true",
         "facet.field": %w[organization extras_theme-primary res_format],
+        "f.organization.facet.limit": ORGANISATIONS_LIMIT,
         "facet.sort": "count",
         "facet.mincount": 1,
       }


### PR DESCRIPTION
We were not returning all organisations associated with returned datasets in the Publisher filter because the upper limit on organization facet is too low. It defaults to 100.
https://solr.apache.org/guide/6_6/faceting.html#Faceting-Thefacet.limitParameter

"There are currently around 1500 organisations." was mentioned in
https://github.com/alphagov/datagovuk_find/commit/76b7204cd0c086241ed21589dd728f7c7b4e1aae
We're increasing it to match the [reindexing_script](https://github.com/alphagov/ckanext-datagovuk/blob/4cfb397/ckanext/datagovuk/lib/cli.py#L398)