### PR TITLE
Only include datasets in the results (exclude harvesters)

### DIFF
--- a/app/services/search/solr.rb
+++ b/app/services/search/solr.rb
@@ -33,7 +33,7 @@ module Search
       format_param = params.dig(:filters, :format)
       licence_param = params.dig(:filters, :licence_code)
 
-      filter_query = ["state:active"]
+      filter_query = ["state:active type:dataset"]
       filter_query << publisher_filter(publisher_param) if publisher_param.present?
       filter_query << topic_filter(topic_param) if topic_param.present?
       filter_query << format_filter(format_param) if format_param.present?

--- a/spec/services/search/solr_spec.rb
+++ b/spec/services/search/solr_spec.rb
@@ -284,7 +284,7 @@ RSpec.describe Search::Solr do
     it "includes active datasets filter" do
       filter_query = described_class.build_filter_query({ filters: {} })
 
-      expect(filter_query).to eq(["state:active"])
+      expect(filter_query).to eq(["state:active type:dataset"])
     end
   end
 


### PR DESCRIPTION
Harvesters were being included in the search results (type:harvest). There was also 1 item of type "showcase" but was deleted.