### PR TITLE
DGUK-340 ONS line chart

### DIFF
--- a/app/assets/javascripts/v2/application.js
+++ b/app/assets/javascripts/v2/application.js
@@ -18,5 +18,8 @@
 //= require chartkick
 //= require Chart.bundle
 //= require chartjs-plugin-datalabels/dist/chartjs-plugin-datalabels
+// TODO: include highcharts ?
+//= require @ons/design-system/scripts/main.es5
+
 
 Chart.register(ChartDataLabels);

--- a/app/assets/javascripts/v2/application.js
+++ b/app/assets/javascripts/v2/application.js
@@ -18,7 +18,6 @@
 //= require chartkick
 //= require Chart.bundle
 //= require chartjs-plugin-datalabels/dist/chartjs-plugin-datalabels
-// TODO: include highcharts ?
 //= require @ons/design-system/scripts/main.es5
 
 

--- a/app/assets/stylesheets/v2/application.scss
+++ b/app/assets/stylesheets/v2/application.scss
@@ -13,6 +13,8 @@ $datagovuk-max-width: 1100px;
 @import 'govuk_publishing_components/component_support';
 @import 'govuk_publishing_components/components/_cookie-banner';
 
+@import "@ons/design-system/css/main.css";
+
 @import "colours";
 @import "typography";
 
@@ -21,3 +23,4 @@ $datagovuk-max-width: 1100px;
 @import 'components/main';
 
 @import 'pages/main';
+

--- a/app/content/data/fuel-and-oil-prices/fuel-and-oil-prices-2.json
+++ b/app/content/data/fuel-and-oil-prices/fuel-and-oil-prices-2.json
@@ -2,15 +2,18 @@
   "chartType": "line",
   "title": "Fuel price in pence per litre (yearly)",
   "subtitle": "Average annual prices for Premium unleaded (ULSP) and Diesel (ULSD)",
-  "id": "fuel-price-chart",
   "description": "Line chart showing the rise and fall of fuel prices in the UK from 1977 to 2025.",
