### PR TITLE
[DGUK-220] Change header and home page to name the site 'data directory'

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -53,7 +53,7 @@
         <div class="govuk-grid-row">
           <div class="govuk-header__logo govuk-grid-column-one-half">
             <a href="<%= root_path %>" class="govuk-header__link govuk-header__link--homepage">
-                <%= t('.data_gov_uk')%> | <%= t('.find_open_data') %>
+                <%= t('.data_gov_uk')%> <%= t('.directory') %>
               </a>
           </div>
           <div class="govuk-grid-column-one-half">

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -3,7 +3,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= render "govuk_publishing_components/components/title", {
-        title: t('.find_open_data')
+        title: t('.data_directory')
       } %>
 
       <%= render "govuk_publishing_components/components/lead_paragraph", {

--- a/config/locales/views/layouts/en.yml
+++ b/config/locales/views/layouts/en.yml
@@ -7,6 +7,6 @@ en:
       support: "Support"
     application:
       site_name: "data.gov.uk"
-      find_open_data: "Find open data"
+      directory: "directory"
       data_gov_uk: "data.gov.uk"
       go_to_home: "Go to the Find open data homepage"

--- a/config/locales/views/pages/en.yml
+++ b/config/locales/views/pages/en.yml
@@ -44,5 +44,6 @@ en:
       transport_label: "Transport"
       transport_description: "Airports, roads, freight, electric vehicles, parking, buses and footpaths"
     home:
+      data_directory: "Data directory"
       find_open_data: "Find open data"
       lede: "Find data published by central government, local authorities and public bodies to help you build products and services"

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "pages", type: :request do
     end
 
     it "renders the home page" do
-      expect(response.body).to include(I18n.t("pages.home.find_open_data"))
+      expect(response.body).to include(I18n.t("pages.home.data_directory"))
     end
 
     include_examples "renders the publishers page"


### PR DESCRIPTION
Change site header and home page heading to signpost the site as "data directory".  This wording is in preparation for V2 where we will refer to the existing pages as such.