### PR TITLE
Return strings for additional metadata access constraints

### DIFF
--- a/app/models/solr_dataset.rb
+++ b/app/models/solr_dataset.rb
@@ -1,7 +1,7 @@
 class SolrDataset
   include ActiveModel::Model
 
-  attr_reader :uuid, :name, :title, :summary, :public_updated_at, :topic, :licence_title, :licence_url, :organisation, :datafiles, :contact_email, :contact_name, :foi_name, :foi_email, :foi_web, :docs, :licence_custom, :inspire_dataset, :harvested, :licence_code
+  attr_reader :uuid, :name, :title, :summary, :public_updated_at, :topic, :licence_title, :licence_url, :datafiles, :contact_email, :contact_name, :foi_name, :foi_email, :foi_web, :docs, :licence_custom, :inspire_dataset, :harvested, :licence_code
 
   ORGANOGRAM_SCHEMA_IDS = [
     "538b857a-64ba-490e-8440-0e32094a28a7", # Local authority
@@ -22,8 +22,7 @@ class SolrDataset
     @licence_code = dataset_dict["license_id"]
     @licence_custom = dataset["extras_licence"].gsub(/"|\[|\]/, "") if dataset["extras_licence"].present?
 
-    organisation_slug = dataset_dict["organization"]["name"]
-    @organisation = Organisation.new(get_organisation(organisation_slug), organisation_slug)
+    @organisation_slug = dataset_dict["organization"]["name"]
 
     @datafiles = []
     @docs = []
@@ -86,6 +85,12 @@ class SolrDataset
     )
     additional_info.empty? ? nil : additional_info
   end
+
+  def organisation
+    Organisation.new(get_organisation(@organisation_slug), @organisation_slug)
+  end
+
+  private
 
   def get_organisation(name)
     query = Search::Solr.get_organisation(name)

--- a/app/models/solr_dataset.rb
+++ b/app/models/solr_dataset.rb
@@ -61,28 +61,30 @@ class SolrDataset
   end
 
   def additional_information(data)
-    additional_info = {}
-    data.each do |item|
-      additional_info.store(item["key"], item["value"])
+    allowed_keys = %w[
+      licence
+      metadata-date
+      access_constraints
+      guid
+      bbox-east-long
+      bbox-west-long
+      bbox-north-lat
+      bbox-south-lat
+      spatial-reference-system
+      dataset-reference-date
+      frequency-of-update
+      responsible-party
+      resource-type
+      metadata-language
+      harvest_object_id
+    ]
+
+    additional_info = data.each_with_object({}) do |item, hash|
+      key = item["key"]
+      value = item["value"]
+      hash[key] = value if allowed_keys.include?(key)
     end
 
-    additional_info = additional_info&.slice(
-      "licence",
-      "metadata-date",
-      "access_constraints",
-      "guid",
-      "bbox-east-long",
-      "bbox-west-long",
-      "bbox-north-lat",
-      "bbox-south-lat",
-      "spatial-reference-system",
-      "dataset-reference-date",
-      "frequency-of-update",
-      "responsible-party",
-      "resource-type",
-      "metadata-language",
-      "harvest_object_id",
-    )
     additional_info.empty? ? nil : additional_info
   end
 

--- a/app/models/solr_dataset.rb
+++ b/app/models/solr_dataset.rb
@@ -97,13 +97,6 @@ class SolrDataset
     Organisation.new(get_organisation(@organisation_slug), @organisation_slug)
   end
 
-  private
-
-  def get_organisation(name)
-    query = Search::Solr.get_organisation(name)
-    query["response"]["docs"].first
-  end
-
   def self.get_by_query(query:)
     solr_client = Search::Solr.client
 
@@ -127,8 +120,19 @@ class SolrDataset
     SolrDataset.new(dataset_attr)
   end
 
+  private_class_method :get_by_query
+
+private
+
+  def get_organisation(name)
+    query = Search::Solr.get_organisation(name)
+    query["response"]["docs"].first
+  end
+
   def parse_json_value(value)
     JSON.parse(value)
+  rescue JSON::ParserError
+    value
   end
 
   class NotFound < StandardError; end

--- a/app/models/solr_dataset.rb
+++ b/app/models/solr_dataset.rb
@@ -61,7 +61,7 @@ class SolrDataset
   end
 
   def additional_information(data)
-    allowed_keys = %w[
+    relevant_keys = %w[
       licence
       metadata-date
       access_constraints
@@ -78,11 +78,16 @@ class SolrDataset
       metadata-language
       harvest_object_id
     ]
+    json_value_keys = %w[access_constraints dataset-reference-date]
 
     additional_info = data.each_with_object({}) do |item, hash|
       key = item["key"]
       value = item["value"]
-      hash[key] = value if allowed_keys.include?(key)
+      if json_value_keys.include?(key)
+        hash[key] = parse_json_value(value)
+      elsif relevant_keys.include?(key)
+        hash[key] = value
+      end
     end
 
     additional_info.empty? ? nil : additional_info
@@ -120,6 +125,10 @@ class SolrDataset
     raise NotFound if dataset_attr.nil?
 
     SolrDataset.new(dataset_attr)
+  end
+
+  def parse_json_value(value)
+    JSON.parse(value)
   end
 
   class NotFound < StandardError; end

--- a/app/views/datasets/_additional_info.html.erb
+++ b/app/views/datasets/_additional_info.html.erb
@@ -21,7 +21,9 @@
             <% end %>
             <% if i['access_constraints'] %>
               <dt><%= t('.inspire_access_constraints') %></dt>
-              <dd><%= i['access_constraints'].first || t('.inspire_access_constraints_unspecified') %></dd>
+              <% constraints = i['access_constraints'] %>
+              <% pp constraints %>
+              <dd><%= constraints.is_a?(String) ? constraints : constraints.first || t('.inspire_access_constraints_unspecified') %></dd>
             <% end %>
             <% if i['guid'] %>
               <dt><%= t('.inspire_guid') %></dt>

--- a/app/views/datasets/_additional_info.html.erb
+++ b/app/views/datasets/_additional_info.html.erb
@@ -20,9 +20,8 @@
               <dd><%= i['metadata-date'].to_date %></dd>
             <% end %>
             <% if i['access_constraints'] %>
-              <% ref = JSON.parse(i['access_constraints']) %>
               <dt><%= t('.inspire_access_constraints') %></dt>
-              <dd><%= ref.first || t('.inspire_access_constraints_unspecified') %></dd>
+              <dd><%= i['access_constraints'].first || t('.inspire_access_constraints_unspecified') %></dd>
             <% end %>
             <% if i['guid'] %>
               <dt><%= t('.inspire_guid') %></dt>
@@ -38,9 +37,8 @@
               <dd><%= i['spatial-reference-system'] %></dd>
             <% end %>
             <% if i['dataset-reference-date'] %>
-              <% ref = JSON.parse(i['dataset-reference-date']) %>
               <dt><%= t('.inspire_dataset_ref_date') %></dt>
-              <% ref.each do |date| %>
+              <% i['dataset-reference-date'].each do |date| %>
                 <dd><%= date['value'] %> (<%= date['type'] %>)</dd>
               <% end %>
             <% end %>

--- a/spec/factories/solr_datafile.rb
+++ b/spec/factories/solr_datafile.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :solr_datafile, class: SolrDataset do
+  factory :solr_datafile, class: SolrDatafile do
     id { 1 }
     name { "Name" }
     url { "http://example.com" }

--- a/spec/factories/solr_dataset.rb
+++ b/spec/factories/solr_dataset.rb
@@ -1,0 +1,49 @@
+FactoryBot.define do
+  factory :solr_dataset, class: SolrDataset do
+    id { "420932c7-e6f8-43ea-adc5-3141f757b5cb" }
+    name { "a-very-interesting-dataset" }
+    title { "A very interesting dataset" }
+    summary { "Lorem ipsum dolor sit amet." }
+    public_updated_at { "2017-06-30T09:08:37.040Z" }
+    topic { "government" }
+    licence_title { "UK Open Government Licence (OGL)" }
+    licence_url { "http://reference.data.gov.uk/id/open-government-licence" }
+    licence_code { "uk-ogl" }
+    contact_email { "" }
+    contact_name { "" }
+    foi_name { "" }
+    foi_email { "" }
+    foi_web { "" }
+    licence_custom { "" }
+    inspire_dataset { nil }
+    harvested { false }
+    validated_data_dict do
+      JSON.dump({
+        "license_title" => "UK Open Government Licence (OGL)",
+        "license_url" => "http://reference.data.gov.uk/id/open-government-licence",
+        "license_id" => "uk-ogl",
+        "organization" => {
+          "id" => "48f370c9-7ab9-4550-9722-8c9477020fc7",
+          "name" => "department-for-communities-and-local-government",
+          "title" => "Ministry of Housing, Communities and Local Government",
+          "type" => "organization",
+          "description" => "The Ministry of Housing, Communities and Local Government's (formerly the Department for Communities and Local Government) job is to create great places to live and work, and to give more power to local people to shape what happens in their area.",
+          "created" => "2012-06-27T14:48:38.548677",
+          "is_organization" => true,
+          "approval_status" => "pending",
+          "state" => "active",
+        },
+        "resources" => [
+          { "resource-type" => "file", "url" => "http://example.com/file.csv" },
+        ],
+        "extras" => [],
+      })
+    end
+
+    organization { build(:organisation) }
+
+    initialize_with do
+      SolrDataset.new(attributes.stringify_keys)
+    end
+  end
+end

--- a/spec/models/solr_dataset_spec.rb
+++ b/spec/models/solr_dataset_spec.rb
@@ -169,7 +169,6 @@ RSpec.describe SolrDataset do
   end
 
   describe "#additional_information" do
-    let(:response) { JSON.parse(File.read(Rails.root.join("spec/fixtures/solr_inspire_dataset.json").to_s)) }
     let(:dataset) { build(:solr_dataset) }
 
     it "returns a filtered hash with relevant keys when valid data is provided" do
@@ -180,7 +179,7 @@ RSpec.describe SolrDataset do
       ]
       expected = {
         "licence" => "Open Data",
-        "access_constraints" => "[\"http://example.com\"]",
+        "access_constraints" => ["http://example.com"],
         "guid" => "12345",
       }
 
@@ -190,12 +189,23 @@ RSpec.describe SolrDataset do
     it "returns a filtered hash excluding the extra keys when data contains extra keys" do
       data = [
         { "key" => "licence", "value" => "Open Data" },
-        { "key" => "access_constraints", "value" => "[\"http://example.com\"]" },
         { "key" => "extra_key", "value" => "extra_value" },
       ]
       expected = {
         "licence" => "Open Data",
-        "access_constraints" => "[\"http://example.com\"]",
+      }
+
+      expect(dataset.additional_information(data)).to eq(expected)
+    end
+
+    it "parses JSON for access_constraints and dataset-reference-date" do
+      data = [
+        { "key" => "access_constraints", "value" => "[\"http://example.com\"]" },
+        { "key" => "dataset-reference-date", "value" => "[{\"type\": \"creation\", \"value\": \"2015-04-21\"}]" },
+      ]
+      expected = {
+        "access_constraints" => ["http://example.com"],
+        "dataset-reference-date" => [{"type"=>"creation", "value"=>"2015-04-21"}],
       }
 
       expect(dataset.additional_information(data)).to eq(expected)

--- a/spec/models/solr_dataset_spec.rb
+++ b/spec/models/solr_dataset_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe SolrDataset do
     let(:response) { JSON.parse(File.read(Rails.root.join("spec/fixtures/solr_inspire_dataset.json").to_s)) }
     let(:dataset) { build(:solr_dataset) }
 
-    it "returns a filtered hash with allowed keys when valid data with allowed keys is provided" do
+    it "returns a filtered hash with relevant keys when valid data is provided" do
       data = [
         { "key" => "licence", "value" => "Open Data" },
         { "key" => "access_constraints", "value" => "[\"http://example.com\"]" },
@@ -187,7 +187,7 @@ RSpec.describe SolrDataset do
       expect(dataset.additional_information(data)).to eq(expected)
     end
 
-    it "returns a filtered hash excluding the extra keys when data contains extra keys not in the allowed list" do
+    it "returns a filtered hash excluding the extra keys when data contains extra keys" do
       data = [
         { "key" => "licence", "value" => "Open Data" },
         { "key" => "access_constraints", "value" => "[\"http://example.com\"]" },

--- a/spec/models/solr_dataset_spec.rb
+++ b/spec/models/solr_dataset_spec.rb
@@ -205,7 +205,7 @@ RSpec.describe SolrDataset do
       ]
       expected = {
         "access_constraints" => ["http://example.com"],
-        "dataset-reference-date" => [{"type"=>"creation", "value"=>"2015-04-21"}],
+        "dataset-reference-date" => [{ "type" => "creation", "value" => "2015-04-21" }],
       }
 
       expect(dataset.additional_information(data)).to eq(expected)
@@ -224,6 +224,20 @@ RSpec.describe SolrDataset do
       data = []
 
       expect(dataset.additional_information(data)).to be_nil
+    end
+
+    it "returns the raw string for 'access_constraints' when the key has invalid JSON" do
+      data = [
+        { "key" => "licence", "value" => "Open Data" },
+        { "key" => "access_constraints", "value" => "None" },
+      ]
+
+      expected = {
+        "licence" => "Open Data",
+        "access_constraints" => "None",
+      }
+
+      expect(dataset.additional_information(data)).to eq(expected)
     end
   end
 end

--- a/spec/models/solr_dataset_spec.rb
+++ b/spec/models/solr_dataset_spec.rb
@@ -167,4 +167,53 @@ RSpec.describe SolrDataset do
       expect(dataset.organogram?).to eq(false)
     end
   end
+
+  describe "#additional_information" do
+    let(:response) { JSON.parse(File.read(Rails.root.join("spec/fixtures/solr_inspire_dataset.json").to_s)) }
+    let(:dataset) { build(:solr_dataset) }
+
+    it "returns a filtered hash with allowed keys when valid data with allowed keys is provided" do
+      data = [
+        { "key" => "licence", "value" => "Open Data" },
+        { "key" => "access_constraints", "value" => "[\"http://example.com\"]" },
+        { "key" => "guid", "value" => "12345" },
+      ]
+      expected = {
+        "licence" => "Open Data",
+        "access_constraints" => "[\"http://example.com\"]",
+        "guid" => "12345",
+      }
+
+      expect(dataset.additional_information(data)).to eq(expected)
+    end
+
+    it "returns a filtered hash excluding the extra keys when data contains extra keys not in the allowed list" do
+      data = [
+        { "key" => "licence", "value" => "Open Data" },
+        { "key" => "access_constraints", "value" => "[\"http://example.com\"]" },
+        { "key" => "extra_key", "value" => "extra_value" },
+      ]
+      expected = {
+        "licence" => "Open Data",
+        "access_constraints" => "[\"http://example.com\"]",
+      }
+
+      expect(dataset.additional_information(data)).to eq(expected)
+    end
+
+    it "returns nil when no valid keys are present in the data" do
+      data = [
+        { "key" => "extra_key", "value" => "extra_value" },
+        { "key" => "another_key", "value" => "another_value" },
+      ]
+
+      expect(dataset.additional_information(data)).to be_nil
+    end
+
+    it "returns nil when data is empty" do
+      data = []
+
+      expect(dataset.additional_information(data)).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
Fixes https://govuk.sentry.io/issues/6199647014/?environment=production&project=1461892

```
ActionView::Template::Error
unexpected token at 'None' (ActionView::Template::Error)
JSON::ParserError
unexpected token at 'None' (JSON::ParserError)
```

Some dataset have this value as a String (not JSON).
<img width="535" alt="Screenshot 2025-01-17 at 14 53 27" src="https://github.com/user-attachments/assets/6d4acb95-cf98-4996-a57a-806a5b1b557c" />


JSON still works as expected
<img width="613" alt="Screenshot 2025-01-17 at 14 53 18" src="https://github.com/user-attachments/assets/a01feb40-0772-4907-93e1-f3e1d57fb9ad" />

