### PR TITLE
Update the site_id field which is used to store an index of organisation

### DIFF
--- a/app/services/search/solr.rb
+++ b/app/services/search/solr.rb
@@ -2,6 +2,7 @@ module Search
   class Solr
     RESULTS_PER_PAGE = 20
     ORGANISATIONS_LIMIT = 3000 # Should match `rows` in https://github.com/alphagov/ckanext-datagovuk/blob/4cfb397/ckanext/datagovuk/lib/cli.py#L398
+    DGU_ORGANISATIONS_ID = "dgu_organisations_2".freeze # Should match DGU_ORGANISATIONS_ID in https://github.com/alphagov/ckanext-datagovuk/blob/e774ed637178533a47ddfa8fadaf83adc9e903be/ckanext/datagovuk/lib/cli.py#L26
 
     def self.search(params)
       query_param = (params["q"] || "").to_s.squish
@@ -24,7 +25,7 @@ module Search
       processed_query = SearchHelper.process_query(query_param)
       raise NoSearchTermsError, "Query string is empty after processing" if processed_query.blank?
 
-      @query = "(title:(#{processed_query})^2 OR notes:(#{processed_query})) AND NOT site_id:dgu_organisations"
+      @query = "(title:(#{processed_query})^2 OR notes:(#{processed_query})) AND NOT site_id:#{DGU_ORGANISATIONS_ID}"
     end
 
     def self.build_filter_query(params)
@@ -92,7 +93,7 @@ module Search
         query = solr_client.get "select", params: {
           q: "*:*",
           fq: [
-            "site_id:dgu_organisations",
+            "site_id:#{DGU_ORGANISATIONS_ID}",
           ],
           fl: %w[title name],
           rows: ORGANISATIONS_LIMIT,
@@ -112,7 +113,7 @@ module Search
         solr_client.get "select", params: {
           q: "*:*",
           fq: [
-            "site_id:dgu_organisations",
+            "site_id:#{DGU_ORGANISATIONS_ID}",
             "name:#{name}",
           ],
           fl: %w[title name extras_contact-email extras_foi-email extras_foi-web extras_foi-name],

--- a/app/services/search/solr.rb
+++ b/app/services/search/solr.rb
@@ -2,7 +2,8 @@ module Search
   class Solr
     RESULTS_PER_PAGE = 20
     ORGANISATIONS_LIMIT = 3000 # Should match `rows` in https://github.com/alphagov/ckanext-datagovuk/blob/4cfb397/ckanext/datagovuk/lib/cli.py#L398
-    DGU_ORGANISATIONS_ID = "dgu_organisations_2".freeze # Should match DGU_ORGANISATIONS_ID in https://github.com/alphagov/ckanext-datagovuk/blob/e774ed637178533a47ddfa8fadaf83adc9e903be/ckanext/datagovuk/lib/cli.py#L26
+    DGU_ORGANISATIONS_PREFIX = "dgu_organisations".freeze
+    DGU_ORGANISATIONS_ID = "#{DGU_ORGANISATIONS_PREFIX}_2".freeze # Should match DGU_ORGANISATIONS_ID in https://github.com/alphagov/ckanext-datagovuk/blob/e774ed637178533a47ddfa8fadaf83adc9e903be/ckanext/datagovuk/lib/cli.py#L26
 
     def self.search(params)
       query_param = (params["q"] || "").to_s.squish
@@ -25,7 +26,7 @@ module Search
       processed_query = SearchHelper.process_query(query_param)
       raise NoSearchTermsError, "Query string is empty after processing" if processed_query.blank?
 
-      @query = "(title:(#{processed_query})^2 OR notes:(#{processed_query})) AND NOT site_id:#{DGU_ORGANISATIONS_ID}"
+      @query = "(title:(#{processed_query})^2 OR notes:(#{processed_query})) AND NOT site_id:#{DGU_ORGANISATIONS_PREFIX}.*"
     end
 
     def self.build_filter_query(params)

--- a/spec/services/search/solr_spec.rb
+++ b/spec/services/search/solr_spec.rb
@@ -340,7 +340,7 @@ RSpec.describe Search::Solr do
         "dataset",
       )
       expect(term_query).to eq(
-        "(title:(dataset)^2 OR notes:(dataset)) AND NOT site_id:dgu_organisations",
+        "(title:(dataset)^2 OR notes:(dataset)) AND NOT site_id:#{described_class::DGU_ORGANISATIONS_ID}",
       )
     end
 
@@ -350,7 +350,7 @@ RSpec.describe Search::Solr do
       )
 
       expect(term_query).to eq(
-        "(title:(animal health)^2 OR notes:(animal health)) AND NOT site_id:dgu_organisations",
+        "(title:(animal health)^2 OR notes:(animal health)) AND NOT site_id:#{described_class::DGU_ORGANISATIONS_ID}",
       )
     end
 
@@ -360,7 +360,7 @@ RSpec.describe Search::Solr do
       )
 
       expect(term_query).to eq(
-        "(title:(\"animal health\")^2 OR notes:(\"animal health\")) AND NOT site_id:dgu_organisations",
+        "(title:(\"animal health\")^2 OR notes:(\"animal health\")) AND NOT site_id:#{described_class::DGU_ORGANISATIONS_ID}",
       )
     end
 
