### PR TITLE
DGUK-751 Add new survey banner

### DIFF
--- a/app/assets/images/v2/close.svg
+++ b/app/assets/images/v2/close.svg
@@ -1,0 +1,3 @@
+<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0.75 16.75L8.75 8.75L16.75 16.75M16.75 0.75L8.74847 8.75L0.75 0.75" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/app/assets/javascripts/v2/survey-banner.js
+++ b/app/assets/javascripts/v2/survey-banner.js
@@ -13,7 +13,7 @@ class DatagovukSurveyBanner {
     this.$closeLink.addEventListener('click', (event) => this.dismiss(event))
   }
 
-  getConsentCookie() {
+  getCookieSettings() {
     var consentCookie = window.GOVUK.cookie('cookies_policy')
     if (!consentCookie) return null
     try {
@@ -23,18 +23,18 @@ class DatagovukSurveyBanner {
     }
   }
 
-  hasSettingsConsent() {
-    var consent = this.getConsentCookie()
+  hasConsentedToCookies() {
+    var consent = this.getCookieSettings()
     return consent && consent.settings === true
   }
 
   getDismissedCookie() {
-    return document.cookie.split(';').some(c => c.trim() === 'survey_banner_dismissed_2026_07=true')
+    return document.cookie.split(';').some(cookie => cookie.trim() === 'survey_banner_dismissed_2026_07=true')
   }
 
   setDismissedCookie() {
-    if (!this.hasSettingsConsent()) return
-    var maxAge = 60 * 24 * 60 * 60 // 60 days in seconds
+    if (!this.hasConsentedToCookies()) return
+    var maxAge = 15 * 24 * 60 * 60 // 15 days in seconds
     document.cookie = 'survey_banner_dismissed_2026_07=true; max-age=' + maxAge + '; path=/'
   }
 

--- a/app/assets/javascripts/v2/survey-banner.js
+++ b/app/assets/javascripts/v2/survey-banner.js
@@ -1,0 +1,54 @@
+class DatagovukSurveyBanner {
+  constructor($module) {
+    this.$module = $module
+    this.$closeLink = $module.querySelector('.datagovuk-close')
+
+    if (!this.$closeLink) return
+
+    if (this.getDismissedCookie()) {
+      this.$module.hidden = true
+      return
+    }
+
+    this.$closeLink.addEventListener('click', (event) => this.dismiss(event))
+  }
+
+  getConsentCookie() {
+    var cookies = document.cookie.split(';').map(cookie => cookie.trim())
+    var match = cookies.find(cookie => cookie.startsWith('cookies_policy='))
+
+    if (!match) return null
+    try {
+      return JSON.parse(decodeURIComponent(match.split('=').slice(1).join('=')))
+    } catch (e) {
+      return null
+    }
+  }
+
+  hasSettingsConsent() {
+    var consent = this.getConsentCookie()
+    return consent && consent.settings === true
+  }
+
+  getDismissedCookie() {
+    return document.cookie.split(';').some(c => c.trim() === 'survey_banner_dismissed_2026_07=true')
+  }
+
+  setDismissedCookie() {
+    if (!this.hasSettingsConsent()) return
+    var maxAge = 60 * 24 * 60 * 60 // 60 days in seconds
+    document.cookie = 'survey_banner_dismissed_2026_07=true; max-age=' + maxAge + '; path=/; SameSite=Strict'
+  }
+
+  dismiss(event) {
+    event.preventDefault()
+    this.$module.hidden = true
+    this.setDismissedCookie()
+  }
+}
+
+// Initialize
+const $surveyBanner = document.querySelector('.datagovuk-notification-banner')
+if ($surveyBanner) {
+  new DatagovukSurveyBanner($surveyBanner)
+}

--- a/app/assets/javascripts/v2/survey-banner.js
+++ b/app/assets/javascripts/v2/survey-banner.js
@@ -14,12 +14,10 @@ class DatagovukSurveyBanner {
   }
 
   getConsentCookie() {
-    var cookies = document.cookie.split(';').map(cookie => cookie.trim())
-    var match = cookies.find(cookie => cookie.startsWith('cookies_policy='))
-
-    if (!match) return null
+    var consentCookie = window.GOVUK.cookie('cookies_policy')
+    if (!consentCookie) return null
     try {
-      return JSON.parse(decodeURIComponent(match.split('=').slice(1).join('=')))
+      return JSON.parse(consentCookie)
     } catch (e) {
       return null
     }
@@ -37,7 +35,7 @@ class DatagovukSurveyBanner {
   setDismissedCookie() {
     if (!this.hasSettingsConsent()) return
     var maxAge = 60 * 24 * 60 * 60 // 60 days in seconds
-    document.cookie = 'survey_banner_dismissed_2026_07=true; max-age=' + maxAge + '; path=/; SameSite=Strict'
+    document.cookie = 'survey_banner_dismissed_2026_07=true; max-age=' + maxAge + '; path=/'
   }
 
   dismiss(event) {

--- a/app/assets/stylesheets/v2/pages/_survey_banner.scss
+++ b/app/assets/stylesheets/v2/pages/_survey_banner.scss
@@ -1,3 +1,7 @@
+.datagovuk-notification-banner {
+  margin-bottom: 20px;
+}
+
 .datagovuk-notification-banner__inner {
   border-left: 4px solid $datagovuk-pink;
   background-color: $datagovuk-light-pink;
@@ -29,5 +33,9 @@
 @media (min-width: $desktop-header-breakpoint) {
   .datagovuk-notification-banner__inner {
     padding: 20px 40px;
+  }
+
+  .datagovuk-notification-banner {
+    margin-bottom: 10px;
   }
 }

--- a/app/assets/stylesheets/v2/pages/_survey_banner.scss
+++ b/app/assets/stylesheets/v2/pages/_survey_banner.scss
@@ -1,0 +1,40 @@
+.datagovuk-notification-banner__inner {
+  border-left: 4px solid $datagovuk-pink;
+  background-color: $datagovuk-light-pink;
+  padding-left: 30px;
+  padding-right: 30px;
+}
+
+.datagovuk-notification-banner__content {
+  display: flex;
+  align-items: center;
+  min-height: 140px;
+  gap: 12px;
+}
+
+.datagovuk-notification-banner__content .datagovuk-body {
+   margin: 0;
+}
+
+.datagovuk-close__image {
+  display: block;
+  width: 20px;
+  height: 20px;
+}
+
+.datagovuk-close__container {
+    margin-left: auto;
+    flex: 0 0 auto;
+}
+
+/* Desktop styling overrides */
+@media (min-width: $desktop-header-breakpoint) {
+    .datagovuk-notification-banner__content {
+        min-height: 80px;
+    }
+
+    .datagovuk-notification-banner__inner {
+        padding-left: 40px;
+        padding-right: 40px;
+    }
+}

--- a/app/assets/stylesheets/v2/pages/_survey_banner.scss
+++ b/app/assets/stylesheets/v2/pages/_survey_banner.scss
@@ -8,12 +8,11 @@
 .datagovuk-notification-banner__content {
   display: flex;
   align-items: center;
-  min-height: 140px;
   gap: 12px;
 }
 
 .datagovuk-notification-banner__content .datagovuk-body {
-   margin: 0;
+  margin: 0;
 }
 
 .datagovuk-close__image {
@@ -23,18 +22,18 @@
 }
 
 .datagovuk-close__container {
-    margin-left: auto;
-    flex: 0 0 auto;
+  margin-left: auto;
+  flex: 0 0 auto;
 }
 
 /* Desktop styling overrides */
 @media (min-width: $desktop-header-breakpoint) {
-    .datagovuk-notification-banner__content {
-        min-height: 80px;
-    }
+  .datagovuk-notification-banner__content {
+      min-height: 80px;
+  }
 
-    .datagovuk-notification-banner__inner {
-        padding-left: 40px;
-        padding-right: 40px;
-    }
+  .datagovuk-notification-banner__inner {
+    padding-left: 40px;
+    padding-right: 40px;
+  }
 }

--- a/app/assets/stylesheets/v2/pages/_survey_banner.scss
+++ b/app/assets/stylesheets/v2/pages/_survey_banner.scss
@@ -18,15 +18,16 @@
   margin: 0;
 }
 
+.datagovuk-close {
+  padding: 12px;
+  margin-left: auto;
+  flex: 0 0 auto;
+}
+
 .datagovuk-close__image {
   display: block;
   width: 20px;
   height: 20px;
-}
-
-.datagovuk-close__container {
-  margin-left: auto;
-  flex: 0 0 auto;
 }
 
 /* Desktop styling overrides */

--- a/app/assets/stylesheets/v2/pages/_survey_banner.scss
+++ b/app/assets/stylesheets/v2/pages/_survey_banner.scss
@@ -1,8 +1,7 @@
 .datagovuk-notification-banner__inner {
   border-left: 4px solid $datagovuk-pink;
   background-color: $datagovuk-light-pink;
-  padding-left: 30px;
-  padding-right: 30px;
+  padding: 20px 30px;
 }
 
 .datagovuk-notification-banner__content {
@@ -28,12 +27,7 @@
 
 /* Desktop styling overrides */
 @media (min-width: $desktop-header-breakpoint) {
-  .datagovuk-notification-banner__content {
-      min-height: 80px;
-  }
-
   .datagovuk-notification-banner__inner {
-    padding-left: 40px;
-    padding-right: 40px;
+    padding: 20px 40px;
   }
 }

--- a/app/assets/stylesheets/v2/pages/main.scss
+++ b/app/assets/stylesheets/v2/pages/main.scss
@@ -1,6 +1,7 @@
 @import 'content';
 @import 'data_manual';
 @import 'roadmap';
+@import 'survey_banner';
 @import 'cookies';
 @import "collections/content";
 @import "collections/headline";

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -68,18 +68,6 @@
       </div>
     </header>
 
-    <div class="datagovuk-v2-banner govuk-!-margin-top-2">
-      <div class="govuk-width-container">
-        <div class="govuk-grid-row">
-          <div class="govuk-grid-column-full">
-            <p class="govuk-body govuk-!-padding-top-4 govuk-!-padding-bottom-4 govuk-!-margin-bottom-0"> 
-              We’re making changes to the National Data Library — <a class="govuk-link" href="/roadmap">Find out more</a>
-            </p>
-          </div>
-        </div>
-      </div>
-    </div>
-
     <%= render 'layouts/integration_ribbon' if Rails.env.integration? %>
     <%= render 'layouts/staging_ribbon' if Rails.env.staging? %>
 

--- a/app/views/v2/_header.html.erb
+++ b/app/views/v2/_header.html.erb
@@ -4,7 +4,7 @@
       <div class="datagovuk-notification-banner__content">
         <p class="govuk-body datagovuk-body">
           Help us improve the National Data Library -
-          <a class="govuk-link datagovuk-link" href="https://surveys.publishing.service.gov.uk/s/2W0DN6/">complete this short survey</a>.
+          <a class="govuk-link datagovuk-link" href="https://surveys.publishing.service.gov.uk/s/2W0DN6/">complete this short survey</a>
         </p>
         <a class="datagovuk-close" href="#">
           <img class="datagovuk-close__image" src="<%= image_path 'v2/close.svg' %>" alt="Close survey banner" />

--- a/app/views/v2/_header.html.erb
+++ b/app/views/v2/_header.html.erb
@@ -1,3 +1,21 @@
+<div class="datagovuk-notification-banner govuk-!-padding-top-6">
+  <div class="govuk-width-container datagovuk-width-container">
+    <div class="datagovuk-notification-banner__inner">
+      <div class="datagovuk-notification-banner__content">
+        <p class="govuk-body datagovuk-body">
+          Help us improve the National Data Library -
+          <a class="govuk-link datagovuk-link" href="https://surveys.publishing.service.gov.uk/s/2W0DN6/">complete this short survey</a>.
+        </p>
+        <div class="datagovuk-close__container">
+          <a class="datagovuk-close" href="#">
+            <img class="datagovuk-close__image" src="<%= image_path 'v2/close.svg' %>" alt="close survey banner" />
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
 <header role="banner" class="datagovuk-header">
   <div class="govuk-width-container datagovuk-width-container datagovuk-header__inner">
     <div class="datagovuk-header__logo">

--- a/app/views/v2/_header.html.erb
+++ b/app/views/v2/_header.html.erb
@@ -6,11 +6,9 @@
           Help us improve the National Data Library -
           <a class="govuk-link datagovuk-link" href="https://surveys.publishing.service.gov.uk/s/2W0DN6/">complete this short survey</a>.
         </p>
-        <div class="datagovuk-close__container">
-          <a class="datagovuk-close" href="#">
-            <img class="datagovuk-close__image" src="<%= image_path 'v2/close.svg' %>" alt="close survey banner" />
-          </a>
-        </div>
+        <a class="datagovuk-close" href="#">
+          <img class="datagovuk-close__image" src="<%= image_path 'v2/close.svg' %>" alt="Close survey banner" />
+        </a>
       </div>
     </div>
   </div>

--- a/spec/features/search_results_page_spec.rb
+++ b/spec/features/search_results_page_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature "Search directory page", type: :feature do
   end
 
   def and_i_can_see_a_survey_banner
-    expect(page).to have_content("Help us improve the National Data Library - complete this short survey.")
+    expect(page).to have_content("Help us improve the National Data Library - complete this short survey")
     expect(page).to have_link("complete this short survey", href: "https://surveys.publishing.service.gov.uk/s/2W0DN6/")
   end
 end

--- a/spec/features/search_results_page_spec.rb
+++ b/spec/features/search_results_page_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature "Search directory page", type: :feature do
   scenario "User visits the search directory page" do
     given_i_am_on_the_search_directory_page
     then_i_can_see_the_title
-    and_i_can_see_a_notification_banner
+    and_i_can_see_a_survey_banner
   end
 
   def given_i_am_on_the_search_directory_page
@@ -21,7 +21,8 @@ RSpec.feature "Search directory page", type: :feature do
     expect(page).to have_content("Search directory")
   end
 
-  def and_i_can_see_a_notification_banner
-    expect(page).to have_content("We’re making changes to the National Data Library")
+  def and_i_can_see_a_survey_banner
+    expect(page).to have_content("Help us improve the National Data Library - complete this short survey.")
+    expect(page).to have_link("complete this short survey", href: "https://surveys.publishing.service.gov.uk/s/2W0DN6/")
   end
 end

--- a/spec/features/solr_inspire_dataset_show_page_spec.rb
+++ b/spec/features/solr_inspire_dataset_show_page_spec.rb
@@ -6,6 +6,8 @@ RSpec.feature "Solr Inspire dataset", type: :feature do
     given_an_inspire_dataset_exists
     when_i_visit_solr_dataset_page(@response_inspire, @dataset_inspire)
 
+    then_i_can_see_the_survey_banner
+
     # Custom Licence
     then_the_custom_licence_title_is_displayed
     then_the_custom_licence_information_is_displayed
@@ -43,6 +45,11 @@ RSpec.feature "Solr Inspire dataset", type: :feature do
 
   def when_i_visit_solr_dataset_page(_response, dataset)
     visit dataset_path(dataset.uuid, dataset.name)
+  end
+
+  def then_i_can_see_the_survey_banner
+    expect(page).to have_content("Help us improve the National Data Library - complete this short survey.")
+    expect(page).to have_link("complete this short survey", href: "https://surveys.publishing.service.gov.uk/s/2W0DN6/")
   end
 
   def then_the_custom_licence_title_is_displayed

--- a/spec/features/solr_inspire_dataset_show_page_spec.rb
+++ b/spec/features/solr_inspire_dataset_show_page_spec.rb
@@ -48,7 +48,7 @@ RSpec.feature "Solr Inspire dataset", type: :feature do
   end
 
   def then_i_can_see_the_survey_banner
-    expect(page).to have_content("Help us improve the National Data Library - complete this short survey.")
+    expect(page).to have_content("Help us improve the National Data Library - complete this short survey")
     expect(page).to have_link("complete this short survey", href: "https://surveys.publishing.service.gov.uk/s/2W0DN6/")
   end
 

--- a/spec/requests/search_spec.rb
+++ b/spec/requests/search_spec.rb
@@ -20,6 +20,10 @@ RSpec.describe "Search", type: :request do
       expect(response.body).to include("Search directory")
     end
 
+    it "renders a survey banner" do
+      expect(response.body).to match(%r{<a[^>]*href="https://surveys.publishing.service.gov.uk/s/2W0DN6/"[^>]*>\s*complete this short survey\s*</a>}i)
+    end
+
     it "returns no results section" do
       expect(response.body).not_to match(/<div class="dgu-results__result">/)
     end


### PR DESCRIPTION
Ticket: [DGUK-751](https://cddodatamarketplace.atlassian.net/browse/DGUK-751)

- Add new survey banner above the header section. This displays on every page
- Replace the old banner with this 
- Add survey banner as a cookie that expires after 15 days
- Add unit and feature tests

ℹ️ `survey-banner.js` sets the cookie manually without the GOVUK cookie helper function (from govuk-publishing-components) because we use a custom cookie name that isn't allowed in the helper. Therefore this checks if the user accepted cookie storing and then adds the survey banner cookie manually.

-------
<img width="996" height="394" alt="image" src="https://github.com/user-attachments/assets/3e10dc5e-f432-48cd-8116-19ee63394dfa" />

-------

<img width="439" height="474" alt="image" src="https://github.com/user-attachments/assets/a511cad4-d6a9-4ad4-be0d-bf53034d2038" />