### PR TITLE
DGUK-345 Add title to frontmatter

### DIFF
--- a/app/content/content-pages/about.md
+++ b/app/content/content-pages/about.md
@@ -1,3 +1,6 @@
+---
+title: About
+---
 # About data.gov.uk
 Since 2010, data.gov.uk has been helping people to find and use open government data, and supporting government publishers to maintain data. The website is run by the Government Digital Service (GDS).
 

--- a/app/content/content-pages/accessibility.md
+++ b/app/content/content-pages/accessibility.md
@@ -1,3 +1,6 @@
+---
+title: Accessibility
+---
 # Accessibility statement for data.gov.uk
 This accessibility statement applies to https://data.gov.uk. It does not cover other data.gov.uk subdomains (for example, environment.data.gov.uk) which have their own accessibility statements.
 

--- a/app/content/content-pages/privacy-and-terms.md
+++ b/app/content/content-pages/privacy-and-terms.md
@@ -1,3 +1,6 @@
+---
+title: Privacy and terms
+---
 # Privacy and terms
 
 ## Terms of use

--- a/app/content/content-pages/roadmap.md
+++ b/app/content/content-pages/roadmap.md
@@ -1,3 +1,6 @@
+---
+title: Our plan for data.gov.uk
+---
 ## data.gov.uk roadmap
 
 This roadmap sets out our priorities and direction for data.gov.uk, as of March 2026:

--- a/app/content/content-pages/support.md
+++ b/app/content/content-pages/support.md
@@ -1,3 +1,6 @@
+---
+title: Support
+---
 # Support
 The Government Digital Service (GDS) maintains the service behind data.gov.uk. This includes:
 

--- a/app/content/content-pages/team.md
+++ b/app/content/content-pages/team.md
@@ -1,3 +1,6 @@
+---
+title: Team
+---
 # data.gov.uk team
 The data.gov.uk team at the Government Digital Service (GDS) is transforming the data.gov.uk website and the experience of finding and using public sector data.
 


### PR DESCRIPTION
Add title to frontmatter for the content pages to be used in datagovuk Django app https://github.com/alphagov/datagovuk/pull/19

The front matter in the content pages for this repo, won't be rendered. it'll be used in [datagovuk](https://github.com/alphagov/datagovuk/pull/19) repo within the git submodule