### PR TITLE
Remove basic auth log warning

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -149,7 +149,6 @@ private
           ActiveSupport::SecurityUtils.secure_compare(password, ENV["BASIC_AUTH_PASSWORD"])
       end
     else
-      logger.warn "BASIC_AUTH_USERNAME and BASIC_AUTH_PASSWORD environment variables are not set. Basic authentication is disabled."
       true
     end
   end


### PR DESCRIPTION
In production,  basic auth is not set and therefore our current state causes a log warning upon every request to the app. This leads to a really noisy stdout log output.

Our helm charts configuration should expect basic auth values to be set for staging and integration which should suffice, i think.