### PR TITLE
DGUK-115 Guard against empty string in env

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,7 +1,7 @@
 class Rack::Attack
   Rack::Attack.enabled = !Rails.env.test?
-  RATE_LIMIT_COUNT  = ENV.fetch("RATE_LIMIT_COUNT", 120).to_i
-  RATE_LIMIT_PERIOD = ENV.fetch("RATE_LIMIT_PERIOD", 60).to_i
+  RATE_LIMIT_COUNT = (ENV.fetch("RATE_LIMIT_COUNT", nil).presence || 120).to_i
+  RATE_LIMIT_PERIOD = (ENV.fetch("RATE_LIMIT_PERIOD", nil).presence || 60).to_i
 
   throttle("/search", limit: RATE_LIMIT_COUNT, period: RATE_LIMIT_PERIOD) do |request|
     if request.path == "/search"

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -53,6 +53,16 @@ RSpec.describe "rack-attack throttling", type: :request do
       end
     end
 
+    context "when there are no values in the rate env variables" do
+      it "does not return a failure http response" do
+        allow(ENV).to receive(:fetch).with("RATE_LIMIT_COUNT", nil).and_return("")
+        allow(ENV).to receive(:fetch).with("RATE_LIMIT_PERIOD", nil).and_return("")
+
+        get path, valid_params, headers
+        expect(last_response.status).to eq(200)
+      end
+    end
+
     context "when period exceeded" do
       it "allows a new request after the throttle period passes" do
         get path, valid_params, headers


### PR DESCRIPTION
Fix issue with the rack-attack config.

When running in integration the env values were set to an empty string `""` and `"".to_i` becomes `0` . rack_attack would try to do divisions on zero which caused an exception.

Update the rack_attack.rb config
If the env value is an empty string then use the default value 120 for RATE_LIMIT_COUNT and 60 for RATE_LIMIT_PERIOD


