### PR TITLE
[DGUK-221] Add correct google analytics domains to CSP settings

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -2,13 +2,13 @@ SecureHeaders::Configuration.default do |config|
   config.csp = {
     preserve_schemes: true,
     default_src: ["'none'"],
-    connect_src: ["'self'", "www.google-analytics.com"],
+    connect_src: ["'self'", "*.google-analytics.com", "*.googletagmanager.com", "*.analytics.google.com"],
     font_src: ["'self'", "data:"],
-    img_src: ["'self'", "www.google-analytics.com"],
+    img_src: ["'self'", "*.google-analytics.com", "*.googletagmanager.com"],
     manifest_src: ["'self'"],
     media_src: ["'self'"],
     object_src: ["'self'"],
-    script_src: ["'unsafe-inline'", "'self'", "www.google-analytics.com", "www.googletagmanager.com"],
+    script_src: ["'unsafe-inline'", "'self'", "*.google-analytics.com", "*.googletagmanager.com"],
     style_src: ["'unsafe-inline'", "'self'"],
   }
 end


### PR DESCRIPTION
Currently on data.gov.uk production, we can see errors in the browser console as follows;
```
Connecting to 'https://region1.google-analytics.com/g/collect?v=2' violates the following Content Security Policy directive: "connect-src 'self' www.google-analytics.com". The action has been blocked.

Fetch API cannot load https://region1.google-analytics.com/g/collect?v=2.... Refused to connect because it violates the document's Content Security Policy.
```

It seems that we are only receiving partial google analytics data - this tallies with what we see in the analytics dashboards as certain geographical regions are suspiciously low on pageviews.

This change fixes the issue by allowing the domains which are required by google analytics in the app's content security policy.