-  "source": "Department for Energy Security and Net Zero",
-  "theme": "primary",
+  "source": "https://www.gov.uk/government/statistical-data-sets/oil-and-petroleum-products-monthly-statistics",
   "legend": true,
   "xAxis": {
     "title": { "text": "Year" },
-    "type": "linear",
     "lineWidth": 0,
+    "type": "datetime",
+    "tickInterval": 31536000000, 
+    "labels": {
+      "format": "{value:%Y}"
+    },
+    "showLastLabel": true,
     "categories": ["1977", "1978", "1979", "1980", "1981", "1982", "1983", "1984", "1985", "1986", "1987", "1988", "1989", "1990", "1991", "1992", "1993", "1994", "1995", "1996", "1997", "1998", "1999", "2000", "2001", "2002", "2003", "2004", "2005", "2006", "2007", "2008", "2009", "2010", "2011", "2012", "2013", "2014", "2015", "2016", "2017", "2018", "2019", "2020", "2021", "2022", "2023", "2024", "2025"]
   },
   "yAxis": {

--- a/app/content/data/fuel-and-oil-prices/fuel-and-oil-prices-2.json
+++ b/app/content/data/fuel-and-oil-prices/fuel-and-oil-prices-2.json
@@ -1,0 +1,35 @@
+{
+  "chartType": "line",
+  "title": "Fuel price in pence per litre (yearly)",
+  "subtitle": "Average annual prices for Premium unleaded (ULSP) and Diesel (ULSD)",
+  "id": "fuel-price-chart",
+  "description": "Line chart showing the rise and fall of fuel prices in the UK from 1977 to 2025.",
+  "source": "Department for Energy Security and Net Zero",
+  "theme": "primary",
+  "legend": true,
+  "xAxis": {
+    "title": { "text": "Year" },
+    "type": "linear",
+    "lineWidth": 0,
+    "categories": ["1977", "1978", "1979", "1980", "1981", "1982", "1983", "1984", "1985", "1986", "1987", "1988", "1989", "1990", "1991", "1992", "1993", "1994", "1995", "1996", "1997", "1998", "1999", "2000", "2001", "2002", "2003", "2004", "2005", "2006", "2007", "2008", "2009", "2010", "2011", "2012", "2013", "2014", "2015", "2016", "2017", "2018", "2019", "2020", "2021", "2022", "2023", "2024", "2025"]
+  },
+  "yAxis": {
+    "title": { "text": "Pence per litre" },
+    "labels": { "format": "{value:,.f}" },
+    "gridLineDashStyle": "LongDash"
+  },
+  "series": [
+    {
+      "name": "Premium unleaded / ULSP",
+      "marker": { "enabled": false },
+      "dataLabels": { "enabled": false },
+      "data": [null, null, null, null, null, null, null, null, null, null, null, null, 38.29, 42.03, 45.07, 46.07, 49.44, 51.58, 53.77, 56.52, 61.82, 64.8, 70.16, 79.93, 75.72, 73.24, 76.04, 80.22, 86.75, 91.32, 94.24, 107.08, 99.29, 116.9, 133.27, 135.39, 134.15, 127.5, 111.13, 108.85, 117.59, 125.2, 124.88, 113.95, 131.27, 164.73, 147.75, 141.48, 135.07]
+    },
+    {
+      "name": "Diesel / ULSD",
+      "marker": { "enabled": false },
+      "dataLabels": { "enabled": false },
+      "data": [18.21, 18.46, 23.65, 29.67, 34.01, 35.86, 37.3, 38.33, 41.94, 35.6, 34.58, 34.0, 36.18, 40.48, 43.82, 45.01, 49.2, 51.53, 54.24, 57.71, 62.47, 65.5, 72.49, 81.34, 77.84, 75.46, 77.92, 81.91, 90.86, 95.21, 96.85, 117.51, 103.93, 119.26, 138.72, 141.83, 140.41, 133.46, 114.9, 110.13, 120.15, 129.98, 131.48, 119.14, 134.94, 177.66, 158.19, 148.33, 142.55]
+    }
+  ]
+}

--- a/app/controllers/v2/pages_controller.rb
+++ b/app/controllers/v2/pages_controller.rb
@@ -13,7 +13,6 @@ module V2
       @ons_line_chart = JSON.parse(File.read(Rails.root.join("app/content/data/fuel-and-oil-prices/fuel-and-oil-prices-2.json")))
 
       @bar_chart = bar_chart
-      @fuel_price_chart = build_fuel_price_chart
       render layout: "v2/layouts/application"
     end
 
@@ -63,56 +62,6 @@ module V2
         }
       end
       fuel_and_oil_prices
-    end
-
-    def build_fuel_price_chart
-      {
-        chartType: "line",
-        title: "Fuel price in pence per litre (yearly)",
-        subtitle: "Average annual prices for Premium unleaded (ULSP) and Diesel (ULSD)",
-        id: "fuel-price-chart",
-        description: "Line chart showing the rise and fall of fuel prices in the UK from 1977 to 2025.",
-        theme: "primary",
-        legend: true,
-        caption: "Source: Department for Energy Security and Net Zero",
-        download: {
-          title: "Download Figure 1 data",
-          itemsList: [
-            { text: "Excel spreadsheet (XLSX format, 18KB)", url: "#" },
-            { text: "Simple text file (CSV format, 25KB)", url: "#" },
-            { text: "Image (PNG format, 25KB)", url: "#" },
-          ],
-        },
-        footnotes: {
-          title: "Footnotes",
-          content: "<ol><li>---</li><li>---</li></ol>",
-        },
-        xAxis: {
-          title: { text: "Year" },
-          type: "linear",
-          lineWidth: 0,
-          categories: %w[1977 1978 1979 1980 1981 1982 1983 1984 1985 1986 1987 1988 1989 1990 1991 1992 1993 1994 1995 1996 1997 1998 1999 2000 2001 2002 2003 2004 2005 2006 2007 2008 2009 2010 2011 2012 2013 2014 2015 2016 2017 2018 2019 2020 2021 2022 2023 2024 2025],
-        },
-        yAxis: {
-          title: { text: "Pence per litre" },
-          labels: { format: "{value:,.f}" },
-          gridLineDashStyle: "LongDash",
-        },
-        series: [
-          {
-            name: "Premium unleaded / ULSP",
-            marker: { enabled: false },
-            dataLabels: { enabled: false },
-            data: [nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 38.29, 42.03, 45.07, 46.07, 49.44, 51.58, 53.77, 56.52, 61.82, 64.8, 70.16, 79.93, 75.72, 73.24, 76.04, 80.22, 86.75, 91.32, 94.24, 107.08, 99.29, 116.9, 133.27, 135.39, 134.15, 127.5, 111.13, 108.85, 117.59, 125.2, 124.88, 113.95, 131.27, 164.73, 147.75, 141.48, 135.07],
-          },
-          {
-            name: "Diesel / ULSD",
-            marker: { enabled: false },
-            dataLabels: { enabled: false },
-            data: [18.21, 18.46, 23.65, 29.67, 34.01, 35.86, 37.3, 38.33, 41.94, 35.6, 34.58, 34.0, 36.18, 40.48, 43.82, 45.01, 49.2, 51.53, 54.24, 57.71, 62.47, 65.5, 72.49, 81.34, 77.84, 75.46, 77.92, 81.91, 90.86, 95.21, 96.85, 117.51, 103.93, 119.26, 138.72, 141.83, 140.41, 133.46, 114.9, 110.13, 120.15, 129.98, 131.48, 119.14, 134.94, 177.66, 158.19, 148.33, 142.55],
-          },
-        ],
-      }
     end
   end
 end

