### PR TITLE
[DGUK-272] Style V2 cookie banner

### DIFF
--- a/app/assets/stylesheets/v2/application.scss
+++ b/app/assets/stylesheets/v2/application.scss
@@ -1,4 +1,5 @@
 $desktop-breakpoint: 40.0625em;
+$datagovuk-max-width: 1100px;
 
 // Components from govuk_publishing_components gem
 @import 'govuk_publishing_components/govuk_frontend_support';

--- a/app/assets/stylesheets/v2/overrides/_cookie-banner.scss
+++ b/app/assets/stylesheets/v2/overrides/_cookie-banner.scss
@@ -1,0 +1,21 @@
+/* 
+  Breaking out of our BEM conventions for cookie banner overrides as 
+  the banner was taken from govuk-publishing-components and depends on 
+  certain classes for javascript to work.
+*/
+#global-cookie-message {
+  background-color: $datagovuk-light-grey;
+  margin: 20px 0;
+}
+
+.datagovuk-cookie-banner {
+  background-color: $datagovuk-light-grey;
+}
+
+#global-cookie-message .gem-c-button {
+  display: none;
+}
+
+.govuk-button-group .govuk-link.datagovuk-link {
+  @extend .datagovuk-body;
+}

--- a/app/assets/stylesheets/v2/overrides/main.scss
+++ b/app/assets/stylesheets/v2/overrides/main.scss
@@ -1,4 +1,5 @@
 @import 'footer';
+@import 'cookie-banner';
 
 /* inter-regular - latin */
 @font-face {
@@ -17,12 +18,16 @@
   src: url('/fonts/libre-baskerville-v24-latin-regular.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
 }
 
+.datagovuk-template {
+  background-color: $datagovuk-light-grey;
+}
+
 .datagovuk-main {
   margin: 30px 0 80px 0;
 }
 
 .datagovuk-width-container {
-  max-width: 1100px;
+  max-width: $datagovuk-max-width;
 }
 
 .datagovuk-body,
@@ -85,6 +90,8 @@
   font-family: 'Inter', sans-serif;
 }
 
+
+
 /* Desktop styling overrides */
 @media (min-width: $desktop-breakpoint) {
   .datagovuk-heading-xl{
@@ -106,4 +113,5 @@
   .datagovuk-list {
     font-size: 22px;
   }
+
 }

--- a/app/views/v2/layouts/application.html.erb
+++ b/app/views/v2/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="govuk-template">
+<html lang="en" class="govuk-template datagovuk-template">
  <head>
     <meta charset="utf-8">
     <title><%= yield(:page_title) %> - data.gov.uk</title>
@@ -40,10 +40,38 @@
   <body class="govuk-template__body">
     <script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
 
-    <%= render "govuk_publishing_components/components/cookie_banner", {
-      text: sanitize("We use <a href='/cookies' class='govuk-link'>cookies to collect information</a> about how you use data.gov.uk. We use this information to make the website work as well as possible."),
-      cookie_preferences_href: "/cookies",
-    } %>
+    <div id="global-cookie-message" data-module="cookie-banner" role="region" aria-label="cookie banner" data-nosnippet="" style="display: block;">
+      <div class="govuk-cookie-banner datagovuk-cookie-banner js-banner-wrapper" role="region" aria-label="Cookies on data.gov.uk">
+        <div class="govuk-cookie-banner__message govuk-width-container datagovuk-width-container">
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+              <h2 class="govuk-cookie-banner__heading govuk-heading-m datagovuk-heading-m">Cookies on data.gov.uk</h2>
+              <div class="govuk-cookie-banner__content">
+                <p class="govuk-body datagovuk-body">
+                  We use <a href="/cookies" class="govuk-link datagovuk-link">cookies to collect information</a> about how you use data.gov.uk. We use this information to make the website work as well as possible.</p>
+              </div>
+            </div>
+          </div>
+          <div class="govuk-button-group">
+            <button class="govuk-button datagovuk-button" type="submit" data-accept-cookies="true" data-track-category="cookieBanner" data-track-action="Cookie banner accepted" data-cookie-types="all">
+              Accept additional cookies
+            </button>
+            <button class="govuk-button datagovuk-button" type="submit" data-reject-cookies="true" data-track-category="cookieBanner" data-track-action="Cookie banner rejected">
+              Reject additional cookies
+            </button>
+            <a class="govuk-body datagovuk-body govuk-link datagovuk-link" href="/cookies">View cookies</a>
+          </div>
+        </div>
+      </div>
+      <div class="gem-c-cookie-banner__confirmation govuk-width-container datagovuk-width-container" tabindex="-1" hidden="">
+        <p class="gem-c-cookie-banner__confirmation-message govuk-body datagovuk-body" role="alert">
+          You can <a class="govuk-link datagovuk-link" data-track-category="cookieBanner" data-track-action="Cookie banner settings clicked from confirmation" href="/cookies">change your cookie settings</a> at any time.
+        </p>
+        <div class="govuk-button-group">
+          <button class="govuk-button datagovuk-button" data-hide-cookie-banner="true" data-module="gem-track-click" data-track-category="cookieBanner" data-track-action="Hide cookie banner">Hide this message</button>
+        </div>
+      </div>
+    </div>
 
     <a href="#main" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
 


### PR DESCRIPTION
This adds V2 styling to the cookie banner;
<img width="1916" height="1521" alt="image" src="https://github.com/user-attachments/assets/703da6f5-be17-4fe3-9480-92f129bcbd3f" />

I've broken the HTML out from the govuk publishing components library so that we have more control over styling.  Much like the cookies page https://github.com/alphagov/datagovuk_find/pull/1599 it's a bit of a half way house towards our ideal standards because we are limited by the javascript which we don't really want to touch at this stage.