### PR TITLE
DGUK-115 Reduce throttling threshold

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,6 +1,6 @@
 class Rack::Attack
   Rack::Attack.enabled = !Rails.env.test?
-  RATE_LIMIT_COUNT  = ENV.fetch("RATE_LIMIT_COUNT", 300).to_i
+  RATE_LIMIT_COUNT  = ENV.fetch("RATE_LIMIT_COUNT", 120).to_i
   RATE_LIMIT_PERIOD = ENV.fetch("RATE_LIMIT_PERIOD", 60).to_i
 
   throttle("/search", limit: RATE_LIMIT_COUNT, period: RATE_LIMIT_PERIOD) do |request|


### PR DESCRIPTION
Reduce the default rack-attack threshold to 120 requests per minute per ip address / user

This will help us block bots IP addresses from overwhelming our service / search feature.

The decision to set to 120 requests per minute per IP is an initial assumption. A user wouldn't normally request that many per minute. However, this is a trial and we'll adjust this value. 