### PR TITLE
DGUK-262 Add govuk govspeak barchart

### DIFF
--- a/app/assets/stylesheets/v2/components/_bar_chart.scss
+++ b/app/assets/stylesheets/v2/components/_bar_chart.scss
@@ -2,16 +2,16 @@
   font-weight: normal;
 }
 
-/* Row Layout */
+/* Row Layout: Full width on mobile */
 .mc-chart.mc-chart--bar .mc-tr {
   display: flex !important;
   align-items: center;
-  width: 50%;
+  width: 100%;
   margin-bottom: 15px;
   box-sizing: border-box;
 }
 
-/* Left Column - Labels (40% width) */
+/* Labels: Using a flexible percentage that works on small screens */
 .mc-chart.mc-chart--bar .mc-key-cell {
   flex: 0 0 40% !important;
   width: 40% !important;
@@ -23,9 +23,10 @@
   display: block !important;
   overflow: hidden;
   text-overflow: ellipsis;
+  font-size: 14px; /* Slightly smaller for mobile if needed */
 }
 
-/* Bar Container (remaining 60%) */
+/* Bar Container */
 .mc-chart.mc-chart--bar .mc-td.mc-bar-cell {
   flex: 1 !important;
   display: flex !important;
@@ -50,13 +51,22 @@
 
 /* Data Numbers */
 .mc-chart.mc-chart--bar .mc-bar-cell span {
-  padding-left: 12px !important;
+  padding-left: 8px !important;
   padding-right: 0 !important;
   color: $datagovuk-black !important;
+  font-size: 14px;
 }
 
-/* Desktop Overrides */
+/* Hide Toggle Button */
+.mc-chart.mc-chart--bar .mc-toggle-button {
+  display: none !important;
+}
+
 @media (min-width: $desktop-breakpoint) {
+  .mc-chart.mc-chart--bar .mc-tr {
+    width: 50% !important;
+  }
+
   .govuk-govspeak .datagovuk-heading-xl {
     font-size: 42px;
   }
@@ -64,10 +74,11 @@
   .mc-chart.mc-chart--bar .mc-key-cell {
     padding-right: 15px !important;
     line-height: 1.2;
+    font-size: 15px;
   }
-}
 
-/* Hide Toggle Button */
-.mc-chart.mc-chart--bar .mc-toggle-button {
-  display: none !important;
+  .mc-chart.mc-chart--bar .mc-bar-cell span {
+    padding-left: 12px !important;
+    font-size: 15px;
+  }
 }

--- a/app/assets/stylesheets/v2/components/_bar_chart.scss
+++ b/app/assets/stylesheets/v2/components/_bar_chart.scss
@@ -1,39 +1,31 @@
-/* Container and Toggle Button */
-.mc-chart.mc-chart--bar .mc-toggle-button {
-  display: none !important;
+.govuk-govspeak .datagovuk-heading-m {
+  font-weight: normal;
 }
 
 /* Row Layout */
 .mc-chart.mc-chart--bar .mc-tr {
   display: flex !important;
   align-items: center;
-  width: 100%;
-  margin-bottom: 16px;
+  width: 50%;
+  margin-bottom: 15px;
   box-sizing: border-box;
 }
 
-/* Left Column - Party Labels */
+/* Left Column - Labels (40% width) */
 .mc-chart.mc-chart--bar .mc-key-cell {
-  flex: 0 0 120px !important;
-  width: 120px !important;
+  flex: 0 0 40% !important;
+  width: 40% !important;
+  white-space: nowrap;
   text-align: left !important;
-  padding-right: 15px !important;
+  padding-right: 10px !important;
   padding-left: 0 !important;
   margin: 0 !important;
-  line-height: 1.2;
-  word-wrap: break-word;
   display: block !important;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
-/* Responsive adjustment for Labels */
-@media (min-width: 640px) {
-  .mc-chart.mc-chart--bar .mc-key-cell {
-    flex: 0 0 160px !important;
-    width: 160px !important;
-  }
-}
-
-/* Bar Container */
+/* Bar Container (remaining 60%) */
 .mc-chart.mc-chart--bar .mc-td.mc-bar-cell {
   flex: 1 !important;
   display: flex !important;
@@ -46,29 +38,36 @@
   overflow: visible;
 }
 
-/* The Actual Pink Bar */
+/* Bar */
 .mc-chart.mc-chart--bar .mc-td.mc-bar-cell::before {
   content: "";
   display: block;
   height: 40px;
-  width: inherit; /* Pulls percentage width from JS inline style */
-  background-color: #C27A9A !important;
+  width: inherit;
+  background-color: $datagovuk-pink !important;
   flex-shrink: 0;
 }
 
-/* The Data Numbers (33.7, etc.) */
+/* Data Numbers */
 .mc-chart.mc-chart--bar .mc-bar-cell span {
-  position: static !important; /* Kept static to stay inside container on mobile */
   padding-left: 12px !important;
   padding-right: 0 !important;
-  margin: 0 !important;
-  color: #0b0c0c !important;
-  white-space: nowrap;
-  line-height: 48px;
-  display: inline-block !important;
-  flex-shrink: 1;
+  color: $datagovuk-black !important;
 }
 
-.govuk-govspeak .datagovuk-heading-xl {
-    font-weight: normal;
+/* Desktop Overrides */
+@media (min-width: $desktop-breakpoint) {
+  .govuk-govspeak .datagovuk-heading-xl {
+    font-size: 42px;
+  }
+
+  .mc-chart.mc-chart--bar .mc-key-cell {
+    padding-right: 15px !important;
+    line-height: 1.2;
+  }
+}
+
+/* Hide Toggle Button */
+.mc-chart.mc-chart--bar .mc-toggle-button {
+  display: none !important;
 }

--- a/app/assets/stylesheets/v2/components/_bar_chart.scss
+++ b/app/assets/stylesheets/v2/components/_bar_chart.scss
@@ -68,3 +68,7 @@
   display: inline-block !important;
   flex-shrink: 1;
 }
+
+.govuk-govspeak .datagovuk-heading-xl {
+    font-weight: normal;
+}

--- a/app/assets/stylesheets/v2/components/_bar_chart.scss
+++ b/app/assets/stylesheets/v2/components/_bar_chart.scss
@@ -22,8 +22,7 @@
   margin: 0 !important;
   display: block !important;
   overflow: hidden;
-  text-overflow: ellipsis;
-  font-size: 14px; /* Slightly smaller for mobile if needed */
+  font-size: 14px;
 }
 
 /* Bar Container */

--- a/app/assets/stylesheets/v2/components/_bar_chart.scss
+++ b/app/assets/stylesheets/v2/components/_bar_chart.scss
@@ -1,0 +1,70 @@
+/* Container and Toggle Button */
+.mc-chart.mc-chart--bar .mc-toggle-button {
+  display: none !important;
+}
+
+/* Row Layout */
+.mc-chart.mc-chart--bar .mc-tr {
+  display: flex !important;
+  align-items: center;
+  width: 100%;
+  margin-bottom: 16px;
+  box-sizing: border-box;
+}
+
+/* Left Column - Party Labels */
+.mc-chart.mc-chart--bar .mc-key-cell {
+  flex: 0 0 120px !important;
+  width: 120px !important;
+  text-align: left !important;
+  padding-right: 15px !important;
+  padding-left: 0 !important;
+  margin: 0 !important;
+  line-height: 1.2;
+  word-wrap: break-word;
+  display: block !important;
+}
+
+/* Responsive adjustment for Labels */
+@media (min-width: 640px) {
+  .mc-chart.mc-chart--bar .mc-key-cell {
+    flex: 0 0 160px !important;
+    width: 160px !important;
+  }
+}
+
+/* Bar Container */
+.mc-chart.mc-chart--bar .mc-td.mc-bar-cell {
+  flex: 1 !important;
+  display: flex !important;
+  align-items: center;
+  background-color: transparent !important;
+  position: relative;
+  padding: 0 !important;
+  margin: 0 !important;
+  border: none !important;
+  overflow: visible;
+}
+
+/* The Actual Pink Bar */
+.mc-chart.mc-chart--bar .mc-td.mc-bar-cell::before {
+  content: "";
+  display: block;
+  height: 40px;
+  width: inherit; /* Pulls percentage width from JS inline style */
+  background-color: #C27A9A !important;
+  flex-shrink: 0;
+}
+
+/* The Data Numbers (33.7, etc.) */
+.mc-chart.mc-chart--bar .mc-bar-cell span {
+  position: static !important; /* Kept static to stay inside container on mobile */
+  padding-left: 12px !important;
+  padding-right: 0 !important;
+  margin: 0 !important;
+  color: #0b0c0c !important;
+  white-space: nowrap;
+  line-height: 48px;
+  display: inline-block !important;
+  flex-shrink: 1;
+}

--- a/app/assets/stylesheets/v2/components/main.scss
+++ b/app/assets/stylesheets/v2/components/main.scss
@@ -1,5 +1,6 @@
 @import 'data_manual_grid';
 @import 'data_manual_card';
+@import 'bar_chart';
 @import 'line_chart';
 @import 'section_navigation';
 @import 'feedback';

--- a/app/assets/stylesheets/v2/components/main.scss
+++ b/app/assets/stylesheets/v2/components/main.scss
@@ -4,3 +4,5 @@
 @import 'section_navigation';
 @import 'feedback';
 @import 'header';
+@import "govuk_publishing_components/components/govspeak";
+@import "govuk_publishing_components/components/govspeak/charts";

--- a/app/content/data/vote-share/vote-share.json
+++ b/app/content/data/vote-share/vote-share.json
@@ -1,0 +1,20 @@
+{
+    "title": "2024 Vote share by party (%)",
+    "subtitle": "Percentage of votes cast for each party that won at least one seat",
+    "visualisation_type": "bar",
+    "data": {
+        "Labour": 33.7,
+        "Conservative": 23.7,
+        "Liberal Democrat": 12.22,
+        "SNP": 2.52,
+        "Sinn Féin": 0.73,
+        "Reform UK": 14.29,
+        "DUP": 0.6,
+        "Green Party": 6.4,
+        "Plaid Cymru": 0.68,
+        "SDLP": 0.3,
+        "Alliance": 0.41,
+        "UUP": 0.33,
+        "TUV": 0.17
+    }
+}

--- a/app/controllers/v2/pages_controller.rb
+++ b/app/controllers/v2/pages_controller.rb
@@ -8,6 +8,7 @@ module V2
     def components
       @average_house_prices = average_house_prices
       @fuel_and_oil_prices = fuel_and_oil_prices
+      @bar_chart = JSON.parse(File.read(Rails.root.join("app/content/data/vote-share/vote-share.json")))
       render layout: "v2/layouts/application"
     end
 

--- a/app/views/v2/collection/charts/_bar_chart.html.erb
+++ b/app/views/v2/collection/charts/_bar_chart.html.erb
@@ -6,14 +6,14 @@
 } do %>
   <div data-module="govspeak">
     <div class="gem-c-govspeak govuk-govspeak">
-      <h2 class="govuk-heading-xl datagovuk-heading-xl">Share of Vote (%)</h3>
+      <h2 class="govuk-headingml datagovuk-heading-m">Share of Vote (%)</h3>
       
       <div class="mc-chart mc-chart--bar">
         <table class="js-barchart-table mc-auto-outdent">
           <tbody>
             <% data.each do |party, vote_share| %>
               <tr>
-                <th scope="row"><%= party %></th>
+                <th scope="row" class="govuk-body-m datagovuk-body"><%= party %></th>
                 <td><%= vote_share %></td>
               </tr>
             <% end %>

--- a/app/views/v2/collection/charts/_bar_chart.html.erb
+++ b/app/views/v2/collection/charts/_bar_chart.html.erb
@@ -1,0 +1,25 @@
+<%
+  data = local_assigns[:data] || {}
+%>
+
+<%= render "govuk_publishing_components/components/govspeak", {
+} do %>
+  <div data-module="govspeak">
+    <div class="gem-c-govspeak govuk-govspeak">
+      <h3 class="govuk-heading-m">Share of Vote (%)</h3>
+      
+      <div class="mc-chart mc-chart--bar">
+        <table class="js-barchart-table mc-auto-outdent">
+          <tbody>
+            <% data.each do |party, vote_share| %>
+              <tr>
+                <th scope="row"><%= party %></th>
+                <td><%= vote_share %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/v2/collection/charts/_bar_chart.html.erb
+++ b/app/views/v2/collection/charts/_bar_chart.html.erb
@@ -5,10 +5,9 @@
 <%= render "govuk_publishing_components/components/govspeak", {
 } do %>
   <div data-module="govspeak">
-    <div class="gem-c-govspeak govuk-govspeak">
-      <h2 class="govuk-headingml datagovuk-heading-m">Share of Vote (%)</h3>
-      
+    <div class="gem-c-govspeak govuk-govspeak">      
       <div class="mc-chart mc-chart--bar">
+              <h2 class="govuk-headingml datagovuk-heading-m">Share of Vote (%)</h3>
         <table class="js-barchart-table mc-auto-outdent">
           <tbody>
             <% data.each do |party, vote_share| %>

--- a/app/views/v2/collection/charts/_bar_chart.html.erb
+++ b/app/views/v2/collection/charts/_bar_chart.html.erb
@@ -6,7 +6,7 @@
 } do %>
   <div data-module="govspeak">
     <div class="gem-c-govspeak govuk-govspeak">
-      <h3 class="govuk-heading-m">Share of Vote (%)</h3>
+      <h2 class="govuk-heading-xl datagovuk-heading-xl">Share of Vote (%)</h3>
       
       <div class="mc-chart mc-chart--bar">
         <table class="js-barchart-table mc-auto-outdent">

--- a/app/views/v2/pages/components.html.erb
+++ b/app/views/v2/pages/components.html.erb
@@ -56,4 +56,9 @@
     data_series: @fuel_and_oil_prices["series"]
   } %>
 
+  <%= render partial: "v2/collection/charts/bar_chart", locals: {
+    title: @bar_chart["title"],
+    data: @bar_chart["data"]
+  } %>
+
 </div>


### PR DESCRIPTION
Add govuk [magnacharta](https://github.com/alphagov/magna-charta) bar chart

This uses code found in the Gemfile govuk_publishing_components


<img width="1022" height="957" alt="image" src="https://github.com/user-attachments/assets/0972d4d6-9729-4f53-8cca-1a8c86b9131e" />


Optional: with the "Change to table" button
<img width="954" height="1063" alt="image" src="https://github.com/user-attachments/assets/1e0c5fc8-fcbc-4c2b-9b70-d657701a377a" />