--- a/app/controllers/v2/pages_controller.rb
+++ b/app/controllers/v2/pages_controller.rb
@@ -10,7 +10,10 @@ module V2
       @fuel_and_oil_prices = fuel_and_oil_prices
       bar_chart = JSON.parse(File.read(Rails.root.join("app/content/data/election-results/vote-share.json")))
 
+      @ons_line_chart = JSON.parse(File.read(Rails.root.join("app/content/data/fuel-and-oil-prices/fuel-and-oil-prices-2.json")))
+
       @bar_chart = bar_chart
+      @fuel_price_chart = build_fuel_price_chart
       render layout: "v2/layouts/application"
     end
 
@@ -60,6 +63,56 @@ module V2
         }
       end
       fuel_and_oil_prices
+    end
+
+    def build_fuel_price_chart
+      {
+        chartType: "line",
+        title: "Fuel price in pence per litre (yearly)",
+        subtitle: "Average annual prices for Premium unleaded (ULSP) and Diesel (ULSD)",
+        id: "fuel-price-chart",
+        description: "Line chart showing the rise and fall of fuel prices in the UK from 1977 to 2025.",
+        theme: "primary",
+        legend: true,
+        caption: "Source: Department for Energy Security and Net Zero",
+        download: {
+          title: "Download Figure 1 data",
+          itemsList: [
+            { text: "Excel spreadsheet (XLSX format, 18KB)", url: "#" },
+            { text: "Simple text file (CSV format, 25KB)", url: "#" },
+            { text: "Image (PNG format, 25KB)", url: "#" },
+          ],
+        },
+        footnotes: {
+          title: "Footnotes",
+          content: "<ol><li>---</li><li>---</li></ol>",
+        },
+        xAxis: {
+          title: { text: "Year" },
+          type: "linear",
+          lineWidth: 0,
+          categories: %w[1977 1978 1979 1980 1981 1982 1983 1984 1985 1986 1987 1988 1989 1990 1991 1992 1993 1994 1995 1996 1997 1998 1999 2000 2001 2002 2003 2004 2005 2006 2007 2008 2009 2010 2011 2012 2013 2014 2015 2016 2017 2018 2019 2020 2021 2022 2023 2024 2025],
+        },
+        yAxis: {
+          title: { text: "Pence per litre" },
+          labels: { format: "{value:,.f}" },
+          gridLineDashStyle: "LongDash",
+        },
+        series: [
+          {
+            name: "Premium unleaded / ULSP",
+            marker: { enabled: false },
+            dataLabels: { enabled: false },
+            data: [nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 38.29, 42.03, 45.07, 46.07, 49.44, 51.58, 53.77, 56.52, 61.82, 64.8, 70.16, 79.93, 75.72, 73.24, 76.04, 80.22, 86.75, 91.32, 94.24, 107.08, 99.29, 116.9, 133.27, 135.39, 134.15, 127.5, 111.13, 108.85, 117.59, 125.2, 124.88, 113.95, 131.27, 164.73, 147.75, 141.48, 135.07],
+          },
+          {
+            name: "Diesel / ULSD",
+            marker: { enabled: false },
+            dataLabels: { enabled: false },
+            data: [18.21, 18.46, 23.65, 29.67, 34.01, 35.86, 37.3, 38.33, 41.94, 35.6, 34.58, 34.0, 36.18, 40.48, 43.82, 45.01, 49.2, 51.53, 54.24, 57.71, 62.47, 65.5, 72.49, 81.34, 77.84, 75.46, 77.92, 81.91, 90.86, 95.21, 96.85, 117.51, 103.93, 119.26, 138.72, 141.83, 140.41, 133.46, 114.9, 110.13, 120.15, 129.98, 131.48, 119.14, 134.94, 177.66, 158.19, 148.33, 142.55],
+          },
+        ],
+      }
     end
   end
 end

