### PR TITLE
[DGUK-785] Modify copy when a dataset has no resources

### DIFF
--- a/app/views/datasets/_meta_data.html.erb
+++ b/app/views/datasets/_meta_data.html.erb
@@ -20,12 +20,6 @@
     <div class="column-two-thirds">
       <div class="dgu-metadata__box dgu-metadata__box--in-dataset">
         <dl class="metadata">
-          <% unless @dataset.datafiles.present? %>
-            <dt><%= t('.availability') %>:</dt>
-            <dd>
-              <span class="dgu-highlight">Not released</span>
-            </dd>
-          <% end %>
           <dt><%= t('.published_by') %>:</dt>
           <dd property="dc:creator">
             <%= @dataset.organisation.title %>

--- a/app/views/datasets/_no_datafiles.html.erb
+++ b/app/views/datasets/_no_datafiles.html.erb
@@ -1,12 +1,3 @@
 <div class="govuk-details__text govuk-!-margin-bottom-4">
   <p class="govuk-body"><%= t('datasets.show.not_released') %></p>
-  <p class="govuk-body">
-    <% if contact_information_exists?(dataset) %>
-      <%= t('datasets.show.contact_the_publisher') %>
-    <% else %>
-      <%= t('datasets.show.contact_the_team') %>
-      <%= link_to 'data.gov.uk/support', support_path, class: 'govuk-link' %>
-      <%= t('datasets.show.if_you_have_questions') %>
-    <% end %>
-  </p>
 </div>

--- a/config/locales/views/datasets/en.yml
+++ b/config/locales/views/datasets/en.yml
@@ -23,7 +23,7 @@ en:
       search: "Search"
     show:
       data_links: "Data links"
-      not_released: "This data hasn’t been released by the publisher."
+      not_released: "There are no links to this data."
       contact_the_publisher: "Contact the publisher for more information."
       contact_the_team: "Contact the team on"
       if_you_have_questions: "if you have any questions."

--- a/spec/features/solr_dataset_edge_cases_spec.rb
+++ b/spec/features/solr_dataset_edge_cases_spec.rb
@@ -10,7 +10,6 @@ RSpec.feature "Solr Dataset page edge cases", type: :feature do
     when_i_visit_solr_dataset_page(@dataset_no_datafiles)
 
     then_a_message_indicates_no_data_links_are_available
-    and_a_not_released_label_is_displayed
   end
 
   scenario "User tries to visit a dataset page that doesn't exist" do
@@ -81,10 +80,7 @@ RSpec.feature "Solr Dataset page edge cases", type: :feature do
 
   def then_a_message_indicates_no_data_links_are_available
     expect(page).to have_css("h2", text: "Data links")
-    expect(page).to have_content("This data hasn’t been released by the publisher.")
+    expect(page).to have_content("There are no links to this data.")
   end
 
-  def and_a_not_released_label_is_displayed
-    expect(page).to have_content("Availability: Not released")
-  end
 end

--- a/spec/features/solr_dataset_edge_cases_spec.rb
+++ b/spec/features/solr_dataset_edge_cases_spec.rb
@@ -82,5 +82,4 @@ RSpec.feature "Solr Dataset page edge cases", type: :feature do
     expect(page).to have_css("h2", text: "Data links")
     expect(page).to have_content("There are no links to this data.")
   end
-
 end


### PR DESCRIPTION
This modifies the copy on a dataset page when a dataset has no resources, as follows:
<img width="1830" height="1296" alt="image" src="https://github.com/user-attachments/assets/5cc1877e-df7f-4466-9144-cb4a1c80bcaa" />
