### PR TITLE
Handle missing organisations

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -51,7 +51,7 @@ class Dataset
     @foi_web = hash["foi_web"]
     @inspire_dataset = hash["inspire_dataset"]
     @harvested = hash["harvested"]
-    @organisation = Organisation.new(hash["organisation"])
+    @organisation = Organisation.new(hash["organisation"], nil)
     @datafiles = hash["datafiles"].map { |file| Datafile.new(file) }
     @docs = hash["docs"].map { |file| Doc.new(file) }
     @schema_id = hash["schema_id"]

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -5,10 +5,10 @@ class Organisation
   def initialize(hash)
     @title = hash["title"]
     @name = hash["name"]
-    @contact_email = hash["contact_email"] || hash["extras_contact-email"]
-    @contact_name = hash["contact_name"] || hash["extras_contact-name"]
-    @foi_email = hash["foi_email"] || hash["extras_foi-email"]
-    @foi_web = hash["foi_web"] || hash["extras_foi-web"]
-    @foi_name = hash["foi_name"] || hash["extras_foi-name"]
+    @contact_email = hash["extras_contact-email"]
+    @contact_name = hash["extras_contact-name"]
+    @foi_email = hash["extras_foi-email"]
+    @foi_web = hash["extras_foi-web"]
+    @foi_name = hash["extras_foi-name"]
   end
 end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -2,13 +2,27 @@ class Organisation
   attr_reader :title, :name, :contact_email, :foi_name,
               :foi_email, :foi_web, :contact_name
 
-  def initialize(hash)
-    @title = hash["title"]
-    @name = hash["name"]
-    @contact_email = hash["extras_contact-email"]
-    @contact_name = hash["extras_contact-name"]
-    @foi_email = hash["extras_foi-email"]
-    @foi_web = hash["extras_foi-web"]
-    @foi_name = hash["extras_foi-name"]
+  def initialize(hash, slug)
+    capture_exception_in_sentry(slug) if hash.nil?
+
+    @title = hash.try(:[], "title") || slug.titleize
+    @name = hash.try(:[], "name") || slug
+    @contact_email = hash.try(:[], "extras_contact-email")
+    @contact_name = hash.try(:[], "extras_contact-name")
+    @foi_email = hash.try(:[], "extras_foi-email")
+    @foi_web = hash.try(:[], "extras_foi-web")
+    @foi_name = hash.try(:[], "extras_foi-name")
   end
+
+private
+
+  def capture_exception_in_sentry(slug)
+    if defined?(Sentry)
+      Sentry.capture_exception(
+        NotFound.new("Organisation `#{slug}` was not found in the Solr index"),
+      )
+    end
+  end
+
+  class NotFound < StandardError; end
 end

--- a/app/models/solr_dataset.rb
+++ b/app/models/solr_dataset.rb
@@ -22,7 +22,8 @@ class SolrDataset
     @licence_code = dataset_dict["license_id"]
     @licence_custom = dataset["extras_licence"].gsub(/"|\[|\]/, "") if dataset["extras_licence"].present?
 
-    @organisation = Organisation.new(get_organisation(dataset_dict["organization"]["name"]))
+    organisation_slug = dataset_dict["organization"]["name"]
+    @organisation = Organisation.new(get_organisation(organisation_slug), organisation_slug)
 
     @datafiles = []
     @docs = []

--- a/spec/factories/organisation.rb
+++ b/spec/factories/organisation.rb
@@ -47,6 +47,6 @@ FactoryBot.define do
       initialize_with { attributes.stringify_keys }
     end
 
-    initialize_with { Organisation.new(attributes.stringify_keys) }
+    initialize_with { Organisation.new(attributes.stringify_keys, attributes[:name]) }
   end
 end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -1,0 +1,61 @@
+# spec/models/organisation_spec.rb
+
+require "rails_helper"
+
+RSpec.describe Organisation do
+  describe "#initialize" do
+    context "when organisation is returned from Solr" do
+      let(:slug) { "test-org" }
+      let(:valid_hash) do
+        {
+          "title" => "Test Organisation",
+          "name" => slug,
+          "extras_contact-email" => "contact@example.com",
+          "extras_contact-name" => "John Doe",
+          "extras_foi-email" => "foi@example.com",
+          "extras_foi-web" => "http://foi.example.com",
+          "extras_foi-name" => "Jane Doe",
+        }
+      end
+
+      it "assigns the correct attributes from the hash" do
+        organisation = described_class.new(valid_hash, slug)
+
+        expect(organisation.title).to eq("Test Organisation")
+        expect(organisation.name).to eq("test-org")
+        expect(organisation.contact_email).to eq("contact@example.com")
+        expect(organisation.contact_name).to eq("John Doe")
+        expect(organisation.foi_email).to eq("foi@example.com")
+        expect(organisation.foi_web).to eq("http://foi.example.com")
+        expect(organisation.foi_name).to eq("Jane Doe")
+      end
+    end
+
+    context "when organisation doeasn't exist in Solr" do
+      let(:slug) { "test-org" }
+
+      it "uses the slug to set the title and name" do
+        organisation = described_class.new(nil, slug)
+
+        expect(organisation.title).to eq("Test Org")
+        expect(organisation.name).to eq("test-org")
+      end
+
+      it "doesn't set contact and FOI details" do
+        organisation = described_class.new(nil, slug)
+
+        expect(organisation.contact_email).to eq(nil)
+        expect(organisation.contact_name).to eq(nil)
+        expect(organisation.foi_email).to eq(nil)
+        expect(organisation.foi_web).to eq(nil)
+        expect(organisation.foi_name).to eq(nil)
+      end
+
+      it "calls capture_exception_in_sentry" do
+        allow_any_instance_of(described_class).to receive(:capture_exception_in_sentry)
+
+        expect(described_class.new(nil, slug)).to have_received(:capture_exception_in_sentry).with(slug)
+      end
+    end
+  end
+end


### PR DESCRIPTION
A number of organisations is missing from the Solr index. We want to be notified about those so we can investigate the issue with the Solr index but we still want to render the dataset pages correctly.

The contact details and FOI information on those pages may not be showing until the the organisation is in the index.

Tested capturing exceptions in Sentry locally: https://govuk.sentry.io/issues/6210169007

This will resolve the following Sentry errors:

```
NoMethodError
undefined method `[]' for nil:NilClass (NoMethodError)

    @title = hash["title"]
                 ^^^^^^^^^
```
https://govuk.sentry.io/issues/6205677017/?project=1461892
https://govuk.sentry.io/issues/6194439420/?project=1461892
https://govuk.sentry.io/issues/6205675340/?project=1461892
https://govuk.sentry.io/issues/6205675293/?project=1461892