--- a/app/helpers/ons_charts_helper.rb
+++ b/app/helpers/ons_charts_helper.rb
@@ -1,0 +1,13 @@
+module OnsChartsHelper
+  def ons_line_chart(config)
+    content_tag(:div, data: { "highcharts-base-chart": true, "highcharts-type": "line" }) do
+      concat content_tag(
+        :script,
+        config.to_json.html_safe,
+        type: "application/json",
+        data: { "highcharts-config--id": true },
+        nonce: content_security_policy_nonce,
+      )
+    end
+  end
+end

--- a/app/views/v2/pages/components.html.erb
+++ b/app/views/v2/pages/components.html.erb
@@ -66,4 +66,54 @@
     download: @bar_chart["download"],
     size: 15
   } %>
+
+  <div data-highcharts-base-chart data-highcharts-type="line" data-highcharts-theme="primary"
+    data-highcharts-title="Sales volumes and values saw moderate growth in July 2024" data-highcharts-id="id"
+    data-highcharts-percentage-height-desktop="35" data-highcharts-percentage-height-mobile="90"
+    data-highcharts-x-axis-tick-interval-mobile="30" data-highcharts-x-axis-tick-interval-desktop="15">
+    <figure class="ons-chart" aria-describedby="chart-audio-description-id">
+      <h4 class="ons-chart__title"><%= @ons_line_chart["title"] %></h4>
+      <h5 class="ons-chart__subtitle"><%= @ons_line_chart["subtitle"] %></h5>
+      <p class="ons-u-vh" id="chart-audio-description-id"><%= @ons_line_chart["audio_description"] %></p>
+      <div data-highcharts-chart-container class="ons-chart__container" tabindex="0" role="region"
+        aria-label="chart container" aria-describedby="chart-instructions-id">
+        <div id="chart-instructions-id" class="ons-u-vh"><%= @ons_line_chart["instructions"] %></div>
+        <div data-highcharts-chart class="ons-chart__chart"></div>
+      </div>
+      <noscript id="fallback-image--id">
+        <%# TODO: Add fallback image %>
+        <img src="/img/small/line-chart-screenshot.png" alt="Fallback image for the chart as JavaScript is disabled" class="ons-chart__fallback-image" />
+      </noscript>
+      <figcaption class="ons-chart__caption">Source: <%= @ons_line_chart["source"] %></figcaption>
+    </figure>
+    <h6 class="ons-chart__download-title">Download Figure 1 data</h6>
+    <ol class="ons-list">
+      <li class="ons-list__item">
+        <a href="#" class="ons-list__link"><%= "Download data" %></a>
+      </li>
+      <li class="ons-list__item">
+        <a href="#" class="ons-list__link"><%= "Download data" %></a>
+      </li>
+      <li class="ons-list__item">
+        <a href="#" class="ons-list__link"><%= "Download data" %></a>
+      </li>
+    </ol>
+    <div id="footnotes--id" class="ons-details ons-js-details ons-u-mt-xl">
+      <div class="ons-details__heading ons-js-details-heading" role="button">
+        <h6 class="ons-details__title ons-u-fs-r--b">Footnotes</h6>
+        <span class="ons-details__icon">
+          <svg class="ons-icon" viewBox="0 0 8 13" xmlns="http://www.w3.org/2000/svg" focusable="false" fill="currentColor" role="img" aria-hidden="true">
+            <path d="M5.74,14.28l-.57-.56a.5.5,0,0,1,0-.71h0l5-5-5-5a.5.5,0,0,1,0-.71h0l.57-.56a.5.5,0,0,1,.71,0h0l5.93,5.93a.5.5,0,0,1,0,.7L6.45,14.28a.5.5,0,0,1-.71,0Z" transform="translate(-5.02 -1.59)" />
+          </svg>
+        </span>
+      </div>
+      <div id="footnotes--id-content" class="ons-details__content ons-js-details-content">
+        <ol>
+          <li>---</li>
+          <li>---</li>
+        </ol>
+      </div>
+    </div>
+    <%= ons_line_chart(@ons_line_chart) %>
+  </div>
 </div>

