### PR TITLE
DGUK-150: Fix auto-merge integration PR — add --auto flag

### DIFF
--- a/docker/create-pr.sh
+++ b/docker/create-pr.sh
@@ -32,7 +32,7 @@ for ENV in $(echo $ENVS | tr "," " "); do
       git commit -m "Update datagovuk_find image tags for ${ENV} to ${IMAGE_TAG}"
       git push --set-upstream origin "${BRANCH}"
       PR_URL=$(gh pr create --title "Update datagovuk_find image tags for ${ENV} (${IMAGE_TAG})" --base main --head "${BRANCH}" --fill --repo alphagov/govuk-dgu-charts)
-      gh pr merge "${PR_URL}" --merge --delete-branch
+      gh pr merge "${PR_URL}" --auto --merge --delete-branch
     else
       BRANCH="ci/${IMAGE_TAG}-${ENV}"
 


### PR DESCRIPTION
## Problem

`gh pr merge --merge` fails immediately because `govuk-dgu-charts` branch protection requires status checks to pass before merging:

```
X Pull request is not mergeable: the base branch policy prohibits the merge.
To have the pull request merged after all the requirements have been met, add the --auto flag.
```

## Fix

One character change: add `--auto` to the `gh pr merge` call so the PR is queued for auto-merge and merges automatically once all required checks pass.

## Test plan

- [ ] Merge to main and verify pipeline creates the integration PR in `govuk-dgu-charts` and enables auto-merge on it
- [ ] Verify the PR merges automatically once checks pass and `integration/find.yaml` is updated