### PR TITLE
Fix the build-image step by pinning the Docker version to 28.5.2.

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -64,6 +64,10 @@ jobs:
     permissions:
       packages: write
     steps:
+      - uses: docker/setup-docker-action@e43656e248c0bd0647d3f5c195d116aacf6fcaf4 # v4.7.0
+        with:
+          version: "version=28.5.2"
+
       - name: Login to GHCR
         uses: docker/login-action@v3
         with:
@@ -166,6 +170,10 @@ jobs:
       contents: read
       packages: write
     steps:
+      - uses: docker/setup-docker-action@e43656e248c0bd0647d3f5c195d116aacf6fcaf4 # v4.7.0
+        with:
+          version: "version=28.5.2"
+
       - name: Setup Docker BuildX
         uses: docker/setup-buildx-action@v3
 


### PR DESCRIPTION
The current Ubuntu runners provided by GitHub contain Docker engine v29, which is incompatible with how we're building container images.