### PR TITLE
Revise language to reflect NDL name change

### DIFF
--- a/app/content/content-pages/about.md
+++ b/app/content/content-pages/about.md
@@ -1,34 +1,35 @@
 ---
 title: About
 ---
-# About data.gov.uk
-Since 2010, data.gov.uk has been helping people to find and use open government data, and supporting government publishers to maintain data. The website is run by the Government Digital Service (GDS).
+# About the National Data Library
+Since 2010, the data.gov.uk website, now known as the National Data Library, has been helping people to find and use open government data, and supporting government publishers to maintain data. The website is run by the Government Digital Service (GDS) in the Department for Science, Innovation and Technology (DSIT).
 
-In March 2026, we added new features to the site as a first step to transforming it into a new home for UK public data. This release includes:
+In early 2026, we added new features to the site and new branding. These were first steps to transforming the data.gov.uk website into the UK National Data Library and a commitment to making the service a single trusted gateway to curated, high-quality public sector data. In the first two releases we added:
 
-- a new visual design
-- links to curated [collections](/) of trusted, open data that’s in high demand
+- a new visual design and name
+- curated [collections](/) of trusted, open data that’s in high demand
+- a spotlighted ['Early years'](/collections/early-years) collection to highlight the importance of this data as DSIT launches a new project working with local authorities to explore how better-connected data can support children and families outcomes
 - a [data manual](/data-manual) that signposts the most current and authoritative guidance for people who work with data in the public sector
 - a [roadmap](/roadmap) that explains our current and upcoming work
 
 ## Changes to the previous data.gov.uk functionality
-The previous functionality is still available. We’ve renamed this the ‘data.gov.uk directory’ to differentiate it from the data collections and data manual.
+The previous functionality is still available. We’ve renamed this 'the directory’ to differentiate it from the data collections and data manual.
 
-On the data.gov.uk directory, you can still: 
+On the directory, you can still: 
 
 - [find links to data](/search) published by central government, local authorities and public bodies
 - [make your organisation’s data available](/publishers) by adding links to datasets published on GOV.UK or the website for your organisation or service
 
-We’re working on some issues with the data.gov.uk directory, including navigation and data updates. Please bear with us while we get these resolved.
+We’re currently working on fixing some issues with the directory, including navigation and data updates. Please bear with us while we get these resolved.
 
-## How data.gov.uk and policy work together
+## How the National Data Library and policy work together
 Good data informs policy decisions and the continuous improvement of services. Government departments can combat fraud and reduce waste. Individuals and organisations can test and develop new products that support social and economic outcomes.
 
 By taking ethical, transparent and innovative approaches to data, the government can build trust with citizens and build services tailored to their needs. Data is at the heart of digital transformation and a part of the [roadmap for modern digital government](https://roadmap-for-modern-digital-government.campaign.gov.uk/digital-and-data-infrastructure/).
 
 GDS works with other organisations within and outside government to shape the strategic direction for how data is managed, accessed and used. We work collaboratively on a range of issues with the Office for National Statistics (ONS), the Cabinet Office and the National Cyber Security Centre (NCSC).
 
-## Reuse of information published on data.gov.uk
-You can republish any of the content on data.gov.uk as long as you meet the conditions of either the [Open Government Licence](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/) or another licence it’s covered by. For questions about a dataset on the data.gov.uk directory, you can contact the publisher directly if they’ve provided contact details on the dataset’s page.
+## Reuse of information published on the National Data Library
+You can republish any of the content available on the National Data Library as long as you meet the conditions of either the [Open Government Licence](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/) or another licence it’s covered by. For questions about a dataset on the directory, you can contact the publisher directly if they’ve provided contact details on the dataset’s page.
 
 If you want to propose data for, or have feedback or questions about, the new curated collections, complete our [feedback form](https://forms.office.com/e/9V26PNFQaR).


### PR DESCRIPTION
Updated the content to reflect the rebranding of data.gov.uk to the National Data Library, including new features and changes to the directory.