### PR TITLE
feat: change backup environment variable name

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -3,5 +3,5 @@ require "sentry-rails"
 
 Sentry.init do |config|
   config.dsn = ENV["SENTRY_DSN"] if ENV["SENTRY_DSN"]
-  config.environment = ENV["GOVUK_ENVIRONMENT_NAME"]
+  config.environment = ENV["GOVUK_ENVIRONMENT"]
 end


### PR DESCRIPTION
- GOVUK_ENVIRONMENT is now available in in dgu-helm-charts, so replace old name GOVUK_ENVIRONMENT_NAME