### PR TITLE
Add Content Security Policy to fix Google Tag Manager

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,6 +31,7 @@
     <meta name="theme-color" content="#0b0c0c" />
 
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="Content-Security-Policy" content="default-src *; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com">
 
     <%= stylesheet_link_tag 'application' %>
     <%= csrf_meta_tags %>


### PR DESCRIPTION
Google Tag Manager is reporting lots of untagged datasets due to CSP blocking a request to the google tag manager website so add it to a safelist of websites to access.

https://cddodatamarketplace.atlassian.net/browse/DGUK-83?atlOrigin=eyJpIjoiYTBmMzFkMTRlMTVhNDEwZjk4M2IzODQ4MmY4YjE2YjQiLCJwIjoiaiJ9 