### PR TITLE
Update update_charts job to wait for build_and_push job

### DIFF
--- a/.github/workflows/build-image-mvp.yaml
+++ b/.github/workflows/build-image-mvp.yaml
@@ -19,6 +19,7 @@ jobs:
   update_charts:
     name: Update Find SHA in charts for MVP
     runs-on: ubuntu-latest
+    needs: build_and_push
     steps:
       - name: Checkout datagovuk_find repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Updating the sha before the build_and_push job is complete doesn't make sense as the image is not available for the Find pod to pull. So wait for the image to be pushed up to GHCR first.