### PR TITLE
Handle Solr connection errors

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,12 @@ class ApplicationController < ActionController::Base
   rescue_from SolrDataset::NotFound, with: :render_not_found
   rescue_from SolrDatafile::NotFound, with: :render_not_found
 
+  rescue_from RSolr::Error::ConnectionRefused do |exception|
+    Sentry.capture_exception(exception) if defined?(Sentry)
+
+    render "errors/service_unavailable_error", status: :service_unavailable
+  end
+
   def render_not_found
     render "errors/not_found", status: :not_found
   end

--- a/app/views/errors/service_unavailable_error.en.html.erb
+++ b/app/views/errors/service_unavailable_error.en.html.erb
@@ -1,0 +1,11 @@
+<% content_for :page_title do %>Service unavailable<% end %>
+
+<main id="content" role="main">
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <h1 class="heading-large">Service unavailable</h1>
+      <p>Sorry, we’re experiencing technical difficulties</p>
+      <p>Please try again in a few moments.</p>
+    </div>
+  </div>
+</main>

--- a/spec/requests/error_handling_spec.rb
+++ b/spec/requests/error_handling_spec.rb
@@ -38,4 +38,12 @@ RSpec.describe "Error handling", type: :request do
     get "/dataset/something.json"
     expect(response).to have_http_status(:not_found)
   end
+
+  it "handles Solr connection errors" do
+    request = { uri: URI("http://solr-example.data.gov.uk") }
+    allow(Search::Solr).to receive(:search).and_raise(RSolr::Error::ConnectionRefused.new(request))
+
+    get "/search"
+    expect(response).to have_http_status(:service_unavailable)
+  end
 end


### PR DESCRIPTION
Minor change to the users (status code will change from 500 to more appropriate 503). 
This will avoid ActionView::Template::Error when we can't connect to Solr.

https://govuk.sentry.io/issues/6204257119/?project=1461892

We want to log it into Sentry for a few months so check if this is a bigger availability issue we need to address.