@@ -370,7 +370,7 @@ RSpec.describe Search::Solr do
       )
 
       expect(term_query).to eq(
-        "(title:(\"animal health\" dogs)^2 OR notes:(\"animal health\" dogs)) AND NOT site_id:dgu_organisations",
+        "(title:(\"animal health\" dogs)^2 OR notes:(\"animal health\" dogs)) AND NOT site_id:#{described_class::DGU_ORGANISATIONS_ID}",
       )
     end
 
@@ -380,7 +380,7 @@ RSpec.describe Search::Solr do
       )
 
       expect(term_query).to eq(
-        "(title:(organogram staff roles salaries)^2 OR notes:(organogram staff roles salaries)) AND NOT site_id:dgu_organisations",
+        "(title:(organogram staff roles salaries)^2 OR notes:(organogram staff roles salaries)) AND NOT site_id:#{described_class::DGU_ORGANISATIONS_ID}",
       )
     end
 
@@ -390,7 +390,7 @@ RSpec.describe Search::Solr do
       )
 
       expect(term_query).to eq(
-        "(title:(\"organogram of staff roles & salaries\")^2 OR notes:(\"organogram of staff roles & salaries\")) AND NOT site_id:dgu_organisations",
+        "(title:(\"organogram of staff roles & salaries\")^2 OR notes:(\"organogram of staff roles & salaries\")) AND NOT site_id:#{described_class::DGU_ORGANISATIONS_ID}",
       )
     end
 

--- a/spec/services/search/solr_spec.rb
+++ b/spec/services/search/solr_spec.rb
@@ -340,7 +340,7 @@ RSpec.describe Search::Solr do
         "dataset",
       )
       expect(term_query).to eq(
-        "(title:(dataset)^2 OR notes:(dataset)) AND NOT site_id:#{described_class::DGU_ORGANISATIONS_ID}",
+        "(title:(dataset)^2 OR notes:(dataset)) AND NOT site_id:#{described_class::DGU_ORGANISATIONS_PREFIX}.*",
       )
     end
 
@@ -350,7 +350,7 @@ RSpec.describe Search::Solr do
       )
 
       expect(term_query).to eq(
-        "(title:(animal health)^2 OR notes:(animal health)) AND NOT site_id:#{described_class::DGU_ORGANISATIONS_ID}",
+        "(title:(animal health)^2 OR notes:(animal health)) AND NOT site_id:#{described_class::DGU_ORGANISATIONS_PREFIX}.*",
       )
     end
 
@@ -360,7 +360,7 @@ RSpec.describe Search::Solr do
       )
 
       expect(term_query).to eq(
-        "(title:(\"animal health\")^2 OR notes:(\"animal health\")) AND NOT site_id:#{described_class::DGU_ORGANISATIONS_ID}",
+        "(title:(\"animal health\")^2 OR notes:(\"animal health\")) AND NOT site_id:#{described_class::DGU_ORGANISATIONS_PREFIX}.*",
       )
     end
 
@@ -370,7 +370,7 @@ RSpec.describe Search::Solr do
       )
 
       expect(term_query).to eq(
-        "(title:(\"animal health\" dogs)^2 OR notes:(\"animal health\" dogs)) AND NOT site_id:#{described_class::DGU_ORGANISATIONS_ID}",
+        "(title:(\"animal health\" dogs)^2 OR notes:(\"animal health\" dogs)) AND NOT site_id:#{described_class::DGU_ORGANISATIONS_PREFIX}.*",
       )
     end
 
@@ -380,7 +380,7 @@ RSpec.describe Search::Solr do
       )
 
       expect(term_query).to eq(
-        "(title:(organogram staff roles salaries)^2 OR notes:(organogram staff roles salaries)) AND NOT site_id:#{described_class::DGU_ORGANISATIONS_ID}",
+        "(title:(organogram staff roles salaries)^2 OR notes:(organogram staff roles salaries)) AND NOT site_id:#{described_class::DGU_ORGANISATIONS_PREFIX}.*",
       )
     end
 
@@ -390,7 +390,7 @@ RSpec.describe Search::Solr do
       )
 
       expect(term_query).to eq(
-        "(title:(\"organogram of staff roles & salaries\")^2 OR notes:(\"organogram of staff roles & salaries\")) AND NOT site_id:#{described_class::DGU_ORGANISATIONS_ID}",
+        "(title:(\"organogram of staff roles & salaries\")^2 OR notes:(\"organogram of staff roles & salaries\")) AND NOT site_id:#{described_class::DGU_ORGANISATIONS_PREFIX}.*",
       )
     end
 


### PR DESCRIPTION
The index of organisations on production grew beyond the 3000 row limit, there are less than 1500 orgs on the system so the 3000 limit should give enough headroom to handle extra organisations for a few years. Rather than purge the existing index and repopulate it which will cause some downtime with the directory, a new index has been created which has the correct number of publishers. 

So point the code to the new organisation index.

https://cddodatamarketplace.atlassian.net/jira/software/c/projects/DGUK/boards/527?selectedIssue=DGUK-432