### PR TITLE
Bugfix Remove pry requirement from rake task

### DIFF
--- a/lib/tasks/markdown_to_static_html.rake
+++ b/lib/tasks/markdown_to_static_html.rake
@@ -1,5 +1,4 @@
 require Rails.root.join("app/services/dgu/markdown")
-require "pry"
 
 namespace :markdown do
   desc "Convert markdown to static html pages"


### PR DESCRIPTION
Remove pry requirement from rake task as it's just a development environment dependency.