### PR TITLE
Update partner organizations in about page

### DIFF
--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -45,7 +45,7 @@
 
       <p class="govuk-body">GDS works with other organisations both within and outside government on shaping the strategic direction on how
         data is managed, accessed and used. We work collaboratively on a range of issues with the Office for National
-        Statistics, Department for Digital, Culture, Media & Sport and The National Cyber Security Centre.</p>
+        Statistics, Cabinet Office and The National Cyber Security Centre.</p>
 
       <%= render "govuk_publishing_components/components/heading", {
         text: "Reuse information published on Find open data",


### PR DESCRIPTION
Update partner organisations in text. Reference was to DCMS as responsible for data, where this is now DSIT which GDS is part of, so changed to CO which we partner with on guidance