### PR TITLE
disable uglifier

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,6 @@ gem "secure_headers"
 gem "sentry-rails"
 gem "sentry-ruby"
 gem "sprockets-rails"
-gem "uglifier"
 
 group :development, :test do
   gem "brakeman"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -647,8 +647,6 @@ GEM
     timeout (0.4.3)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    uglifier (4.2.1)
-      execjs (>= 0.3.0, < 3)
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
@@ -712,7 +710,6 @@ DEPENDENCIES
   spring-commands-rspec
   spring-watcher-listen
   sprockets-rails
-  uglifier
   webmock
 
 BUNDLED WITH

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -24,9 +24,6 @@ Rails.application.configure do
   # Apache or NGINX already handles this.
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
-  # Compress JS using a preprocessor.
-  config.assets.js_compressor = :uglifier
-
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass
   # Rather than use a CSS compressor, use the SASS style to perform compression.


### PR DESCRIPTION
uglifier is too old to process es6, lets try disabling it and see how big the js is. Current application.js is 182kb