### PR TITLE
DGUK-751 Set survey-banner cookie to essential

### DIFF
--- a/app/assets/javascripts/v2/survey-banner.js
+++ b/app/assets/javascripts/v2/survey-banner.js
@@ -13,27 +13,11 @@ class DatagovukSurveyBanner {
     this.$closeLink.addEventListener('click', (event) => this.dismiss(event))
   }
 
-  getCookieSettings() {
-    var consentCookie = window.GOVUK.cookie('cookies_policy')
-    if (!consentCookie) return null
-    try {
-      return JSON.parse(consentCookie)
-    } catch (e) {
-      return null
-    }
-  }
-
-  hasConsentedToCookies() {
-    var consent = this.getCookieSettings()
-    return consent && consent.settings === true
-  }
-
   getDismissedCookie() {
     return document.cookie.split(';').some(cookie => cookie.trim() === 'survey_banner_dismissed_2026_07=true')
   }
 
   setDismissedCookie() {
-    if (!this.hasConsentedToCookies()) return
     var maxAge = 15 * 24 * 60 * 60 // 15 days in seconds
     document.cookie = 'survey_banner_dismissed_2026_07=true; max-age=' + maxAge + '; path=/'
   }

--- a/spec/features/survey_banner_spec.rb
+++ b/spec/features/survey_banner_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.feature "Survey banner", type: :feature, js: true do
+  before do
+    allow(Search::Solr).to receive(:search).and_return(JSON.parse(File.read(Rails.root.join("spec/fixtures/solr_response.json").to_s)))
+    allow(Search::Solr).to receive(:get_organisations).and_return({})
+  end
+
+  scenario "Survey banner is visible on page load" do
+    given_i_am_on_the_search_page
+    then_banner_is_visible
+    and_i_dismiss_the_banner
+    then_banner_is_not_visible
+  end
+
+  scenario "Survey banner stays hidden after rejecting additional cookies" do
+    given_i_am_on_the_search_page
+    then_i_reject_additional_cookies
+    and_i_dismiss_the_banner
+    and_i_refresh_the_page
+    then_banner_is_not_visible
+  end
+
+  def then_i_reject_additional_cookies
+    click_button "Reject additional cookies"
+  end
+
+  def and_i_dismiss_the_banner
+    find(".datagovuk-close").click
+  end
+
+  def given_i_am_on_the_search_page
+    visit search_path
+  end
+
+  def and_i_refresh_the_page
+    visit current_path
+  end
+
+  def then_banner_is_visible
+    expect(page).to have_content("Help us improve the National Data Library")
+  end
+
+  def then_banner_is_not_visible
+    expect(page).not_to have_content("Help us improve the National Data Library")
+  end
+end


### PR DESCRIPTION
Survey banner cookie makes sure that the banner stays closed if a user clicks the close button.

It's an essential cookie because the close banner option will break without it

Add feature test for survey banner. Including a scenario around when cookies are rejected


https://github.com/user-attachments/assets/f1fe1314-5e34-4017-af23-bcd2fce89120

