### PR TITLE
[DGUK-282] Fix issue where open nav menu would close on scroll on iphone

### DIFF
--- a/app/assets/javascripts/v2/header.js
+++ b/app/assets/javascripts/v2/header.js
@@ -20,6 +20,7 @@ class DatagovukHeader {
   
     this.$mobileButton.setAttribute('aria-expanded', 'false')
     this.$mobileButton.addEventListener('click', () => this.toggleMobile())
+    this.watchMediaQueryChange();
 
     this.$desktopButtons.forEach($button => {
       $button.setAttribute('aria-expanded', 'false')
@@ -27,11 +28,21 @@ class DatagovukHeader {
     })
 
     document.addEventListener('keydown', (event) => this.handleKeydown(event))
-    window.addEventListener('resize', () => this.closeAll())
     this.$header.addEventListener('focusout', (event) => {
       // events bubble up so we need to check that focus has left header entirely
       if (this.$header.contains(event.relatedTarget) === false) this.closeAll()
     })
+  }
+
+  watchMediaQueryChange() {
+    const style = getComputedStyle(document.documentElement)
+    const desktopBreakpoint = style.getPropertyValue('--datagovuk-desktop-breakpoint').trim()
+    const mediaQuery = window.matchMedia('(max-width: ' + desktopBreakpoint + ')')
+    mediaQuery.addEventListener('change', (event) => this.handleMediaQueryChange(event))
+  }
+  
+  handleMediaQueryChange(event) {
+    this.closeAll()
   }
 
   getMenuFor($button) {

--- a/app/assets/stylesheets/v2/application.scss
+++ b/app/assets/stylesheets/v2/application.scss
@@ -1,6 +1,11 @@
 $desktop-breakpoint: 40.0625em;
 $datagovuk-max-width: 1100px;
 
+:root {
+  // Make desktop breakpoint easily readable by our header javascript
+  --datagovuk-desktop-breakpoint: #{$desktop-breakpoint};
+}
+
 // Components from govuk_publishing_components gem
 @import 'govuk_publishing_components/govuk_frontend_support';
 @import 'govuk_publishing_components/component_support';


### PR DESCRIPTION
This change fixes an issue where the "Menu" navigation drawer would close on scroll on iphone.

Testing is a little fiddly, but I've been able to do so against my local copy with iphone/android as I'm running the app through docker-compose and can expose the port necessary to see the find app on my local network.