### PR TITLE
Prerelease update headline charts

### DIFF
--- a/app/controllers/v2/pages_controller.rb
+++ b/app/controllers/v2/pages_controller.rb
@@ -8,7 +8,7 @@ module V2
     def components
       @average_house_prices = average_house_prices
       @fuel_and_oil_prices = fuel_and_oil_prices
-      bar_chart = JSON.parse(File.read(Rails.root.join("app/content/data/election-results-data/vote-share.json")))
+      bar_chart = JSON.parse(File.read(Rails.root.join("app/content/data/election-results/vote-share.json")))
 
       @bar_chart = bar_chart
       render layout: "v2/layouts/application"

--- a/app/helpers/collection_helper.rb
+++ b/app/helpers/collection_helper.rb
@@ -1,0 +1,38 @@
+module CollectionHelper
+  HEADLINE_ITEM_KEYS = %w[subtitle description value analysis trend value_change percent_change].freeze
+
+  def chart_partial_path(visualisation_type)
+    {
+      "line" => "v2/collection/charts/line_chart",
+      "headline" => "v2/collection/charts/headline/headline",
+      "bar" => "v2/collection/charts/bar_chart",
+    }.fetch(visualisation_type)
+  end
+
+  def chart_locals(chart_data)
+    case chart_data["visualisation_type"]
+    when "line"
+      {
+        max_value: chart_data["max_value"],
+        title: chart_data["title"],
+        empty_description: "No data available",
+        number_base: chart_data["number_base"],
+        suffix: chart_data["visualisation_suffix"],
+        min: chart_data["min_value"],
+        data_series: chart_data["series"],
+      }
+    when "headline"
+      {
+        title: chart_data["title"],
+        source: chart_data["source"],
+        items: chart_data["items"].map { |item| item.slice(*HEADLINE_ITEM_KEYS).symbolize_keys },
+      }
+    when "bar"
+      {
+        title: chart_data["title"],
+        data: chart_data["data"],
+        size: 15,
+      }
+    end
+  end
+end

--- a/app/views/v2/collection/_content.html.erb
+++ b/app/views/v2/collection/_content.html.erb
@@ -1,10 +1,5 @@
-<%
-  chart_data = @chart_data || {}
-  collection = @collection || ""
-  collection_topic_path = @collection_topic_path || ""
-%>
-
-<h1 class="govuk-heading-l datagovuk-heading-l"><%= @title %></h1>
+<% chart_data = @chart_data || {} %>
+<% collection_topic_path = @collection_topic_path || "" %>
 
 <section class="govuk-section datagovuk-section">
   <%= @body %>
@@ -12,46 +7,12 @@
 
 <% if chart_data["visualisation_type"].present? %>
   <section class="datagovuk-headline govuk-section datagovuk-section govuk-!-margin-top-8">
-    <% if chart_data["visualisation_type"] == "line" %>
-      <%= render partial: "v2/collection/charts/line_chart", locals: {
-          max_value: chart_data["max_value"],
-          title: chart_data["title"],
-          empty_description: "No data available",
-          number_base: chart_data["number_base"],
-          suffix: chart_data["visualisation_suffix"],
-          min: chart_data["min_value"],
-          data_series: chart_data["series"]
-      } %>
-    <% elsif chart_data["visualisation_type"] == "headline" %>
-      <%= render partial: "v2/collection/charts/headline/headline", locals: {
-        title: chart_data["title"],
-        source: chart_data["source"],
-        items: [{
-          subtitle: chart_data["items"][0]["subtitle"],
-          description: chart_data["items"][0]["description"],
-          value: chart_data["items"][0]["value"],
-          analysis: chart_data["items"][0]["analysis"],
-          trend: chart_data["items"][0]["trend"],
-          value_change: chart_data["items"][0]["value_change"],
-          percent_change: chart_data["items"][0]["percent_change"]
-        },
-        {
-          subtitle: chart_data["items"][1]["subtitle"],
-          description: chart_data["items"][1]["description"],
-          value: chart_data["items"][1]["value"],
-          analysis: chart_data["items"][1]["analysis"],
-          trend: chart_data["items"][1]["trend"],
-          value_change: chart_data["items"][1]["value_change"],
-          percent_change: chart_data["items"][1]["percent_change"]
-        }]
-      } 
-      %>
-    <% elsif chart_data["visualisation_type"] == "bar" %>
-      <%= render partial: "v2/collection/charts/bar_chart", locals: {
-        title: chart_data["title"],
-        data: chart_data["data"],
-        size: 15
-      } %>
+    <%= render partial: chart_partial_path(chart_data["visualisation_type"]), locals: chart_locals(chart_data) %>
+
+    <% if chart_data["visualisation_type"] == "headline" && chart_data["source"].present? %>
+      <p class="govuk-body datagovuk-body govuk-!-margin-top-4">
+        <a href="<%= chart_data["source"] %>" class="govuk-link datagovuk-link">Source</a>
+      </p>
     <% end %>
 
     <% if chart_data["download"].present? %>

--- a/app/views/v2/collection/charts/_line_chart.html.erb
+++ b/app/views/v2/collection/charts/_line_chart.html.erb
@@ -5,10 +5,7 @@
   number_base = local_assigns[:number_base] || 1
   suffix = local_assigns[:suffix]
   min = local_assigns[:min] || 0
-  download = local_assigns[:download]
   display_legend = local_assigns[:data_series].size > 1 ? true : false
-  collection_topic_path = local_assigns[:collection_topic_path] || ""
-  file_name = local_assigns[:file_name] || ""
 %>
 
 <h2 class="govuk-heading-m datagovuk-heading-m"><%= local_assigns[:title] %></h2>


### PR DESCRIPTION
- ~Update headline styling to fit the subtitles onto one line~
- ~Remove visualisation title from headline chart~
- Use view helper to create charts , easier to read.
- Add "Source" link for headline charts . ⚠️ needs design review
- fix components page

<img width="910" height="646" alt="image" src="https://github.com/user-attachments/assets/6c562232-6d35-4a7e-9501-a33d4a020316" />


The chart source link is : `https://www.gov.uk/government/statistics/companies-register-activities-statistical-release-april-2024-to-march-2025`

<img width="930" height="627" alt="image" src="https://github.com/user-attachments/assets/57f12533-4ef8-4062-988b-35b0a7768d71" />