--- a/app/views/v2/pages/components.html.erb
+++ b/app/views/v2/pages/components.html.erb
@@ -68,7 +68,7 @@
   } %>
 
   <div data-highcharts-base-chart data-highcharts-type="line" data-highcharts-theme="primary"
-    data-highcharts-title="Sales volumes and values saw moderate growth in July 2024" data-highcharts-id="id"
+    data-highcharts-title="<%= @ons_line_chart["title"] %>" data-highcharts-id="id"
     data-highcharts-percentage-height-desktop="35" data-highcharts-percentage-height-mobile="90"
     data-highcharts-x-axis-tick-interval-mobile="30" data-highcharts-x-axis-tick-interval-desktop="15">
     <figure class="ons-chart" aria-describedby="chart-audio-description-id">
@@ -82,38 +82,13 @@
       </div>
       <noscript id="fallback-image--id">
         <%# TODO: Add fallback image %>
-        <img src="/img/small/line-chart-screenshot.png" alt="Fallback image for the chart as JavaScript is disabled" class="ons-chart__fallback-image" />
+        <img src="/img/small/line-chart-screenshot.png" alt="Fallback image for the chart as JavaScript is disabled"
+          class="ons-chart__fallback-image" />
       </noscript>
-      <figcaption class="ons-chart__caption">Source: <%= @ons_line_chart["source"] %></figcaption>
+      <% if @ons_line_chart["source"] %>
+        <figcaption class="ons-chart__caption">Source: <%= @ons_line_chart["source"] %></figcaption>
+      <% end %>
     </figure>
