### PR TITLE
Bugfix - Update collections service to use Struct

### DIFF
--- a/app/services/collections_service.rb
+++ b/app/services/collections_service.rb
@@ -27,9 +27,9 @@ class CollectionsService
     .reject { |files|
       [".", ".."].include?(files)
     }.map do |collection|
-      OpenStruct.new(
-        slug: collection,
-        title: collection.gsub("-", " ").humanize,
+      Struct.new(:slug, :title).new(
+        collection,
+        collection.gsub("-", " ").humanize,
       )
     end
   end


### PR DESCRIPTION
Update collections service to use Struct. This is due to 3.3.10 needing require 'ostruct' in order to use opensruct.

However, it's recommended to use struct or the new Data class it provides.

`uninitialized constant CollectionsService::OpenStruct (NameError)`

