### PR TITLE
Use strong parameters

### DIFF
--- a/app/controllers/legacy/search_controller.rb
+++ b/app/controllers/legacy/search_controller.rb
@@ -1,17 +1,29 @@
 class Legacy::SearchController < ApplicationController
   def redirect
     filters = {
-      format: params["res_format"],
-      publisher: params["publisher"],
+      format: search_params[:res_format],
+      publisher: search_params[:publisher],
       licence: licence_param,
     }.compact
 
-    redirect_to search_path(q: params["q"], filters:)
+    redirect_to search_path(q: search_params[:q], filters:)
   end
 
 private
 
   def licence_param
-    "uk-ogl" if params["license_id-is-ogl"] == "true"
+    "uk-ogl" if search_params["license_id-is-ogl"] == "true"
+  end
+
+  def search_params
+    params.permit(
+      :q,
+      # Legacy filter params
+      :res_format,
+      :publisher,
+      "license_id-is-ogl",
+      # Current filter params
+      filters: %i[publisher topic format licence_code],
+    )
   end
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,14 +1,14 @@
 class SearchController < ApplicationController
   def search
-    @sort = params["sort"]
+    @sort = search_params[:sort]
 
-    @presenter = SearchPresenter.new(solr_search_response, params)
+    @presenter = SearchPresenter.new(solr_search_response, search_params)
 
     @num_results = solr_search_response["response"]["numFound"]
     @datasets = Kaminari.paginate_array(
       solr_search_response["response"]["docs"],
       total_count: @num_results,
-    ).page(params[:page])
+    ).page(search_params[:page])
      .per(Search::Solr::RESULTS_PER_PAGE)
   end
 
@@ -34,5 +34,14 @@ private
 
   def no_results_found
     { "response" => { "numFound" => 0, "docs" => [] } }
+  end
+
+  def search_params
+    params.permit(
+      :q,
+      :sort,
+      :page,
+      filters: %i[publisher topic format licence_code],
+    )
   end
 end


### PR DESCRIPTION
We want to explicitly allow selected parameters. Any other parameter will be ignored, preventing the `ActionController::UnfilteredParameters` error.

https://govuk.sentry.io/issues/6229673891?project=1461892

```
ActionController::UnfilteredParameters
unable to convert unpermitted parameters to hash (ActionController::UnfilteredParameters)

        raise UnfilteredParameters
              ^^^^^^^^^^^^^^^^^^^^
```

String keys are changed to symbols in the controllers for consistency. However in Rails params are a hash-like object (ActionController::Parameters), which handles both strings and symbols as keys. Hence, string keys in `Search::Solr`  and `SearchPresenter` were not changed to symbol to minimise diff.