-    <h6 class="ons-chart__download-title">Download Figure 1 data</h6>
-    <ol class="ons-list">
-      <li class="ons-list__item">
-        <a href="#" class="ons-list__link"><%= "Download data" %></a>
-      </li>
-      <li class="ons-list__item">
-        <a href="#" class="ons-list__link"><%= "Download data" %></a>
-      </li>
-      <li class="ons-list__item">
-        <a href="#" class="ons-list__link"><%= "Download data" %></a>
-      </li>
-    </ol>
-    <div id="footnotes--id" class="ons-details ons-js-details ons-u-mt-xl">
-      <div class="ons-details__heading ons-js-details-heading" role="button">
-        <h6 class="ons-details__title ons-u-fs-r--b">Footnotes</h6>
-        <span class="ons-details__icon">
-          <svg class="ons-icon" viewBox="0 0 8 13" xmlns="http://www.w3.org/2000/svg" focusable="false" fill="currentColor" role="img" aria-hidden="true">
-            <path d="M5.74,14.28l-.57-.56a.5.5,0,0,1,0-.71h0l5-5-5-5a.5.5,0,0,1,0-.71h0l.57-.56a.5.5,0,0,1,.71,0h0l5.93,5.93a.5.5,0,0,1,0,.7L6.45,14.28a.5.5,0,0,1-.71,0Z" transform="translate(-5.02 -1.59)" />
-          </svg>
-        </span>
-      </div>
-      <div id="footnotes--id-content" class="ons-details__content ons-js-details-content">
-        <ol>
-          <li>---</li>
-          <li>---</li>
-        </ol>
-      </div>
-    </div>
     <%= ons_line_chart(@ons_line_chart) %>
   </div>
 </div>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -11,6 +11,7 @@ Rails.application.config.assets.precompile += %w[v2/govuk-frontend-6.0.0.min.css
 # Rails.application.config.assets.paths << Emoji.images_path
 # Add Yarn node_modules folder to the asset load path.
 Rails.application.config.assets.paths << Rails.root.join("node_modules")
+Rails.application.config.assets.paths << Rails.root.join("node_modules/@ons/design-system")
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.

--- a/package.json
+++ b/package.json
@@ -2,8 +2,10 @@
   "name": "datagovuk_find",
   "license": "UNLICENSED",
   "dependencies": {
+    "@ons/design-system": "^73.3.0",
     "accessible-autocomplete": "^2.0.2",
-    "chartjs-plugin-datalabels": "^2.2.0"
+    "chartjs-plugin-datalabels": "^2.2.0",
+    "highcharts": "^12.5.0"
   },
   "devDependencies": {
     "govuk-frontend": "^6.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,14 @@
 # yarn lockfile v1
 
 
+"@ons/design-system@^73.3.0":
+  version "73.3.0"
+  resolved "https://registry.yarnpkg.com/@ons/design-system/-/design-system-73.3.0.tgz#fc116d96bccb8b304b4535ad8d613093adcb1e1c"
+  integrity sha512-IzT7lwl60MX4U0gFbQBo1yyrB7O55NoqNkOHbErYpohpjmkVdzmMY9n7A3/Qhe0FiyG+fnwaZtOIyET4TaKRtw==
+  dependencies:
+    highcharts "12.1.2"
+    pym.js "1.3.2"
+
 accessible-autocomplete@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/accessible-autocomplete/-/accessible-autocomplete-2.0.2.tgz#869d6b3b80a31e21614076b0ce47999f6b1802c8"
@@ -19,7 +27,22 @@ govuk-frontend@^6.0.0:
   resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-6.0.0.tgz#5906601cc9249027796c233f537eca00a0add0db"
   integrity sha512-n1DUbQD6coHL3UkQS0yTbd4ziIxLBzkWBODVCjXMclSY7FvOGeHcTg3c72z6u7DQECQb0tfZofhPjGxPUOIizA==
 
+highcharts@12.1.2:
+  version "12.1.2"
+  resolved "https://registry.yarnpkg.com/highcharts/-/highcharts-12.1.2.tgz#826114935b3ffb6b99dc906da00f137667a67fbb"
+  integrity sha512-paZ72q1um0zZT1sS+O/3JfXVSOLPmZ0zlo8SgRc0rEplPFPQUPc4VpkgQS8IUTueeOBgIWwVpAWyC9tBYbQ0kg==
+
+highcharts@^12.5.0:
+  version "12.5.0"
+  resolved "https://registry.yarnpkg.com/highcharts/-/highcharts-12.5.0.tgz#1cf5bc1214bb7bbd717096420089d130e84847ff"
+  integrity sha512-uNSSv1KqRLNvkyXlf1FbeGWB1mJ/8/IYpVeqYiTIop5Wo8peUvNyzUfLa58vILsmXyz+XrETtgKIEOcSgBBKuQ==
+
 preact@^8.3.1:
   version "8.4.2"
   resolved "https://registry.yarnpkg.com/preact/-/preact-8.4.2.tgz#1263b974a17d1ea80b66590e41ef786ced5d6a23"
   integrity sha512-TsINETWiisfB6RTk0wh3/mvxbGRvx+ljeBccZ4Z6MPFKgu/KFGyf2Bmw3Z/jlXhL5JlNKY6QAbA9PVyzIy9//A==
+
+pym.js@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/pym.js/-/pym.js-1.3.2.tgz#0ebd083c5a7ef7650214db872b4b29a10743305d"
+  integrity sha512-/fFzHFB4BTsJQP5id0wzUdYsDT4VPkfAxk+uENBE9/aP6YbvhAEpcuJHdjxqisqfXOCrcz7duTK1fbtF2rz8RQ==


### PR DESCRIPTION

I removed the footnotes from the ons chart and other things that we may want to redesign:
[ONS design system line chart example](https://service-manual.ons.gov.uk/design-system/components/chart/example-line-chart)

ons chart styling is causing the main content to overflow off the page 
```@import "@ons/design-system/css/main.css";```

<img width="1134" height="663" alt="image" src="https://github.com/user-attachments/assets/10a631c2-8e1a-4ef0-9c63-8255ba659d26" />

